### PR TITLE
Backport generic `TypedDict`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Add `typing_extensions.NamedTuple`, allowing for generic `NamedTuple`s on
   Python <3.11 (backport from python/cpython#92027, by Serhiy Storchaka). Patch
   by Alex Waygood (@AlexWaygood).
+- Adjust `typing_extensions.TypedDict` to allow for generic `TypedDict`s on
+  Python <3.11 (backport from python/cpython#27663, by Samodya Abey). Patch by
+  Alex Waygood (@AlexWaygood).
 
 # Release 4.2.0 (April 17, 2022)
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ Certain objects were changed after they were added to `typing`, and
 - `TypedDict` does not store runtime information
   about which (if any) keys are non-required in Python 3.8, and does not
   honor the `total` keyword with old-style `TypedDict()` in Python
-  3.9.0 and 3.9.1.
+  3.9.0 and 3.9.1. `TypedDict` also does not support multiple inheritance
+  with `typing.Generic` on Python <3.11.
 - `get_origin` and `get_args` lack support for `Annotated` in
   Python 3.8 and lack support for `ParamSpecArgs` and `ParamSpecKwargs`
   in 3.9.

--- a/src/_typed_dict_test_helper.py
+++ b/src/_typed_dict_test_helper.py
@@ -1,0 +1,5 @@
+from typing import TypeVar, Generic, Optional, T
+from typing_extensions import TypedDict
+
+class FooGeneric(TypedDict, Generic[T]):
+    a: Optional[T]

--- a/src/_typed_dict_test_helper.py
+++ b/src/_typed_dict_test_helper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TypeVar, Generic, Optional, T
 from typing_extensions import TypedDict
 


### PR DESCRIPTION
As with https://github.com/python/typing_extensions/pull/44, the tests here are basically copied from the cpython `main` branch. Unlike https://github.com/python/typing_extensions/pull/44, however, the implementation needs to be a little bit different. On Python <= 3.10, `typing.Generic` raises a `TypeError` if `Generic.__init_subclass__` is called from `_TypedDictMeta.__new__`, so I had to work around this.

Backport of https://github.com/python/cpython/pull/27663, by Samodya Abey. Closes #7. Cc. @davidfstr.