### PR TITLE
Remove Python 3.6 from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = py36, py37, py38, py39, py310
+envlist = py37, py38, py39, py310
 
 [testenv]
 changedir = src


### PR DESCRIPTION
The 3.6 tox env fails because the minimum supported version is now 3.7.