### PR TITLE
Remove duplicate test

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -2368,16 +2368,6 @@ class AnnotatedTests(BaseTestCase):
                 get_type_hints(C, globals())["const"], Annotated[Final[int], "Const"]
             )
 
-    def test_hash_eq(self):
-        self.assertEqual(len({Annotated[int, 4, 5], Annotated[int, 4, 5]}), 1)
-        self.assertNotEqual(Annotated[int, 4, 5], Annotated[int, 5, 4])
-        self.assertNotEqual(Annotated[int, 4, 5], Annotated[str, 4, 5])
-        self.assertNotEqual(Annotated[int, 4], Annotated[int, 4, 4])
-        self.assertEqual(
-            {Annotated[int, 4, 5], Annotated[int, 4, 5], Annotated[T, 4, 5]},
-            {Annotated[int, 4, 5], Annotated[T, 4, 5]}
-        )
-
     def test_cannot_subclass(self):
         with self.assertRaisesRegex(TypeError, "Cannot subclass .*Annotated"):
             class C(Annotated):


### PR DESCRIPTION
This method is identical to `test_hash_eq` on lines 2296-2304: https://github.com/python/typing_extensions/blob/a0858e6ba9b46996f3f74dde8749ab86e1561012/src/test_typing_extensions.py#L2296-L2304

(This is a backport of the only relevant part of https://github.com/python/cpython/pull/102445)