### PR TITLE
Fix get_type_hints() on x-module inherited TypedDict in 3.9 and 3.10

### DIFF
--- a/src/_typed_dict_test_helper.py
+++ b/src/_typed_dict_test_helper.py
@@ -4,5 +4,15 @@ from typing import Generic, Optional, T
 from typing_extensions import TypedDict
 
 
+# this class must not be imported into test_typing_extensions.py at top level, otherwise
+# the test_get_type_hints_cross_module_subclass test will pass for the wrong reason
+class _DoNotImport:
+    pass
+
+
+class Foo(TypedDict):
+    a: _DoNotImport
+
+
 class FooGeneric(TypedDict, Generic[T]):
     a: Optional[T]

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -41,6 +41,10 @@ TYPING_3_10_0 = sys.version_info[:3] >= (3, 10, 0)
 # 3.11 makes runtime type checks (_type_check) more lenient.
 TYPING_3_11_0 = sys.version_info[:3] >= (3, 11, 0)
 
+# https://github.com/python/cpython/pull/27017 was backported into some 3.9 and 3.10
+# versions, but not all
+HAS_FORWARD_MODULE = "module" in inspect.signature(typing._type_check).parameters
+
 
 class BaseTestCase(TestCase):
     def assertIsSubclass(self, cls, class_or_tuple, msg=None):
@@ -1982,7 +1986,7 @@ class TypedDictTests(BaseTestCase):
         assert is_typeddict(PointDict2D) is True
         assert is_typeddict(PointDict3D) is True
 
-    @skipUnless(TYPING_3_9_0, "ForwardRef.__forward_module__ was added in 3.9")
+    @skipUnless(HAS_FORWARD_MODULE, "ForwardRef.__forward_module__ was added in 3.9")
     def test_get_type_hints_cross_module_subclass(self):
         self.assertEqual(
             {k: v.__name__ for k, v in get_type_hints(Bar).items()},

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -1988,6 +1988,7 @@ class TypedDictTests(BaseTestCase):
 
     @skipUnless(HAS_FORWARD_MODULE, "ForwardRef.__forward_module__ was added in 3.9")
     def test_get_type_hints_cross_module_subclass(self):
+        self.assertNotIn("_DoNotImport", globals())
         self.assertEqual(
             {k: v.__name__ for k, v in get_type_hints(Bar).items()},
             {'a': "_DoNotImport", 'b': "int"}

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -1984,11 +1984,9 @@ class TypedDictTests(BaseTestCase):
 
     @skipUnless(TYPING_3_9_0, "ForwardRef.__forward_module__ was added in 3.9")
     def test_get_type_hints_cross_module_subclass(self):
-        from _typed_dict_test_helper import _DoNotImport
-
         self.assertEqual(
-            get_type_hints(Bar),
-            {'a': _DoNotImport, 'b': int}
+            {k: v.__name__ for k, v in get_type_hints(Bar).items()},
+            {'a': "_DoNotImport", 'b': "int"}
         )
 
     def test_get_type_hints_generic(self):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -30,7 +30,7 @@ from typing_extensions import assert_type, get_type_hints, get_origin, get_args
 from typing_extensions import clear_overloads, get_overloads, overload
 from typing_extensions import NamedTuple
 from typing_extensions import override
-from _typed_dict_test_helper import FooGeneric
+from _typed_dict_test_helper import Foo, FooGeneric
 
 # Flags used to mark tests that only apply after a specific
 # version of the typing module.
@@ -1774,6 +1774,10 @@ class Point2DGeneric(Generic[T], TypedDict):
     b: T
 
 
+class Bar(Foo):
+    b: int
+
+
 class BarGeneric(FooGeneric[T], total=False):
     b: int
 
@@ -1977,6 +1981,15 @@ class TypedDictTests(BaseTestCase):
         assert is_typeddict(Point) is True
         assert is_typeddict(PointDict2D) is True
         assert is_typeddict(PointDict3D) is True
+
+    @skipUnless(TYPING_3_9_0, "ForwardRef.__forward_module__ was added in 3.9")
+    def test_get_type_hints_cross_module_subclass(self):
+        from _typed_dict_test_helper import _DoNotImport
+
+        self.assertEqual(
+            get_type_hints(Bar),
+            {'a': _DoNotImport, 'b': int}
+        )
 
     def test_get_type_hints_generic(self):
         self.assertEqual(

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2,6 +2,7 @@ import abc
 import collections
 import collections.abc
 import functools
+import inspect
 import operator
 import sys
 import types as _types
@@ -728,6 +729,8 @@ else:
     _typeddict_new.__text_signature__ = ('($cls, _typename, _fields=None,'
                                          ' /, *, total=True, **kwargs)')
 
+    _TAKES_MODULE = "module" in inspect.signature(typing._type_check).parameters
+
     class _TypedDictMeta(type):
         def __init__(cls, name, bases, ns, total=True):
             super().__init__(name, bases, ns)
@@ -753,8 +756,9 @@ else:
             annotations = {}
             own_annotations = ns.get('__annotations__', {})
             msg = "TypedDict('Name', {f0: t0, f1: t1, ...}); each t must be a type"
+            kwds = {"module": tp_dict.__module__} if _TAKES_MODULE else {}
             own_annotations = {
-                n: typing._type_check(tp, msg) for n, tp in own_annotations.items()
+                n: typing._type_check(tp, msg, **kwds) for n, tp in own_annotations.items()
             }
             required_keys = set()
             optional_keys = set()

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -758,7 +758,8 @@ else:
             msg = "TypedDict('Name', {f0: t0, f1: t1, ...}); each t must be a type"
             kwds = {"module": tp_dict.__module__} if _TAKES_MODULE else {}
             own_annotations = {
-                n: typing._type_check(tp, msg, **kwds) for n, tp in own_annotations.items()
+                n: typing._type_check(tp, msg, **kwds)
+                for n, tp in own_annotations.items()
             }
             required_keys = set()
             optional_keys = set()


### PR DESCRIPTION
The fix in https://github.com/python/cpython/pull/27017 was never backported into typing-extensions.

In 3.11 it doesn't matter because we just use `TypedDict` from `typing.py`. But in 3.9 and 3.10, it means this cross-module inheritance scenario with stringified annotations and `get_type_hints` will fail if you use `TypedDict` from `typing_extensions` but work if you use it from `typing`.

I don't attempt here to backport the fix to pre-3.9 versions where `typing.py` doesn't have it; that would require pulling in lots more code (`ForwardRef` and some utility functions) into `typing_extensions.py`. Just aiming for parity with `typing.py` for 3.9 and 3.10.