### PR TITLE
Improve flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,3 +13,4 @@ exclude =
   # tests have more relaxed formatting rules
   # and its own specific config in .flake8-tests
   src/test_typing_extensions.py,
+noqa_require_code = true

--- a/.flake8-tests
+++ b/.flake8-tests
@@ -26,3 +26,4 @@ ignore =
   DW12,
   # consistency with mypy
   W504
+noqa_require_code = true

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -582,7 +582,7 @@ class NotRequiredTests(BaseTestCase):
 
 class IntVarTests(BaseTestCase):
     def test_valid(self):
-        T_ints = IntVar("T_ints")  # noqa
+        T_ints = IntVar("T_ints")
 
     def test_invalid(self):
         with self.assertRaises(TypeError):
@@ -590,7 +590,7 @@ class IntVarTests(BaseTestCase):
         with self.assertRaises(TypeError):
             T_ints = IntVar("T_ints", bound=int)
         with self.assertRaises(TypeError):
-            T_ints = IntVar("T_ints", covariant=True)  # noqa
+            T_ints = IntVar("T_ints", covariant=True)
 
 
 class LiteralTests(BaseTestCase):
@@ -936,7 +936,7 @@ class GetTypeHintTests(BaseTestCase):
         @no_type_check
         class NoTpCheck:
             class Inn:
-                def __init__(self, x: 'not a type'): ...  # noqa
+                def __init__(self, x: 'not a type'): ...
         self.assertTrue(NoTpCheck.__no_type_check__)
         self.assertTrue(NoTpCheck.Inn.__init__.__no_type_check__)
         self.assertEqual(gth(ann_module2.NTC.meth), {})

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -289,7 +289,7 @@ else:
                            instead of a type.""")
 
 
-_overload_dummy = typing._overload_dummy  # noqa
+_overload_dummy = typing._overload_dummy
 
 
 if hasattr(typing, "get_overloads"):  # 3.11+
@@ -478,7 +478,7 @@ else:
         if type(self)._is_protocol:
             raise TypeError('Protocols cannot be instantiated')
 
-    class _ProtocolMeta(abc.ABCMeta):  # noqa: B024
+    class _ProtocolMeta(abc.ABCMeta):
         # This metaclass is a bit unfortunate and exists only because of the lack
         # of __instancehook__.
         def __instancecheck__(cls, instance):
@@ -545,7 +545,7 @@ else:
                 raise TypeError(
                     f"Parameter list to {cls.__qualname__}[...] cannot be empty")
             msg = "Parameters to generic types must be types."
-            params = tuple(typing._type_check(p, msg) for p in params)  # noqa
+            params = tuple(typing._type_check(p, msg) for p in params)
             if cls is Protocol:
                 # Generic can only be subscripted with unique type variables.
                 if not all(isinstance(p, typing.TypeVar) for p in params):
@@ -1435,7 +1435,7 @@ def _concatenate_getitem(self, parameters):
 # 3.10+
 if hasattr(typing, 'Concatenate'):
     Concatenate = typing.Concatenate
-    _ConcatenateGenericAlias = typing._ConcatenateGenericAlias # noqa
+    _ConcatenateGenericAlias = typing._ConcatenateGenericAlias  # noqa: F811
 # 3.9
 elif sys.version_info[:2] >= (3, 9):
     @_TypeAliasForm

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 flake8
 flake8-bugbear
-flake8-pyi>=22.8.0
+flake8-noqa


### PR DESCRIPTION
- Remove flake8-pyi as a test dependency (we don't have any `.pyi` files in this repo)
- Add flake8-noqa as a test dependency
- Remove unused `# noqa` comments
- Add specific error codes for bare `# noqa` comments