### PR TITLE
Backport performance improvements to runtime-checkable protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@
   (originally by Yurii Karabas), ensuring that `isinstance()` calls on
   protocols raise `TypeError` when the protocol is not decorated with
   `@runtime_checkable`. Patch by Alex Waygood.
+- Backport several significant performance improvements to runtime-checkable
+  protocols that have been made in Python 3.12 (see
+  https://github.com/python/cpython/issues/74690 for details). Patch by Alex
+  Waygood.
+
+  A side effect of one of the performance improvements is that the members of
+  a runtime-checkable protocol are now considered “frozen” at runtime as soon
+  as the class has been created. Monkey-patching attributes onto a
+  runtime-checkable protocol will still work, but will have no impact on
+  `isinstance()` checks comparing objects to the protocol. See
+  ["What's New in Python 3.12"](https://docs.python.org/3.12/whatsnew/3.12.html#typing)
+  for more details.
 
 # Release 4.5.0 (February 14, 2023)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3333,9 +3333,11 @@ class AllTests(BaseTestCase):
             'is_typeddict',
         }
         if sys.version_info < (3, 10):
-            exclude |= {'get_args', 'get_origin', 'Protocol', 'runtime_checkable'}
+            exclude |= {'get_args', 'get_origin'}
         if sys.version_info < (3, 11):
             exclude |= {'final', 'NamedTuple', 'Any'}
+        if sys.version_info < (3, 12):
+            exclude |= {'Protocol', 'runtime_checkable'}
         for item in typing_extensions.__all__:
             if item not in exclude and hasattr(typing, item):
                 self.assertIs(

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -439,7 +439,7 @@ def _maybe_adjust_parameters(cls):
     """
     tvars = []
     if '__orig_bases__' in cls.__dict__:
-        tvars = typing._collect_type_vars(cls.__orig_bases__)
+        tvars = _collect_type_vars(cls.__orig_bases__)
         # Look for Generic[T1, ..., Tn] or Protocol[T1, ..., Tn].
         # If found, tvars must be a subset of it.
         # If not found, tvars is it.
@@ -1830,6 +1830,10 @@ else:
 
 if hasattr(typing, "Unpack"):  # 3.11+
     Unpack = typing.Unpack
+
+    def _is_unpack(obj):
+        return get_origin(obj) is Unpack
+
 elif sys.version_info[:2] >= (3, 9):
     class _UnpackSpecialForm(typing._SpecialForm, _root=True):
         def __repr__(self):


### PR DESCRIPTION
This PR backports the following CPython PRs (all by me), which, taken together, substantially improve the performance of `isinstance()` checks against runtime-checkable protocols on Python 3.12 compared to Python 3.11:

- https://github.com/python/cpython/pull/103141
- https://github.com/python/cpython/pull/103152
- https://github.com/python/cpython/pull/103159
- https://github.com/python/cpython/pull/103160
- https://github.com/python/cpython/pull/103280

<details>
<summary>Here is a benchmark script:</summary>

```py
import time
from typing_extensions import Protocol, runtime_checkable

@runtime_checkable
class HasX(Protocol):
    x: int

@runtime_checkable
class SupportsInt(Protocol):
    def __int__(self) -> int: ...

@runtime_checkable
class SupportsIntAndX(Protocol):
    x: int
    def __int__(self) -> int: ...

class Empty:
    description = "Empty class with no attributes"

class Registered:
    description = "Subclass registered using ABCMeta.register"

HasX.register(Registered)
SupportsInt.register(Registered)
SupportsIntAndX.register(Registered)

class PropertyX:
    description = "Class with a property x"
    @property
    def x(self) -> int:
        return 42

class HasIntMethod:
    description = "Class with an __int__ method"
    def __int__(self):
        return 42

class PropertyXWithInt:
    description = "Class with a property x and an __int__ method"
    @property
    def x(self) -> int:
        return 42
    def __int__(self):
        return 42

class ClassVarX:
    description = "Class with a ClassVar x"
    x = 42

class ClassVarXWithInt:
    description = "Class with a ClassVar x and an __int__ method"
    x = 42
    def __int__(self):
        return 42

class InstanceVarX:
    description = "Class with an instance var x"
    def __init__(self):
        self.x = 42

class InstanceVarXWithInt:
    description = "Class with an instance var x and an __int__ method"
    def __init__(self):
        self.x = 42
    def __int__(self):
        return 42
    
class NominalX(HasX):
    description = "Class that explicitly subclasses HasX"
    def __init__(self):
        self.x = 42

class NominalSupportsInt(SupportsInt):
    description = "Class that explicitly subclasses SupportsInt"
    def __int__(self):
        return 42

class NominalXWithInt(SupportsIntAndX):
    description = "Class that explicitly subclasses NominalXWithInt"
    def __init__(self):
        self.x = 42


num_instances = 500_000

classes = {}
for cls in (
    Empty, Registered, PropertyX, PropertyXWithInt, ClassVarX, ClassVarXWithInt,
    InstanceVarX, InstanceVarXWithInt, NominalX, NominalXWithInt, HasIntMethod,
    NominalSupportsInt
):
    classes[cls] = [cls() for _ in range(num_instances)]


def bench(objs, title, protocol):
    start_time = time.perf_counter()
    for obj in objs:
        isinstance(obj, protocol)
    elapsed = time.perf_counter() - start_time
    print(f"{title}: {elapsed:.2f}")


print("Protocols with no callable members\n")
for cls in Empty, Registered, PropertyX, ClassVarX, InstanceVarX, NominalX:
    bench(classes[cls], cls.description, HasX)

print("\nProtocols with only callable members\n")
for cls in Empty, Registered, HasIntMethod, NominalSupportsInt:
    bench(classes[cls], cls.description, SupportsInt)

print("\nProtocols with callable and non-callable members\n")
for cls in (
    Empty, Registered, PropertyXWithInt, ClassVarXWithInt, InstanceVarXWithInt,
    NominalXWithInt
):
    bench(classes[cls], cls.description, SupportsIntAndX)
```

</details>

<details>
<summary>Benchmark results on `main`, using Python 3.11</summary>

```
Protocols with no callable members

Empty class with no attributes: 4.29
Subclass registered using ABCMeta.register: 20.07
Class with a property x: 14.12
Class with a ClassVar x: 14.08
Class with an instance var x: 14.02
Class that explicitly subclasses HasX: 14.04

Protocols with only callable members

Empty class with no attributes: 14.14
Subclass registered using ABCMeta.register: 21.59
Class with an __int__ method: 7.06
Class that explicitly subclasses SupportsInt: 7.04

Protocols with callable and non-callable members

Empty class with no attributes: 15.43
Subclass registered using ABCMeta.register: 24.64
Class with a property x and an __int__ method: 15.52
Class with a ClassVar x and an __int__ method: 15.28
Class with an instance var x and an __int__ method: 15.27
Class that explicitly subclasses NominalXWithInt: 15.28
```

</details>

<details>
<summary>Benchmark results with this PR branch, using Python 3.11</summary>

```
Protocols with no callable members

Empty class with no attributes: 0.58
Subclass registered using ABCMeta.register: 0.56
Class with a property x: 0.27
Class with a ClassVar x: 0.26
Class with an instance var x: 0.26
Class that explicitly subclasses HasX: 0.21

Protocols with only callable members

Empty class with no attributes: 0.59
Subclass registered using ABCMeta.register: 1.27
Class with an __int__ method: 0.19
Class that explicitly subclasses SupportsInt: 0.19

Protocols with callable and non-callable members

Empty class with no attributes: 0.60
Subclass registered using ABCMeta.register: 1.57
Class with a property x and an __int__ method: 1.03
Class with a ClassVar x and an __int__ method: 0.97
Class with an instance var x and an __int__ method: 0.97
Class that explicitly subclasses NominalXWithInt: 0.67
```

</details>

Note that if we choose to backport https://github.com/python/cpython/pull/103034 (using `inspect.getattr_static` instead of `getattr` in `_ProtocolMeta.__instancecheck__`), it will undo a lot of the performance improvements that this PR brings. I leave the decision of whether or not to backport that PR to another PR/issue.