### PR TITLE
Use inline table syntax for license key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ version = "4.3.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 readme = "README.md"
 requires-python = ">=3.7"
-license.file = "LICENSE"
+license = { file = "LICENSE" }
 keywords = [
     "annotations",
     "backport",


### PR DESCRIPTION
This fixes a problem with old pip version that use an outdated TOML
parser.

Closes: #57