### PR TITLE
Silence `flake8-bugbear`

### DIFF
--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -431,7 +431,7 @@ else:
         if type(self)._is_protocol:
             raise TypeError('Protocols cannot be instantiated')
 
-    class _ProtocolMeta(abc.ABCMeta):
+    class _ProtocolMeta(abc.ABCMeta):  # noqa: B024
         # This metaclass is a bit unfortunate and exists only because of the lack
         # of __instancehook__.
         def __instancecheck__(cls, instance):


### PR DESCRIPTION
I don't think that 

> /src/typing_extensions.py:434:5: B024 _ProtocolMeta is an abstract base class, but it has no abstract methods. Remember to use @abstractmethod, @abstractclassmethod and/or @abstractproperty decorators.

is even correct, because in this case we create a new metaclass in the `ABC` chain.
But, I guess the only other option is to complete ignore this violation.