### PR TITLE
Runtime-checkable protocol tests: Use `@runtime_checkable`, not `@runtime`

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -850,7 +850,7 @@ class XRepr(NamedTuple):
     def __add__(self, other):
         return 0
 
-@runtime
+@runtime_checkable
 class HasCallProtocol(Protocol):
     __call__: typing.Callable
 
@@ -1324,7 +1324,7 @@ class Coordinate(Protocol):
     x: int
     y: int
 
-@runtime
+@runtime_checkable
 class Point(Coordinate, Protocol):
     label: str
 
@@ -1339,11 +1339,11 @@ class XAxis(Protocol):
 class YAxis(Protocol):
     y: int
 
-@runtime
+@runtime_checkable
 class Position(XAxis, YAxis, Protocol):
     pass
 
-@runtime
+@runtime_checkable
 class Proto(Protocol):
     attr: int
 
@@ -1367,9 +1367,11 @@ class NT(NamedTuple):
 
 
 class ProtocolTests(BaseTestCase):
+    def test_runtime_alias(self):
+        self.assertIs(runtime, runtime_checkable)
 
     def test_basic_protocol(self):
-        @runtime
+        @runtime_checkable
         class P(Protocol):
             def meth(self):
                 pass
@@ -1387,7 +1389,7 @@ class ProtocolTests(BaseTestCase):
         self.assertNotIsInstance(f, P)
 
     def test_everything_implements_empty_protocol(self):
-        @runtime
+        @runtime_checkable
         class Empty(Protocol): pass
         class C: pass
         def f():
@@ -1437,7 +1439,7 @@ class ProtocolTests(BaseTestCase):
         self.assertIsInstance(CG[int](), CG)
 
     def test_cannot_instantiate_abstract(self):
-        @runtime
+        @runtime_checkable
         class P(Protocol):
             @abc.abstractmethod
             def ameth(self) -> int:
@@ -1455,7 +1457,7 @@ class ProtocolTests(BaseTestCase):
         class P1(Protocol):
             def meth1(self):
                 pass
-        @runtime
+        @runtime_checkable
         class P2(P1, Protocol):
             def meth2(self):
                 pass
@@ -1484,7 +1486,7 @@ class ProtocolTests(BaseTestCase):
         class P2(Protocol):
             def meth2(self):
                 pass
-        @runtime
+        @runtime_checkable
         class P(P1, P2, Protocol):
             pass
         class C:
@@ -1507,10 +1509,10 @@ class ProtocolTests(BaseTestCase):
 
     def test_protocols_issubclass(self):
         T = TypeVar('T')
-        @runtime
+        @runtime_checkable
         class P(Protocol):
             def x(self): ...
-        @runtime
+        @runtime_checkable
         class PG(Protocol[T]):
             def x(self): ...
         class BadP(Protocol):
@@ -1538,7 +1540,7 @@ class ProtocolTests(BaseTestCase):
     def test_protocols_issubclass_non_callable(self):
         class C:
             x = 1
-        @runtime
+        @runtime_checkable
         class PNonCall(Protocol):
             x = 1
         with self.assertRaises(TypeError):
@@ -1560,10 +1562,10 @@ class ProtocolTests(BaseTestCase):
 
     def test_protocols_isinstance(self):
         T = TypeVar('T')
-        @runtime
+        @runtime_checkable
         class P(Protocol):
             def meth(x): ...
-        @runtime
+        @runtime_checkable
         class PG(Protocol[T]):
             def meth(x): ...
         class BadP(Protocol):
@@ -1616,10 +1618,10 @@ class ProtocolTests(BaseTestCase):
 
     def test_protocols_isinstance_init(self):
         T = TypeVar('T')
-        @runtime
+        @runtime_checkable
         class P(Protocol):
             x = 1
-        @runtime
+        @runtime_checkable
         class PG(Protocol[T]):
             x = 1
         class C:
@@ -1629,7 +1631,7 @@ class ProtocolTests(BaseTestCase):
         self.assertIsInstance(C(1), PG)
 
     def test_protocols_support_register(self):
