### PR TITLE
Move builtin protocol whitelist to mapping instead of list

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -1909,7 +1909,6 @@ class ProtocolTests(BaseTestCase):
 
         self.assertIsSubclass(B, Custom)
         self.assertNotIsSubclass(A, Custom)
-    
     def test_builtin_protocol_allowlist(self):
         with self.assertRaises(TypeError):
             class CustomProtocol(TestCase, Protocol):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -1909,6 +1909,7 @@ class ProtocolTests(BaseTestCase):
 
         self.assertIsSubclass(B, Custom)
         self.assertNotIsSubclass(A, Custom)
+
     def test_builtin_protocol_allowlist(self):
         with self.assertRaises(TypeError):
             class CustomProtocol(TestCase, Protocol):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -1909,6 +1909,14 @@ class ProtocolTests(BaseTestCase):
 
         self.assertIsSubclass(B, Custom)
         self.assertNotIsSubclass(A, Custom)
+    
+    def test_builtin_protocol_allowlist(self):
+        with self.assertRaises(TypeError):
+            class CustomProtocol(TestCase, Protocol):
+                pass
+
+        class CustomContextManager(typing.ContextManager, Protocol):
+            pass
 
     def test_no_init_same_for_different_protocol_implementations(self):
         class CustomProtocolWithoutInitA(Protocol):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -389,10 +389,13 @@ Text = typing.Text
 TYPE_CHECKING = typing.TYPE_CHECKING
 
 
-_PROTO_WHITELIST = ['Callable', 'Awaitable',
-                    'Iterable', 'Iterator', 'AsyncIterable', 'AsyncIterator',
-                    'Hashable', 'Sized', 'Container', 'Collection', 'Reversible',
-                    'ContextManager', 'AsyncContextManager']
+_PROTO_ALLOWLIST = {
+    'collections.abc': [
+        'Callable', 'Awaitable', 'Iterable', 'Iterator', 'AsyncIterable',
+        'Hashable', 'Sized', 'Container', 'Collection', 'Reversible',
+    ],
+    'contextlib': ['AbstractContextManager', 'AbstractAsyncContextManager'],
+}
 
 
 def _get_protocol_attrs(cls):
@@ -608,8 +611,8 @@ else:
             # Check consistency of bases.
             for base in cls.__bases__:
                 if not (base in (object, typing.Generic) or
-                        base.__module__ == 'collections.abc' and
-                        base.__name__ in _PROTO_WHITELIST or
+                        base.__module__ in _PROTO_ALLOWLIST and
+                        base.__name__ in _PROTO_ALLOWLIST[base.__module__] or
                         isinstance(base, _ProtocolMeta) and base._is_protocol):
                     raise TypeError('Protocols can only inherit from other'
                                     f' protocols, got {repr(base)}')


### PR DESCRIPTION
Backport from:
https://github.com/python/cpython/pull/15647
Also rename to allowlist, following these changes:
https://github.com/python/cpython/pull/21823
https://github.com/python/cpython/pull/21825