### PR TITLE
Backport tests of `Union` + `Literal` from CPython

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -714,6 +714,13 @@ class LiteralTests(BaseTestCase):
         Literal["x", "y", "z"]
         Literal[None]
 
+    def test_enum(self):
+        import enum
+        class My(enum.Enum):
+            A = 'A'
+
+        self.assertEqual(Literal[My.A].__args__, (My.A,))
+
     def test_illegal_parameters_do_not_raise_runtime_errors(self):
         # Type checkers should reject these types, but we do not
         # raise errors at runtime to maintain maximum flexibility
@@ -794,6 +801,64 @@ class LiteralTests(BaseTestCase):
         # Mutable arguments will not be deduplicated
         self.assertEqual(Literal[[], []].__args__, ([], []))
 
+    def test_union_of_literals(self):
+        self.assertEqual(Union[Literal[1], Literal[2]].__args__,
+                         (Literal[1], Literal[2]))
+        self.assertEqual(Union[Literal[1], Literal[1]],
+                         Literal[1])
+
+        self.assertEqual(Union[Literal[False], Literal[0]].__args__,
+                         (Literal[False], Literal[0]))
+        self.assertEqual(Union[Literal[True], Literal[1]].__args__,
+                         (Literal[True], Literal[1]))
+
+        import enum
+        class Ints(enum.IntEnum):
+            A = 0
+            B = 1
+
+        self.assertEqual(Union[Literal[Ints.A], Literal[Ints.B]].__args__,
+                         (Literal[Ints.A], Literal[Ints.B]))
+
+        self.assertEqual(Union[Literal[Ints.A], Literal[Ints.A]],
+                         Literal[Ints.A])
+        self.assertEqual(Union[Literal[Ints.B], Literal[Ints.B]],
+                         Literal[Ints.B])
+
+        self.assertEqual(Union[Literal[0], Literal[Ints.A], Literal[False]].__args__,
+                         (Literal[0], Literal[Ints.A], Literal[False]))
+        self.assertEqual(Union[Literal[1], Literal[Ints.B], Literal[True]].__args__,
+                         (Literal[1], Literal[Ints.B], Literal[True]))
+
+    def test_or_type_operator_with_Literal(self):
+        Literal = typing.Literal
+        self.assertEqual((Literal[1] | Literal[2]).__args__,
+                         (Literal[1], Literal[2]))
+
+        self.assertEqual((Literal[0] | Literal[False]).__args__,
+                         (Literal[0], Literal[False]))
+        self.assertEqual((Literal[1] | Literal[True]).__args__,
+                         (Literal[1], Literal[True]))
+
+        self.assertEqual(Literal[1] | Literal[1], Literal[1])
+        self.assertEqual(Literal['a'] | Literal['a'], Literal['a'])
+
+        import enum
+        class Ints(enum.IntEnum):
+            A = 0
+            B = 1
+
+        self.assertEqual(Literal[Ints.A] | Literal[Ints.A], Literal[Ints.A])
+        self.assertEqual(Literal[Ints.B] | Literal[Ints.B], Literal[Ints.B])
+
+        self.assertEqual((Literal[Ints.B] | Literal[Ints.A]).__args__,
+                         (Literal[Ints.B], Literal[Ints.A]))
+
+        self.assertEqual((Literal[0] | Literal[Ints.A]).__args__,
+                         (Literal[0], Literal[Ints.A]))
+        self.assertEqual((Literal[1] | Literal[Ints.B]).__args__,
+                         (Literal[1], Literal[Ints.B]))
+
     def test_flatten(self):
         l1 = Literal[Literal[1], Literal[2], Literal[3]]
         l2 = Literal[Literal[1, 2], 3]
@@ -801,6 +866,20 @@ class LiteralTests(BaseTestCase):
         for lit in l1, l2, l3:
             self.assertEqual(lit, Literal[1, 2, 3])
             self.assertEqual(lit.__args__, (1, 2, 3))
+
+    def test_does_not_flatten_enum(self):
+        import enum
+        class Ints(enum.IntEnum):
+            A = 1
+            B = 2
+
+        l = Literal[
+            Literal[Ints.A],
+            Literal[Ints.B],
+            Literal[1],
+            Literal[2],
+        ]
+        self.assertEqual(l.__args__, (Ints.A, Ints.B, 1, 2))
 
     def test_caching_of_Literal_respects_type(self):
         self.assertIs(type(Literal[1].__args__[0]), int)

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -830,6 +830,7 @@ class LiteralTests(BaseTestCase):
         self.assertEqual(Union[Literal[1], Literal[Ints.B], Literal[True]].__args__,
                          (Literal[1], Literal[Ints.B], Literal[True]))
 
+    @skipUnless(TYPING_3_10_0, "Python 3.10+ required")
     def test_or_type_operator_with_Literal(self):
         self.assertEqual((Literal[1] | Literal[2]).__args__,
                          (Literal[1], Literal[2]))

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -872,13 +872,13 @@ class LiteralTests(BaseTestCase):
             A = 1
             B = 2
 
-        l = Literal[
+        literal = Literal[
             Literal[Ints.A],
             Literal[Ints.B],
             Literal[1],
             Literal[2],
         ]
-        self.assertEqual(l.__args__, (Ints.A, Ints.B, 1, 2))
+        self.assertEqual(literal.__args__, (Ints.A, Ints.B, 1, 2))
 
     def test_caching_of_Literal_respects_type(self):
         self.assertIs(type(Literal[1].__args__[0]), int)

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -831,7 +831,6 @@ class LiteralTests(BaseTestCase):
                          (Literal[1], Literal[Ints.B], Literal[True]))
 
     def test_or_type_operator_with_Literal(self):
-        Literal = typing.Literal
         self.assertEqual((Literal[1] | Literal[2]).__args__,
                          (Literal[1], Literal[2]))
 


### PR DESCRIPTION
This PR is the backport of two my CPython's PR:
1. https://github.com/python/cpython/pull/103706 (merged)
2. https://github.com/python/cpython/pull/103747 (not merged yet)

Sorry, I often forget to do the backport﻿ when I write new tests.
