### PR TITLE
Add @typing_extensions.deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-# Release 4.4.1 (?)
+# Unreleased
 
+- Runtime support for PEP 702, adding `typing_extensions.deprecated`. Patch
+  by Jelle Zijlstra.
 - Add better default value for TypeVar `default` parameter, PEP 696. Enables
   runtime check if `None` was passed as default. Patch by Marc Mueller (@cdce8p).
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This module currently contains the following:
   - `override` (see [PEP 698](https://peps.python.org/pep-0698/))
   - The `default=` argument to `TypeVar`, `ParamSpec`, and `TypeVarTuple` (see [PEP 696](https://peps.python.org/pep-0696/))
   - The `infer_variance=` argument to `TypeVar` (see [PEP 695](https://peps.python.org/pep-0695/))
+  - The `@deprecated` decorator (see [PEP 702](https://peps.python.org/pep-0698/))
 
 - In `typing` since Python 3.11
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -29,7 +29,7 @@ from typing_extensions import TypeVarTuple, Unpack, dataclass_transform, reveal_
 from typing_extensions import assert_type, get_type_hints, get_origin, get_args
 from typing_extensions import clear_overloads, get_overloads, overload
 from typing_extensions import NamedTuple
-from typing_extensions import override
+from typing_extensions import override, deprecated
 from _typed_dict_test_helper import Foo, FooGeneric
 
 # Flags used to mark tests that only apply after a specific
@@ -200,6 +200,35 @@ class OverrideTests(BaseTestCase):
         self.assertIs(True, Derived.static_method_good_order.__override__)
         self.assertEqual(Derived.static_method_bad_order(), 42)
         self.assertIs(False, hasattr(Derived.static_method_bad_order, "__override__"))
+
+
+class DeprecatedTests(BaseTestCase):
+    def test_deprecated(self):
+        @deprecated("A will go away soon")
+        class A:
+            pass
+
+        self.assertEqual(A.__deprecated__, "A will go away soon")
+        self.assertIsInstance(A, type)
+
+        @deprecated("b will go away soon")
+        def b():
+            pass
+
+        self.assertEqual(b.__deprecated__, "b will go away soon")
+        self.assertIsInstance(b, types.FunctionType)
+
+        @overload
+        @deprecated("no more ints")
+        def h(x: int) -> int: ...
+        @overload
+        def h(x: str) -> str: ...
+        def h(x):
+            return x
+
+        overloads = get_overloads(h)
+        self.assertEqual(len(overloads), 2)
+        self.assertEqual(overloads[0].__deprecated__, "no more ints")
 
 
 class AnyTests(BaseTestCase):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -52,6 +52,7 @@ __all__ = [
     'assert_type',
     'clear_overloads',
     'dataclass_transform',
+    'deprecated',
     'get_overloads',
     'final',
     'get_args',
@@ -2126,6 +2127,47 @@ else:
             # read-only property, TypeError if it's a builtin class.
             pass
         return __arg
+
+
+if hasattr(typing, "deprecated"):
+    override = typing.deprecated
+else:
+    _T = typing.TypeVar("_T")
+
+    def deprecated(__msg: str) -> typing.Callable[[_T], _T]:
+        """Indicate that a class, function or overload is deprecated.
+
+        Usage:
+
+            @deprecated("Use B instead")
+            class A:
+                pass
+
+            @deprecated("Use g instead")
+            def f():
+                pass
+
+            @deprecated("int support is deprecated")
+            @overload
+            def g(x: int) -> int: ...
+            @overload
+            def g(x: str) -> int: ...
+
+        When this decorator is applied to an object, the type checker
+        will generate a diagnostic on usage of the deprecated object.
+
+        No runtime warning is issued. The decorator sets the ``__deprecated__``
+        attribute on the decorated object to the deprecation message
+        passed to the decorator.
+
+        See PEP 702 for details.
+
+        """
+        def decorator(__arg: _T) -> _T:
+            __arg.__deprecated__ = __msg
+            return __arg
+
+        return decorator
 
 
 # We have to do some monkey patching to deal with the dual nature of

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2159,7 +2159,9 @@ else:
 
         No runtime warning is issued. The decorator sets the ``__deprecated__``
         attribute on the decorated object to the deprecation message
-        passed to the decorator.
+        passed to the decorator. If applied to an overload, the decorator
+        must be after the ``@overload`` decorator for the attribute to
+        exist on the overload as returned by ``get_overloads()``.
 
         See PEP 702 for details.
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2148,8 +2148,8 @@ else:
             def f():
                 pass
 
-            @deprecated("int support is deprecated")
             @overload
+            @deprecated("int support is deprecated")
             def g(x: int) -> int: ...
             @overload
             def g(x: str) -> int: ...

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2130,7 +2130,7 @@ else:
 
 
 if hasattr(typing, "deprecated"):
-    override = typing.deprecated
+    deprecated = typing.deprecated
 else:
     _T = typing.TypeVar("_T")
 


### PR DESCRIPTION
See PEP 702, python/peps#2942. This should not be merged until the PEP
is merged into the repo.
