### PR TITLE
CI: test on Ubuntu-20.04, not Ubuntu-2004

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
         python-version: ["3.7", "3.7.1", "3.8", "3.8.0", "3.9", "3.9.0", "3.10", "3.10.0", "3.11-dev", "pypy3.9"]
 
-    runs-on: ubuntu-2004
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Fixes a typo in https://github.com/python/typing_extensions/commit/5f9258d1efd5d8e4900ffc23ba2486240f2a2f35. We might have to wait a while before Ubuntu-2004 is released :)