-        @runtime
+        @runtime_checkable
         class P(Protocol):
             x = 1
         class PM(Protocol):
@@ -1642,7 +1644,7 @@ class ProtocolTests(BaseTestCase):
         self.assertIsInstance(C(), D)
 
     def test_none_on_non_callable_doesnt_block_implementation(self):
-        @runtime
+        @runtime_checkable
         class P(Protocol):
             x = 1
         class A:
@@ -1656,7 +1658,7 @@ class ProtocolTests(BaseTestCase):
         self.assertIsInstance(C(), P)
 
     def test_none_on_callable_blocks_implementation(self):
-        @runtime
+        @runtime_checkable
         class P(Protocol):
             def x(self): ...
         class A:
@@ -1672,7 +1674,7 @@ class ProtocolTests(BaseTestCase):
     def test_non_protocol_subclasses(self):
         class P(Protocol):
             x = 1
-        @runtime
+        @runtime_checkable
         class PR(Protocol):
             def meth(self): pass
         class NonP(P):
@@ -1705,7 +1707,7 @@ class ProtocolTests(BaseTestCase):
         self.assertNotIsSubclass(BadClass, C)
 
     def test_issubclass_fails_correctly(self):
-        @runtime
+        @runtime_checkable
         class P(Protocol):
             x = 1
         class C: pass
@@ -1715,7 +1717,7 @@ class ProtocolTests(BaseTestCase):
     def test_defining_generic_protocols(self):
         T = TypeVar('T')
         S = TypeVar('S')
-        @runtime
+        @runtime_checkable
         class PR(Protocol[T, S]):
             def meth(self): pass
         class P(PR[int, T], Protocol[T]):
@@ -1739,7 +1741,7 @@ class ProtocolTests(BaseTestCase):
     def test_defining_generic_protocols_old_style(self):
         T = TypeVar('T')
         S = TypeVar('S')
-        @runtime
+        @runtime_checkable
         class PR(Protocol, Generic[T, S]):
             def meth(self): pass
         class P(PR[int, str], Protocol):
@@ -1756,7 +1758,7 @@ class ProtocolTests(BaseTestCase):
             def bar(self, x: T) -> str: ...
         class P2(Generic[T], Protocol):
             def bar(self, x: T) -> str: ...
-        @runtime
+        @runtime_checkable
         class PSub(P1[str], Protocol):
             x = 1
         class Test:
@@ -1813,7 +1815,7 @@ class ProtocolTests(BaseTestCase):
         self.assertIs(P[int].__origin__, P)
 
     def test_generic_protocols_special_from_protocol(self):
-        @runtime
+        @runtime_checkable
         class PR(Protocol):
             x = 1
         class P(Protocol):
@@ -1841,17 +1843,17 @@ class ProtocolTests(BaseTestCase):
 
     def test_no_runtime_deco_on_nominal(self):
         with self.assertRaises(TypeError):
-            @runtime
+            @runtime_checkable
             class C: pass
         class Proto(Protocol):
             x = 1
         with self.assertRaises(TypeError):
-            @runtime
+            @runtime_checkable
             class Concrete(Proto):
                 pass
 
     def test_none_treated_correctly(self):
-        @runtime
+        @runtime_checkable
         class P(Protocol):
             x: int = None
         class B(object): pass
@@ -1882,7 +1884,7 @@ class ProtocolTests(BaseTestCase):
         global P, CP  # pickle wants to reference the class by name
         T = TypeVar('T')
 
-        @runtime
+        @runtime_checkable
         class P(Protocol[T]):
             x = 1
         class CP(P[int]):


### PR DESCRIPTION
The original name for this decorator was `@runtime`, and so that's the name that's currently used in most of the tests for this decorator in `typing_extensions`. However, the name was changed to `@runtime_checkable` before the decorator was added to the `typing` module, and so the old `@runtime` name doesn't appear anywhere in the docs for the typing module. The `@runtime` name exists in `typing_extensions` only for backwards compatibility.

Let's change the usages in our test suite to use the more modern name, so that it's less confusing and more consistent with `typing`.