### PR TITLE
Speedup `isinstance(3, typing_extensions.SupportsIndex)` by >10x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
   `typing_extensions` may no longer be considered instances of that protocol
   using the new release, and vice versa. Most users are unlikely to be affected
   by this change. Patch by Alex Waygood.
+- Speedup `isinstance(3, typing_extensions.SupportsIndex)` by >10x on Python
+  <3.12. Patch by Alex Waygood.
 
 # Release 4.5.0 (February 14, 2023)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3545,7 +3545,7 @@ class AllTests(BaseTestCase):
         if sys.version_info < (3, 11):
             exclude |= {'final', 'NamedTuple', 'Any'}
         if sys.version_info < (3, 12):
-            exclude |= {'Protocol', 'runtime_checkable'}
+            exclude |= {'Protocol', 'runtime_checkable', 'SupportsIndex'}
         for item in typing_extensions.__all__:
             if item not in exclude and hasattr(typing, item):
                 self.assertIs(

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -686,10 +686,9 @@ else:
 runtime = runtime_checkable
 
 
-# 3.8+
-if hasattr(typing, 'SupportsIndex'):
+# Our version of runtime-checkable protocols is faster on Python 3.7-3.11
+if sys.version_info >= (3, 12):
     SupportsIndex = typing.SupportsIndex
-# 3.7
 else:
     @runtime_checkable
     class SupportsIndex(Protocol):


### PR DESCRIPTION
On `main`:

```
(venv) C:\Users\alexw\coding\typing_extensions>python -m timeit -s "from typing_extensions import SupportsIndex" "isinstance(3, SupportsIndex)"
50000 loops, best of 5: 3.96 usec per loop
```

With this PR:

```
(venv) C:\Users\alexw\coding\typing_extensions>python -m timeit -s "from typing_extensions import SupportsIndex" "isinstance(3, SupportsIndex)"
500000 loops, best of 5: 377 nsec per loop
```