### PR TITLE
Add a backport of generic `NamedTuple`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+- Add `typing_extensions.NamedTuple`, allowing for generic `NamedTuple`s on
+  Python <3.11 (backport from python/cpython#92027, by Serhiy Storchaka). Patch
+  by Alex Waygood (@AlexWaygood).
+
 # Release 4.2.0 (April 17, 2022)
 
 - Re-export `typing.Unpack` and `typing.TypeVarTuple` on Python 3.11.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ This module currently contains the following:
   - `Counter`
   - `DefaultDict`
   - `Deque`
+  - `NamedTuple`
   - `NewType`
   - `NoReturn`
   - `overload`
@@ -121,6 +122,10 @@ Certain objects were changed after they were added to `typing`, and
   introspectable at runtime. In order to access overloads with
   `typing_extensions.get_overloads()`, you must use
   `@typing_extensions.overload`.
+- `NamedTuple` was changed in Python 3.11 to allow for multiple inheritance
+  with `typing.Generic` and, therefore, generic `NamedTuple`s. The
+  implementation of `NamedTuple` was also changed in 3.9 so that `NamedTuple`
+  became a function rather than a class.
 
 There are a few types whose interface was modified between different
 versions of typing. For example, `typing.Sequence` was modified to

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Certain objects were changed after they were added to `typing`, and
   `typing_extensions.get_overloads()`, you must use
   `@typing_extensions.overload`.
 - `NamedTuple` was changed in Python 3.11 to allow for multiple inheritance
-  with `typing.Generic` The implementation of `NamedTuple` was also changed in
+  with `typing.Generic`. The implementation of `NamedTuple` was also changed in
   3.9 so that `NamedTuple` became a function rather than a class.
 
 There are a few types whose interface was modified between different

--- a/README.md
+++ b/README.md
@@ -123,9 +123,8 @@ Certain objects were changed after they were added to `typing`, and
   `typing_extensions.get_overloads()`, you must use
   `@typing_extensions.overload`.
 - `NamedTuple` was changed in Python 3.11 to allow for multiple inheritance
-  with `typing.Generic` and, therefore, generic `NamedTuple`s. The
-  implementation of `NamedTuple` was also changed in 3.9 so that `NamedTuple`
-  became a function rather than a class.
+  with `typing.Generic` The implementation of `NamedTuple` was also changed in
+  3.9 so that `NamedTuple` became a function rather than a class.
 
 There are a few types whose interface was modified between different
 versions of typing. For example, `typing.Sequence` was modified to

--- a/README.md
+++ b/README.md
@@ -123,8 +123,7 @@ Certain objects were changed after they were added to `typing`, and
   `typing_extensions.get_overloads()`, you must use
   `@typing_extensions.overload`.
 - `NamedTuple` was changed in Python 3.11 to allow for multiple inheritance
-  with `typing.Generic`. The implementation of `NamedTuple` was also changed in
-  3.9 so that `NamedTuple` became a function rather than a class.
+  with `typing.Generic`.
 
 There are a few types whose interface was modified between different
 versions of typing. For example, `typing.Sequence` was modified to

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -2967,12 +2967,21 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(CoolEmployeeWithDefault._fields, ('name', 'cool'))
         self.assertEqual(CoolEmployeeWithDefault.__annotations__,
                          dict(name=str, cool=int))
-        self.assertEqual(CoolEmployeeWithDefault._field_defaults, dict(cool=0))
 
         with self.assertRaises(TypeError):
             class NonDefaultAfterDefault(NamedTuple):
                 x: int = 3
                 y: int
+
+    @skipUnless(
+        (
+            sys.version_info >= (3, 8)
+            or hasattr(CoolEmployeeWithDefault, '_field_defaults')
+        ),
+        '"_field_defaults" attribute was added in a micro version of 3.7'
+    )
+    def test_field_defaults(self):
+        self.assertEqual(CoolEmployeeWithDefault._field_defaults, dict(cool=0))
 
     def test_annotation_usage_with_methods(self):
         self.assertEqual(XMeth(1).double(), 2)
@@ -3083,9 +3092,10 @@ class NamedTupleTests(BaseTestCase):
         for struct in [NT, CNT]:
             with self.subTest(struct=struct):
                 self.assertEqual(struct._fields, ())
-                self.assertEqual(struct._field_defaults, {})
                 self.assertEqual(struct.__annotations__, {})
                 self.assertIsInstance(struct(), struct)
+                if hasattr(struct, "_field_defaults"):
+                    self.assertEqual(struct._field_defaults, {})
 
     def test_namedtuple_errors(self):
         with self.assertRaises(TypeError):
@@ -3137,6 +3147,7 @@ class NamedTupleTests(BaseTestCase):
             self.NestedEmployee.__annotations__,
             self.NestedEmployee._field_types
         )
