### PR TITLE
Suppress DeprecationWarnings and `print`s when running tests

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -64,7 +64,7 @@ class BaseTestCase(TestCase):
             raise self.failureException(message)
 
     @contextlib.contextmanager
-    def assertWarnsIf(self, condition: bool, expected_warning: type[Warning]):
+    def assertWarnsIf(self, condition: bool, expected_warning: Type[Warning]):
         with contextlib.ExitStack() as stack:
             if condition:
                 stack.enter_context(self.assertWarns(expected_warning))


### PR DESCRIPTION
If I run tests on `main` with Python 3.11, I get this output:

```
(venv) C:\Users\alexw\coding\typing_extensions>python src/test_typing_extensions.py
..............................................................C:\Users\alexw\coding\typing_extensions\src\test_typing_extensions.py:242: DeprecationWarning: A will go away soon
  A(42)
...........................................sssssssssssssssssss..................................................................................Runtime type is 'object'
..........................................C:\Users\alexw\coding\typing_extensions\src\test_typing_extensions.py:1962: DeprecationWarning: The kwargs-based syntax for TypedDict definitions is deprecated in Python 3.11, will be removed in Python 3.13, and may not be understood by third-party type checkers.
  Emp = TypedDict('Emp', name=str, id=int)
........C:\Users\alexw\coding\typing_extensions\src\test_typing_extensions.py:2069: DeprecationWarning: The kwargs-based syntax for TypedDict definitions is deprecated in Python 3.11, will be removed in Python 3.13, and may not be understood by third-party type checkers.
  EmpD = TypedDict('EmpD', name=str, id=int)
..C:\Users\alexw\coding\typing_extensions\src\test_typing_extensions.py:2047: DeprecationWarning: The kwargs-based syntax for TypedDict definitions is deprecated in Python 3.11, will be removed in Python 3.13, and may not be understood by third-party type checkers.
  EmpD = TypedDict('EmpD', name=str, id=int)
....s.C:\Users\alexw\coding\typing_extensions\src\test_typing_extensions.py:1977: DeprecationWarning: The kwargs-based syntax for TypedDict definitions is deprecated in Python 3.11, will be removed in Python 3.13, and may not be understood by third-party type checkers.
  TD = TypedDict("TD", cls=type, self=object, typename=str, _typename=int,
........
----------------------------------------------------------------------
Ran 272 tests in 0.145s

OK (skipped=20)
```

With this PR, I get this output:

```
(venv) C:\Users\alexw\coding\typing_extensions>python src/test_typing_extensions.py
.........................................................................................................sssssssssssssssssss..........................................................................................................................................s.........
----------------------------------------------------------------------
Ran 272 tests in 0.131s

OK (skipped=20)
```