### PR TITLE
Remove flake8-noqa from test-requirements.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,9 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r test-requirements.txt
-          pip install flake8-noqa  # not included in test-requirements.txt as it depends on typing-extensions
+          # not included in test-requirements.txt as it depends on typing-extensions,
+          # so it's a pain to have it installed locally
+          pip install flake8-noqa
 
       - name: Lint implementation
         run: flake8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r test-requirements.txt
+          pip install flake8-noqa  # not included in test-requirements.txt as it depends on typing-extensions
 
       - name: Lint implementation
         run: flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
 flake8
 flake8-bugbear
-flake8-noqa


### PR DESCRIPTION
flake-noqa depends on typing_extensions: https://github.com/plinss/flake8-noqa/blob/96577399165432b72dbb4b28049d273df595f264/pyproject.toml#L26-L29

That means that, following #133, running `pip install -r test-requirements.txt` installs an old version of `typing_extensions` from PyPI into `site-packages`, which then takes precedence over your local version of `typing_extensions` when you run a script that does `import typing_extensions` locally. This caused me a fair bit of confusion while testing #137 locally :)