### PR TITLE
Add a backport of `types.get_original_bases`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@
   Patch by Alex Waygood.
 - Speedup `isinstance(3, typing_extensions.SupportsIndex)` by >10x on Python
   <3.12. Patch by Alex Waygood.
+- Add `typing_extensions.get_original_bases`, a backport of
+  `types.get_original_bases`, introduced in Python 3.12 (CPython PR
+  https://github.com/python/cpython/pull/101827, originally by James
+  Hilton-Balfe). Patch by Alex Waygood.
 
 # Release 4.5.0 (February 14, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,13 +49,19 @@
   Patch by Alex Waygood.
 - Speedup `isinstance(3, typing_extensions.SupportsIndex)` by >10x on Python
   <3.12. Patch by Alex Waygood.
-- Add `typing_extensions.get_original_bases`, a backport of
-  `types.get_original_bases`, introduced in Python 3.12 (CPython PR
-  https://github.com/python/cpython/pull/101827, originally by James
-  Hilton-Balfe). Patch by Alex Waygood.
 - Add `__orig_bases__` to non-generic TypedDicts, call-based TypedDicts, and
   call-based NamedTuples. Other TypedDicts and NamedTuples already had the attribute.
   Patch by Adrian Garcia Badaracco.
+- Add `typing_extensions.get_original_bases`, a backport of
+  [`types.get_original_bases`](https://docs.python.org/3.12/library/types.html#types.get_original_bases),
+  introduced in Python 3.12 (CPython PR
+  https://github.com/python/cpython/pull/101827, originally by James
+  Hilton-Balfe). Patch by Alex Waygood.
+
+  This function should always produce correct results when called on classes
+  constructed using features from `typing_extensions`. However, it may
+  produce incorrect results when called on some `NamedTuple` or `TypedDict`
+  classes that use `typing.{NamedTuple,TypedDict}` on Python <=3.11.
 - Constructing a call-based `TypedDict` using keyword arguments for the fields
   now causes a `DeprecationWarning` to be emitted. This matches the behaviour
   of `typing.TypedDict` on 3.11 and 3.12.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ This module currently contains the following:
 
   - `override` (equivalent to `typing.override`; see [PEP 698](https://peps.python.org/pep-0698/))
   - `Buffer` (equivalent to `collections.abc.Buffer`; see [PEP 688](https://peps.python.org/pep-0688/))
+  - `get_original_bases` (equivalent to
+    [`types.get_original_bases`](https://docs.python.org/3.12/library/types.html#types.get_original_bases)
+    on 3.12+).
+
+    This function should always produce correct results when called on classes
+    constructed using features from `typing_extensions`. However, it may
+    produce incorrect results when called on some `NamedTuple` or `TypedDict`
+    classes that use `typing.{NamedTuple,TypedDict}` on Python <=3.11.
 
 - In `typing` since Python 3.11
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -4311,46 +4311,64 @@ class GetOriginalBasesTests(BaseTestCase):
         self.assertEqual(get_original_bases(F), (list[int],))
 
     def test_namedtuples(self):
-        class ClassBasedNamedTuple(NamedTuple):
-            x: int
+        # On 3.12, this should work well with typing.NamedTuple and typing_extensions.NamedTuple
+        # On lower versions, it will only work fully with typing_extensions.NamedTuple
+        if sys.version_info >= (3, 12):
+            namedtuple_classes = (typing.NamedTuple, typing_extensions.NamedTuple)
+        else:
+            namedtuple_classes = (typing_extensions.NamedTuple,)
 
-        class GenericNamedTuple(NamedTuple, Generic[T]):
-            x: T
+        for NamedTuple in namedtuple_classes:
+            with self.subTest(cls=NamedTuple):
+                class ClassBasedNamedTuple(NamedTuple):
+                    x: int
 
-        CallBasedNamedTuple = NamedTuple("CallBasedNamedTuple", [("x", int)])
+                class GenericNamedTuple(NamedTuple, Generic[T]):
+                    x: T
 
-        self.assertIs(
-            get_original_bases(ClassBasedNamedTuple)[0], NamedTuple
-        )
-        self.assertEqual(
-            get_original_bases(GenericNamedTuple),
-            (NamedTuple, Generic[T])
-        )
-        self.assertIs(
-            get_original_bases(CallBasedNamedTuple)[0], NamedTuple
-        )
+                CallBasedNamedTuple = NamedTuple("CallBasedNamedTuple", [("x", int)])
+
+                self.assertIs(
+                    get_original_bases(ClassBasedNamedTuple)[0], NamedTuple
+                )
+                self.assertEqual(
+                    get_original_bases(GenericNamedTuple),
+                    (NamedTuple, Generic[T])
+                )
+                self.assertIs(
+                    get_original_bases(CallBasedNamedTuple)[0], NamedTuple
+                )
 
     def test_typeddicts(self):
-        class ClassBasedTypedDict(TypedDict):
-            x: int
+        # On 3.12, this should work well with typing.TypedDict and typing_extensions.TypedDict
+        # On lower versions, it will only work fully with typing_extensions.TypedDict
+        if sys.version_info >= (3, 12):
+            typeddict_classes = (typing.TypedDict, typing_extensions.TypedDict)
+        else:
+            typeddict_classes = (typing_extensions.TypedDict,)
 
-        class GenericTypedDict(TypedDict, Generic[T]):
-            x: T
+        for TypedDict in typeddict_classes:
+            with self.subTest(cls=TypedDict):
+                class ClassBasedTypedDict(TypedDict):
+                    x: int
 
-        CallBasedTypedDict = TypedDict("CallBasedTypedDict", {"x": int})
+                class GenericTypedDict(TypedDict, Generic[T]):
+                    x: T
 
-        self.assertIs(
-            get_original_bases(ClassBasedTypedDict)[0],
-            TypedDict
-        )
-        self.assertEqual(
-            get_original_bases(GenericTypedDict),
-            (TypedDict, Generic[T])
-        )
-        self.assertIs(
-            get_original_bases(CallBasedTypedDict)[0],
-            TypedDict
-        )
+                CallBasedTypedDict = TypedDict("CallBasedTypedDict", {"x": int})
+
+                self.assertIs(
+                    get_original_bases(ClassBasedTypedDict)[0],
+                    TypedDict
+                )
+                self.assertEqual(
+                    get_original_bases(GenericTypedDict),
+                    (TypedDict, Generic[T])
+                )
+                self.assertIs(
+                    get_original_bases(CallBasedTypedDict)[0],
+                    TypedDict
+                )
 
 
 if __name__ == '__main__':

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -4318,7 +4318,7 @@ class GetOriginalBasesTests(BaseTestCase):
         else:
             namedtuple_classes = (typing_extensions.NamedTuple,)
 
-        for NamedTuple in namedtuple_classes:
+        for NamedTuple in namedtuple_classes:  # noqa: F402
             with self.subTest(cls=NamedTuple):
                 class ClassBasedNamedTuple(NamedTuple):
                     x: int
@@ -4347,7 +4347,7 @@ class GetOriginalBasesTests(BaseTestCase):
         else:
             typeddict_classes = (typing_extensions.TypedDict,)
 
-        for TypedDict in typeddict_classes:
+        for TypedDict in typeddict_classes:  # noqa: F402
             with self.subTest(cls=TypedDict):
                 class ClassBasedTypedDict(TypedDict):
                     x: int

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2452,7 +2452,8 @@ else:
 
         Examples::
 
-            from typing import TypeVar, Generic, NamedTuple, TypedDict
+            from typing import TypeVar, Generic
+            from typing_extensions import NamedTuple, TypedDict
 
             T = TypeVar("T")
             class Foo(Generic[T]): ...

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -59,6 +59,7 @@ __all__ = [
     'final',
     'get_args',
     'get_origin',
+    'get_original_bases',
     'get_type_hints',
     'IntVar',
     'is_typeddict',
@@ -2423,3 +2424,38 @@ else:
     Buffer.register(memoryview)
     Buffer.register(bytearray)
     Buffer.register(bytes)
+
+
+# Backport of types.get_original_bases, available on 3.12+ in CPython
+if hasattr(_types, "get_original_bases"):
+    get_original_bases = _types.get_original_bases
+else:
+    def get_original_bases(__cls):
+        """Return the class's "original" bases prior to modification by `__mro_entries__`.
+
+        Examples::
+
+            from typing import TypeVar, Generic, NamedTuple, TypedDict
+
+            T = TypeVar("T")
+            class Foo(Generic[T]): ...
+            class Bar(Foo[int], float): ...
+            class Baz(list[str]): ...
+            Eggs = NamedTuple("Eggs", [("a", int), ("b", str)])
+            Spam = TypedDict("Spam", {"a": int, "b": str})
+
+            assert get_original_bases(Bar) == (Foo[int], float)
+            assert get_original_bases(Baz) == (list[str],)
+            assert get_original_bases(Eggs) == (NamedTuple,)
+            assert get_original_bases(Spam) == (TypedDict,)
+            assert get_original_bases(int) == (object,)
+        """
+        try:
+            return __cls.__orig_bases__
+        except AttributeError:
+            try:
+                return __cls.__bases__
+            except AttributeError:
+                raise TypeError(
+                    f'Expected an instance of type, not {type(__cls).__name__!r}'
+                ) from None


### PR DESCRIPTION
Backport of https://github.com/python/cpython/pull/101827 (cc. @Gobot1234).

~~The `NamedTuple` and `TypedDict` tests will fail until #150 is merged~~. CI is now green!