### PR TITLE
Improve CI definitons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,17 @@ name: Test and lint
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   tests:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -2,10 +2,17 @@ name: Test packaging
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   wheel:
@@ -23,7 +30,7 @@ jobs:
       - name: Install pypa/build
         run: |
           # Be wary of running `pip install` here, since it becomes easy for us to
-          # accidentally pick up typing_extensions as installed by a dependency 
+          # accidentally pick up typing_extensions as installed by a dependency
           python -m pip install --upgrade build
           python -m pip list
 
@@ -53,7 +60,7 @@ jobs:
       - name: Install pypa/build
         run: |
           # Be wary of running `pip install` here, since it becomes easy for us to
-          # accidentally pick up typing_extensions as installed by a dependency 
+          # accidentally pick up typing_extensions as installed by a dependency
           python -m pip install --upgrade build
           python -m pip list
 


### PR DESCRIPTION
I've synced the CI definitions with the one we have in `typeshed`: https://github.com/python/typeshed/blob/main/.github/workflows/tests.yml

Basically, I've added:
1. `push` is only executed on `main`, so users won't get duplicated runs / notifications: 
<img width="564" alt="Снимок экрана 2023-04-24 в 12 07 40" src="https://user-images.githubusercontent.com/4660275/233951593-61d85b87-754b-4efa-826c-cefcf330e7ac.png">

2. Previous runs will be canceled when new ones are pushed