### PR TITLE
Allow GenericAlias-like objects to interact with typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,17 @@
   Patch by Alex Waygood.
 - Speedup `isinstance(3, typing_extensions.SupportsIndex)` by >10x on Python
   <3.12. Patch by Alex Waygood.
+- Allow any class that has the following attributes to be treated
+  like `GenericAlias` for the purposes of being used in generic expressions
+  like `List[SomeGeneric[T]][int]`:
+  - `__parameters__`: a tuple of un-substituted generic parameters (as TypeVars).
+  - `__args__`: a tuple of concrete (substituted) generic parameters.
+  - `__origin__`: the original generic class.
+  This allows classes to return something from `__class_getitem__` that behaves
+  like a `GenericAlias` but also implements custom behavior, for example
+  tracking TypeVar substitutions at runtime and communicating them back
+  to the origin class.
+  Patch by Adrian Garcia Badaracco.
 
 # Release 4.5.0 (February 14, 2023)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3986,5 +3986,23 @@ class BufferTests(BaseTestCase):
         self.assertIsSubclass(MySubclassedBuffer, Buffer)
 
 
+class TestGenericAliasLike(BaseTestCase):
+    def test(self):
+
+        T = TypeVar('T')
+
+        class GenericType(Generic[T]):
+            def __class_getitem__(cls, args: Union[Tuple[Type[Any], ...], Type[Any]]) -> 'GenericAliasLike':
+                return GenericAliasLike()
+
+        class GenericAliasLike:
+            __args__ = ()
+            __parameters__ = (T,)
+            __origin__ = GenericType
+
+        res = List[GenericAliasLike[T]][int]
+        self.assertEqual(getattr(res, '__parameters__'), (T,))
+
+
 if __name__ == '__main__':
     main()

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -4004,11 +4004,16 @@ class TestGenericAliasLike(BaseTestCase):
             __parameters__ = (T,)
             __origin__ = GenericType
 
-            # here would go a __getitem__ implementation that
-            # does the tracking of type var substitution
-            # omitted since it is not strictly necessary for this test
+            def __getitem__(self, args):
+                # here would go logic to do the tracking of type var substitution
+                # omitted since it is not strictly necessary for this test
+                return self
+            
+            # __call__ needs to be implemented for this to be considered a type
+            def __call__(self):
+                pass
 
-        res = List[GenericAliasLike[T]][int]
+        res = List[GenericType[T]][int]
         self.assertEqual(getattr(res, '__parameters__'), (T,))
 
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3992,13 +3992,21 @@ class TestGenericAliasLike(BaseTestCase):
         T = TypeVar('T')
 
         class GenericType(Generic[T]):
-            def __class_getitem__(cls, args: Union[Tuple[Type[Any], ...], Type[Any]]) -> 'GenericAliasLike':
+            def __class_getitem__(cls, args):
+                # The goal is that the thing returned from here can
+                # act like a GenericAlias but also implement custom behavior
+                # In particular the original feature request involved tracking
+                # TypeVar substitutions at runtime for Pydantic
                 return GenericAliasLike()
 
         class GenericAliasLike:
             __args__ = ()
             __parameters__ = (T,)
             __origin__ = GenericType
+
+            # here would go a __getitem__ implementation that
+            # does the tracking of type var substitution
+            # omitted since it is not strictly necessary for this test
 
         res = List[GenericAliasLike[T]][int]
         self.assertEqual(getattr(res, '__parameters__'), (T,))

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -4008,7 +4008,7 @@ class TestGenericAliasLike(BaseTestCase):
                 # here would go logic to do the tracking of type var substitution
                 # omitted since it is not strictly necessary for this test
                 return self
-            
+
             # __call__ needs to be implemented for this to be considered a type
             def __call__(self):
                 pass

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -111,17 +111,23 @@ def _check_generic(cls, parameters, elen=_marker):
                         f" actual {alen}, expected {elen}")
 
 
+def _is_generic_alias_like(t) -> bool:
+    return hasattr(t, "__args__") and hasattr(t, "__origin__") and hasattr(t, "__parameters__")
+
+
 if sys.version_info >= (3, 10):
     def _should_collect_from_parameters(t):
         return isinstance(
             t, (typing._GenericAlias, _types.GenericAlias, _types.UnionType)
-        )
+        ) or _is_generic_alias_like(t)
 elif sys.version_info >= (3, 9):
     def _should_collect_from_parameters(t):
-        return isinstance(t, (typing._GenericAlias, _types.GenericAlias))
+        return isinstance(t, (typing._GenericAlias, _types.GenericAlias)) or _is_generic_alias_like(t)
 else:
     def _should_collect_from_parameters(t):
-        return isinstance(t, typing._GenericAlias) and not t._special
+        return (
+            isinstance(t, typing._GenericAlias) and not t._special
+        )  or _is_generic_alias_like(t)
 
 
 def _collect_type_vars(types, typevar_types=None):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -112,7 +112,13 @@ def _check_generic(cls, parameters, elen=_marker):
 
 
 def _is_generic_alias_like(t) -> bool:
-    return hasattr(t, "__args__") and hasattr(t, "__origin__") and hasattr(t, "__parameters__")
+    return (
+        hasattr(t, "__args__")
+        and
+        hasattr(t, "__origin__")
+        and
+        hasattr(t, "__parameters__")
+    )
 
 
 if sys.version_info >= (3, 10):
@@ -122,12 +128,18 @@ if sys.version_info >= (3, 10):
         ) or _is_generic_alias_like(t)
 elif sys.version_info >= (3, 9):
     def _should_collect_from_parameters(t):
-        return isinstance(t, (typing._GenericAlias, _types.GenericAlias)) or _is_generic_alias_like(t)
+        return (
+            isinstance(t, (typing._GenericAlias, _types.GenericAlias))
+            or
+            _is_generic_alias_like(t)
+        )
 else:
     def _should_collect_from_parameters(t):
         return (
-            isinstance(t, typing._GenericAlias) and not t._special
-        )  or _is_generic_alias_like(t)
+            (isinstance(t, typing._GenericAlias) and not t._special)
+            or
+            _is_generic_alias_like(t)
+        )
 
 
 def _collect_type_vars(types, typevar_types=None):


### PR DESCRIPTION
This starts paving the path for GenericAlias-like things to co-exist with the rest of the typing tooling.