### PR TITLE
Remove obsolete README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,1 +1,0 @@
-Please see `README.md <https://github.com/python/typing_extensions/blob/main/README.md>`_ for the current version of the README file.


### PR DESCRIPTION
The README.rst file was left in place, since the current version of
typing-extensions on PyPI still links to it. Since typing_extensions now
moved as a whole, we don't need that link in the current directory. The
typing repository still has a link.

Cf. #13