### PR TITLE
fix release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,6 @@ backwards-incompatible changes.
 
 - Build the source and wheel distributions:
 
-  - `cd typing_extensions`
   - `rm -rf dist/`
   - `python -m build .`
 


### PR DESCRIPTION
Holdover from when we were still in the `typing` repository.