### PR TITLE
TypedDict: Resolve string-based annotations

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -638,6 +638,10 @@ class AnnotatedMovie(TypedDict):
     title: Annotated[Required[str], "foobar"]
     year: NotRequired[Annotated[int, 2000]]
 
+class StringBasedMovie(TypedDict):
+    title: "str"
+    year: "NotRequired[int]"
+
 
 gth = get_type_hints
 
@@ -1828,6 +1832,9 @@ class TypedDictTests(BaseTestCase):
 
         assert TotalMovie.__required_keys__ == frozenset({'title'})
         assert TotalMovie.__optional_keys__ == frozenset({'year'})
+
+        assert StringBasedMovie.__required_keys__ == frozenset({'title'})
+        assert StringBasedMovie.__optional_keys__ == frozenset({'year'})
 
 
     def test_keys_inheritance(self):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -718,7 +718,10 @@ else:
                 _maybe_adjust_parameters(tp_dict)
 
             annotations = {}
-            own_annotations = ns.get('__annotations__', {})
+            if sys.version_info >= (3, 9):
+                own_annotations = typing.get_type_hints(tp_dict, include_extras=True)
+            else:
+                own_annotations = typing.get_type_hints(tp_dict)
             msg = "TypedDict('Name', {f0: t0, f1: t1, ...}); each t must be a type"
             own_annotations = {
                 n: typing._type_check(tp, msg) for n, tp in own_annotations.items()
@@ -727,7 +730,10 @@ else:
             optional_keys = set()
 
             for base in bases:
-                annotations.update(base.__dict__.get('__annotations__', {}))
+                if sys.version_info >= (3, 9):
+                    annotations.update(typing.get_type_hints(base, include_extras=True))
+                else:
+                    annotations.update(typing.get_type_hints(base))
                 required_keys.update(base.__dict__.get('__required_keys__', ()))
                 optional_keys.update(base.__dict__.get('__optional_keys__', ()))
 


### PR DESCRIPTION
Fixes #55 

I'm calling `typing.get_type_hints` because `typing_extensions.get_type_hints` is not yet defined in the relevant section. This shouldn't be a problem as long the behaviour of `get_type_hints(..., include_extras=True)` doesn't change. When porting this to the `typing` module, it should work fine because the definition order is fine there.

The test on Python 3.11 fails because `TypedDict` is rexported from `typing` (it took some time until I realized that this was the problem :D).