### PR TITLE
Fix linting error in src/test_typing_extensions.py

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -930,14 +930,14 @@ class CollectionsAbcTests(BaseTestCase):
             pass
 
     def test_async_iterable(self):
-        base_it = range(10)  # type: Iterator[int]
+        base_it: Iterator[int] = range(10)
         it = AsyncIteratorWrapper(base_it)
         self.assertIsInstance(it, typing_extensions.AsyncIterable)
         self.assertIsInstance(it, typing_extensions.AsyncIterable)
         self.assertNotIsInstance(42, typing_extensions.AsyncIterable)
 
     def test_async_iterator(self):
-        base_it = range(10)  # type: Iterator[int]
+        base_it: Iterator[int] = range(10)
         it = AsyncIteratorWrapper(base_it)
         self.assertIsInstance(it, typing_extensions.AsyncIterator)
         self.assertNotIsInstance(42, typing_extensions.AsyncIterator)
@@ -1697,7 +1697,7 @@ class ProtocolTests(BaseTestCase):
     def test_none_treated_correctly(self):
         @runtime
         class P(Protocol):
-            x = None  # type: int
+            x: int = None
         class B(object): pass
         self.assertNotIsInstance(B(), P)
         class C:
@@ -1717,7 +1717,7 @@ class ProtocolTests(BaseTestCase):
 
     def test_protocols_in_unions(self):
         class P(Protocol):
-            x = None  # type: int
+            x: int = None
         Alias = typing.Union[typing.Iterable, P]
         Alias2 = typing.Union[P, typing.Iterable]
         self.assertEqual(Alias, Alias2)
@@ -2388,7 +2388,7 @@ class TypeAliasTests(BaseTestCase):
         exec('Alias: TypeAlias = Employee', globals(), ns)
 
     def test_canonical_usage_with_type_comment(self):
-        Alias = Employee  # type: TypeAlias
+        Alias: TypeAlias = Employee
 
     def test_cannot_instantiate(self):
         with self.assertRaises(TypeError):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -17,7 +17,7 @@ from test import ann_module, ann_module2, ann_module3
 import typing
 from typing import TypeVar, Optional, Union, AnyStr
 from typing import T, KT, VT  # Not in __all__.
-from typing import Tuple, List, Dict, Iterable, Iterator, Callable
+from typing import Tuple, List, Dict, Iterable, Callable
 from typing import Generic
 from typing import no_type_check
 import typing_extensions

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -17,7 +17,7 @@ from test import ann_module, ann_module2, ann_module3
 import typing
 from typing import TypeVar, Optional, Union, AnyStr
 from typing import T, KT, VT  # Not in __all__.
-from typing import Tuple, List, Dict, Iterable, Callable
+from typing import Tuple, List, Dict, Iterable, Iterator, Callable
 from typing import Generic
 from typing import no_type_check
 import typing_extensions


### PR DESCRIPTION
### Before
```
typing_extensions on  main via 🐍 v3.10.8 took 2s
❯ ~/.local/bin/flake8 --config=.flake8-tests src/test_typing_extensions.py
src/test_typing_extensions.py:20:1: F401 'typing.Iterator' imported but unused

```
### After
```
typing_extensions on  lint-fix [⇡] via 🐍 v3.10.8
❯ ~/.local/bin/flake8 --config=.flake8-tests src/test_typing_extensions.py
```