### PR TITLE
flake8 config: ignore W503

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,6 +7,8 @@ ignore =
   DW12,
   # code is sometimes better without this
   E129,
+  # Contradicts PEP8 nowadays
+  W503,
   # consistency with mypy
   W504
 exclude =

--- a/.flake8-tests
+++ b/.flake8-tests
@@ -24,6 +24,8 @@ ignore =
   # irrelevant plugins
   B3,
   DW12,
+  # Contradicts PEP8 nowadays
+  W503,
   # consistency with mypy
   W504
 noqa_require_code = true


### PR DESCRIPTION
This rule contradicts PEP8, which now says that you should write multiline expressions like this:

```python 
if (
    foo
    and bar
):
```

When W503 was originally introduced, PEP8 had a different recommendation:

```python 
if (
    foo and
    bar
):
```

This PR is needed for #132, which has some lines that go against W503.