### PR TITLE
Add `__override__` attribute to @override (PEP 698)

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -164,16 +164,38 @@ class AssertNeverTests(BaseTestCase):
 class OverrideTests(BaseTestCase):
     def test_override(self):
         class Base:
-            def foo(self): ...
+            def normal_method(self): ...
+            @staticmethod
+            def static_method_good_order(): ...
+            @staticmethod
+            def static_method_bad_order(): ...
+            @staticmethod
+            def decorator_with_slots(): ...
 
         class Derived(Base):
             @override
-            def foo(self):
+            def normal_method(self):
                 return 42
 
+            @staticmethod
+            @override
+            def static_method_good_order():
+                return 42
+
+            @override
+            @staticmethod
+            def static_method_bad_order():
+                return 42
+
+
         self.assertIsSubclass(Derived, Base)
-        self.assertEqual(Derived().foo(), 42)
-        self.assertEqual(dir(Base.foo), dir(Derived.foo))
+        instance = Derived()
+        self.assertEqual(instance.normal_method(), 42)
+        self.assertIs(True, instance.normal_method.__override__)
+        self.assertEqual(Derived.static_method_good_order(), 42)
+        self.assertIs(True, Derived.static_method_good_order.__override__)
+        self.assertEqual(Derived.static_method_bad_order(), 42)
+        self.assertIs(False, hasattr(Derived.static_method_bad_order, "__override__"))
 
 
 class AnyTests(BaseTestCase):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2102,9 +2102,20 @@ else:
         This helps prevent bugs that may occur when a base class is changed
         without an equivalent change to a child class.
 
+        There is no runtime checking of these properties. The decorator
+        sets the ``__override__`` attribute to ``True`` on the decorated object
+        to allow runtime introspection.
+
         See PEP 698 for details.
 
         """
+        try:
+            __arg.__override__ = True
+        except (AttributeError, TypeError):
+            # Skip the attribute silently if it is not writable.
+            # AttributeError happens if the object has __slots__ or a
+            # read-only property, TypeError if it's a builtin class.
+            pass
         return __arg
 
 


### PR DESCRIPTION
As per discussion in
https://mail.python.org/archives/list/typing-sig@python.org/thread/TOIYZ3SNPBJZDBRU3ZSBREXV2NNHF4KW/, we believe this is a good feature to have (as best-effort: it will not work in all cases if the user does not understand decorator implementations enough to get the right order, and it will alwasys fail if a decorator output does not support dynamic attributes).

We decided to support this for two reasons:
- it was a direct request from the `overrides` library owner
- `typing_extensions.final` has similar behavior

Tests:
```
cd src
python -m unittest test_typing_extensions.py
```

Lints:
```
flake8
flake8 --config=.flake8-tests src/test_typing_extensions.py
```

I'll edit PEP 698 to cover this behavior this week, but I wanted to get feedback here and back-port to pyre_extensions first so that we can have the runtime behavior linked in the reference implementation.

I tried to include a test of a decorator with `__slots__`, but I don't know descriptors that well and got stuck. I can add that if we really want it but wasn't sure I wanted to spend the time otherwise. I would guess that most of the time when the runtime behavior fails it will be due to out-of-order decorators rather than output types that have fixed slots, so my static method examples seem more useful as edge-case documentation.