+        self.assertIsInstance(inspect.signature(NamedTuple), inspect.Signature)
 
 
 if __name__ == '__main__':

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3112,7 +3112,12 @@ class NamedTupleTests(BaseTestCase):
     def test_copy_and_pickle(self):
         global Emp  # pickle wants to reference the class by name
         Emp = NamedTuple('Emp', [('name', str), ('cool', int)])
-        for cls in Emp, CoolEmployee, self.NestedEmployee:
+        pickleable_classes = [Emp, CoolEmployee]
+        # support for pickling nested classes
+        # appears to have been added in 3.7.6
+        if sys.version_info >= (3, 7, 6):
+            pickleable_classes.append(self.NestedEmployee)
+        for cls in pickleable_classes:
             with self.subTest(cls=cls):
                 jane = cls('jane', 37)
                 for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -3141,7 +3146,7 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(inspect.signature(NamedTuple), inspect.signature(typing.NamedTuple))
         self.assertIs(type(NamedTuple), type(typing.NamedTuple))
 
-    @skipIf(sys.version_info >= (3, 9), "_field_types attribute was removed on 3.9")
+    @skipIf(sys.version_info >= (3, 9), "tests are only relevant to <=3.8")
     def test_same_as_typing_NamedTuple_38_minus(self):
         self.assertEqual(
             self.NestedEmployee.__annotations__,

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3121,6 +3121,7 @@ class NamedTupleTests(BaseTestCase):
 
         if sys.version_info >= (3, 9):
             self.assertEqual(set(dir(NamedTuple)), set(dir(typing.NamedTuple)))
+            self.assertEqual(inspect.signature(NamedTuple), inspect.signature(typing.NamedTuple))
             self.assertIs(type(NamedTuple), type(typing.NamedTuple))
         else:
             # _field_types was removed in 3.9

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3114,12 +3114,7 @@ class NamedTupleTests(BaseTestCase):
     def test_copy_and_pickle(self):
         global Emp  # pickle wants to reference the class by name
         Emp = NamedTuple('Emp', [('name', str), ('cool', int)])
-        pickleable_classes = [Emp, CoolEmployee]
-        # support for pickling nested classes
-        # appears to have been added in 3.7.6
-        if sys.version_info >= (3, 7, 6):
-            pickleable_classes.append(self.NestedEmployee)
-        for cls in pickleable_classes:
+        for cls in Emp, CoolEmployee, self.NestedEmployee:
             with self.subTest(cls=cls):
                 jane = cls('jane', 37)
                 for proto in range(pickle.HIGHEST_PROTOCOL + 1):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3138,7 +3138,7 @@ class NamedTupleTests(BaseTestCase):
     def test_signature_is_same_as_typing_NamedTuple(self):
         self.assertEqual(inspect.signature(NamedTuple), inspect.signature(typing.NamedTuple))
 
-    @skipIf(sys.version_info >= (3, 8), "tests are only relveant to <=3.7")
+    @skipIf(sys.version_info >= (3, 8), "tests are only relevant to <=3.7")
     def test_signature_on_37(self):
         self.assertIsInstance(inspect.signature(NamedTuple), inspect.Signature)
         self.assertFalse(hasattr(NamedTuple, "__text_signature__"))

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -2906,6 +2906,7 @@ class CoolEmployeeWithDefault(NamedTuple):
 
 class XMeth(NamedTuple):
     x: int
+
     def double(self):
         return 2 * self.x
 
@@ -2913,8 +2914,10 @@ class XMeth(NamedTuple):
 class XRepr(NamedTuple):
     x: int
     y: int = 1
+
     def __str__(self):
         return f'{self.x} -> {self.y}'
+
     def __add__(self, other):
         return 0
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3133,7 +3133,7 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(NamedTuple.__doc__, typing.NamedTuple.__doc__)
 
     @skipIf(sys.version_info < (3, 9), "NamedTuple was a class on 3.8 and lower")
-    def test_same_as_typing_NamedTuple(self):
+    def test_same_as_typing_NamedTuple_39_plus(self):
         self.assertEqual(
             set(dir(NamedTuple)),
             set(dir(typing.NamedTuple)) | {"__text_signature__"}
@@ -3142,12 +3142,13 @@ class NamedTupleTests(BaseTestCase):
         self.assertIs(type(NamedTuple), type(typing.NamedTuple))
 
     @skipIf(sys.version_info >= (3, 9), "_field_types attribute was removed on 3.9")
-    def test__field_types(self):
+    def test_same_as_typing_NamedTuple_38_minus(self):
         self.assertEqual(
             self.NestedEmployee.__annotations__,
             self.NestedEmployee._field_types
         )
         self.assertIsInstance(inspect.signature(NamedTuple), inspect.Signature)
+        self.assertFalse(hasattr(NamedTuple, "__text_signature__"))
 
 
 if __name__ == '__main__':

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3134,13 +3134,21 @@ class NamedTupleTests(BaseTestCase):
     def test_docstring(self):
         self.assertEqual(NamedTuple.__doc__, typing.NamedTuple.__doc__)
 
+    @skipIf(sys.version_info < (3, 8), "NamedTuple had a bad signature on <=3.7")
+    def test_signature_is_same_as_typing_NamedTuple(self):
+        self.assertEqual(inspect.signature(NamedTuple), inspect.signature(typing.NamedTuple))
+
+    @skipIf(sys.version_info >= (3, 8), "tests are only relveant to <=3.7")
+    def test_signature_on_37(self):
+        self.assertIsInstance(inspect.signature(NamedTuple), inspect.Signature)
+        self.assertFalse(hasattr(NamedTuple, "__text_signature__"))
+
     @skipIf(sys.version_info < (3, 9), "NamedTuple was a class on 3.8 and lower")
     def test_same_as_typing_NamedTuple_39_plus(self):
         self.assertEqual(
             set(dir(NamedTuple)),
             set(dir(typing.NamedTuple)) | {"__text_signature__"}
         )
-        self.assertEqual(inspect.signature(NamedTuple), inspect.signature(typing.NamedTuple))
         self.assertIs(type(NamedTuple), type(typing.NamedTuple))
 
     @skipIf(sys.version_info >= (3, 9), "tests are only relevant to <=3.8")
@@ -3149,8 +3157,6 @@ class NamedTupleTests(BaseTestCase):
             self.NestedEmployee.__annotations__,
             self.NestedEmployee._field_types
         )
-        self.assertIsInstance(inspect.signature(NamedTuple), inspect.Signature)
-        self.assertFalse(hasattr(NamedTuple, "__text_signature__"))
 
 
 if __name__ == '__main__':

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1984,7 +1984,7 @@ else:
         return nm_tpl
 
     _prohibited_namedtuple_fields = typing._prohibited
-    _special_namedtuple_fields = typing._special
+    _special_namedtuple_fields = frozenset({'__module__', '__name__', '__annotations__'})
 
     class _NamedTupleMeta(type):
         def __new__(cls, typename, bases, ns):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2023,29 +2023,16 @@ else:
                 nm_tpl.__init_subclass__()
             return nm_tpl
 
-    _bad_args_error_message = (
-        "Either list of fields or keywords can be provided to NamedTuple, not both"
-    )
-
-    # Match the signature of typing.NamedTuple on 3.9+ exactly where possible,
-    # working around the fact that syntax for positional-only arguments
-    # is only available on 3.8+
-    if sys.version_info >= (3, 8):
-        def NamedTuple(typename, fields=None, /, **kwargs):
-            if fields is None:
-                fields = kwargs.items()
-            elif kwargs:
-                raise TypeError(_bad_args_error_message)
-            return _make_nmtuple(typename, fields, module=_caller())
-    else:
-        def NamedTuple(__typename, __fields=None, **kwargs):
-            if __fields is None:
-                __fields = kwargs.items()
-            elif kwargs:
-                raise TypeError(_bad_args_error_message)
-            return _make_nmtuple(__typename, __fields, module=_caller())
+    def NamedTuple(__typename, __fields=None, **kwargs):
+        if __fields is None:
+            __fields = kwargs.items()
+        elif kwargs:
+            raise TypeError("Either list of fields or keywords"
+                            " can be provided to NamedTuple, not both")
+        return _make_nmtuple(__typename, __fields, module=_caller())
 
     NamedTuple.__doc__ = typing.NamedTuple.__doc__
+    NamedTuple.__text_signature__ = '(typename, fields=None, /, **kwargs)'
     _NamedTuple = type.__new__(_NamedTupleMeta, 'NamedTuple', (), {})
 
     def _namedtuple_mro_entries(bases):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1970,7 +1970,7 @@ else:
         except (AttributeError, ValueError):  # For platforms without _getframe()
             return None
 
-    def _make_nmtuple(name, types, module, defaults = ()):
+    def _make_nmtuple(name, types, module, defaults=()):
         fields = [n for n, t in types]
         types = {n: typing._type_check(t, f"field {n} annotation must be a type")
                  for n, t in types}

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1961,7 +1961,7 @@ if not hasattr(typing, "TypeVarTuple"):
     typing._check_generic = _check_generic
 
 
-# Backport NamedTuple as it exists in 3.11
+# Backport typing.NamedTuple as it exists in Python 3.11.
 # In 3.11, the ability to define generic `NamedTuple`s was supported.
 # This was explicitly disallowed in 3.9-3.10, and only half-worked in <=3.8.
 if sys.version_info >= (3, 11):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -37,6 +37,7 @@ __all__ = [
     'Counter',
     'Deque',
     'DefaultDict',
+    'NamedTuple',
     'OrderedDict',
     'TypedDict',
 
@@ -1958,3 +1959,81 @@ else:
 if not hasattr(typing, "TypeVarTuple"):
     typing._collect_type_vars = _collect_type_vars
     typing._check_generic = _check_generic
+
+
+if sys.version_info >= (3, 11):
+    NamedTuple = typing.NamedTuple
+else:
+    def _caller(depth=1, default='__main__'):
+        try:
+            return sys._getframe(depth + 1).f_globals.get('__name__', default)
+        except (AttributeError, ValueError):  # For platforms without _getframe()
+            return None
+
+    def _make_nmtuple(name, types, module, defaults = ()):
+        fields = [n for n, t in types]
+        types = {n: typing._type_check(t, f"field {n} annotation must be a type")
+                 for n, t in types}
+        nm_tpl = collections.namedtuple(name, fields,
+                                        defaults=defaults, module=module)
+        nm_tpl.__annotations__ = nm_tpl.__new__.__annotations__ = types
+        if sys.version_info < (3, 9):
+            nm_tpl._field_types = nm_tpl.__annotations__
+        return nm_tpl
+
+    _prohibited_namedtuple_fields = typing._prohibited
+    _special_namedtuple_fields = typing._special
+
+    class _NamedTupleMeta(type):
+        def __new__(cls, typename, bases, ns):
+            assert _NamedTuple in bases
+            for base in bases:
+                if base is not _NamedTuple and base is not typing.Generic:
+                    raise TypeError(
+                        'can only inherit from a NamedTuple type and Generic')
+            bases = tuple(tuple if base is _NamedTuple else base for base in bases)
+            types = ns.get('__annotations__', {})
+            default_names = []
+            for field_name in types:
+                if field_name in ns:
+                    default_names.append(field_name)
+                elif default_names:
+                    raise TypeError(f"Non-default namedtuple field {field_name} "
+                                    f"cannot follow default field"
+                                    f"{'s' if len(default_names) > 1 else ''} "
+                                    f"{', '.join(default_names)}")
+            nm_tpl = _make_nmtuple(
+                typename, types.items(),
+                defaults=[ns[n] for n in default_names],
+                module=ns['__module__']
+            )
+            nm_tpl.__bases__ = bases
+            if typing.Generic in bases:
+                class_getitem = typing.Generic.__class_getitem__.__func__
+                nm_tpl.__class_getitem__ = classmethod(class_getitem)
+            # update from user namespace without overriding special namedtuple attributes
+            for key in ns:
+                if key in _prohibited_namedtuple_fields:
+                    raise AttributeError("Cannot overwrite NamedTuple attribute " + key)
+                elif key not in _special_namedtuple_fields and key not in nm_tpl._fields:
+                    setattr(nm_tpl, key, ns[key])
+            if typing.Generic in bases:
+                nm_tpl.__init_subclass__()
+            return nm_tpl
+
+    def NamedTuple(__typename, __fields=None, **kwargs):
+        if __fields is None:
+            __fields = kwargs.items()
+        elif kwargs:
+            raise TypeError("Either list of fields or keywords"
+                            " can be provided to NamedTuple, not both")
+        return _make_nmtuple(__typename, __fields, module=_caller())
+
+    NamedTuple.__doc__ = typing.NamedTuple.__doc__
+    _NamedTuple = type.__new__(_NamedTupleMeta, 'NamedTuple', (), {})
+
+    def _namedtuple_mro_entries(bases):
+        assert NamedTuple in bases
+        return (_NamedTuple,)
+
+    NamedTuple.__mro_entries__ = _namedtuple_mro_entries

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1961,6 +1961,9 @@ if not hasattr(typing, "TypeVarTuple"):
     typing._check_generic = _check_generic
 
 
+# Backport NamedTuple as it exists in 3.11
+# In 3.11, the ability to define generic `NamedTuple`s was supported.
+# This was explicitly disallowed in 3.9-3.10, and only half-worked in <=3.8.
 if sys.version_info >= (3, 11):
     NamedTuple = typing.NamedTuple
 else:

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1964,23 +1964,23 @@ if not hasattr(typing, "TypeVarTuple"):
 if sys.version_info >= (3, 11):
     NamedTuple = typing.NamedTuple
 else:
-    def _caller(depth=1, default='__main__'):
+    def _caller():
         try:
-            return sys._getframe(depth + 1).f_globals.get('__name__', default)
+            return sys._getframe(2).f_globals.get('__name__', '__main__')
         except (AttributeError, ValueError):  # For platforms without _getframe()
             return None
 
     def _make_nmtuple(name, types, module, defaults=()):
         fields = [n for n, t in types]
-        types = {n: typing._type_check(t, f"field {n} annotation must be a type")
-                 for n, t in types}
+        annotations = {n: typing._type_check(t, f"field {n} annotation must be a type")
+                       for n, t in types}
         nm_tpl = collections.namedtuple(name, fields,
                                         defaults=defaults, module=module)
-        nm_tpl.__annotations__ = nm_tpl.__new__.__annotations__ = types
+        nm_tpl.__annotations__ = nm_tpl.__new__.__annotations__ = annotations
         # The `_field_types` attribute was removed in 3.9;
         # in earlier versions, it is the same as the `__annotations__` attribute
         if sys.version_info < (3, 9):
-            nm_tpl._field_types = nm_tpl.__annotations__
+            nm_tpl._field_types = annotations
         return nm_tpl
 
     _prohibited_namedtuple_fields = typing._prohibited

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2032,8 +2032,10 @@ else:
         return _make_nmtuple(__typename, __fields, module=_caller())
 
     NamedTuple.__doc__ = typing.NamedTuple.__doc__
-    NamedTuple.__text_signature__ = '(typename, fields=None, /, **kwargs)'
     _NamedTuple = type.__new__(_NamedTupleMeta, 'NamedTuple', (), {})
+
+    if sys.version_info >= (3, 9):
+        NamedTuple.__text_signature__ = '(typename, fields=None, /, **kwargs)'
 
     def _namedtuple_mro_entries(bases):
         assert NamedTuple in bases

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2037,7 +2037,10 @@ else:
     NamedTuple.__doc__ = typing.NamedTuple.__doc__
     _NamedTuple = type.__new__(_NamedTupleMeta, 'NamedTuple', (), {})
 
-    if sys.version_info >= (3, 9):
+    # On 3.8+, alter the signature so that it matches typing.NamedTuple.
+    # The signature of typing.NamedTuple on >=3.8 is invalid syntax in Python 3.7,
+    # so just leave the signature as it is on 3.7.
+    if sys.version_info >= (3, 8):
         NamedTuple.__text_signature__ = '(typename, fields=None, /, **kwargs)'
 
     def _namedtuple_mro_entries(bases):


### PR DESCRIPTION
This PR backports the ability, added in https://github.com/python/cpython/pull/92027, to define generic `NamedTuple` classes. The implementation and the tests are very similar to the implementation on the CPython `main` branch, with a few tweaks so that it all works on earlier versions of Python as well.

#7