### PR TITLE
Backport `NewType` as it exists on py310+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@
 - Constructing a call-based `TypedDict` using keyword arguments for the fields
   now causes a `DeprecationWarning` to be emitted. This matches the behaviour
   of `typing.TypedDict` on 3.11 and 3.12.
+- Backport the implementation of `NewType` from 3.10 (where it is implemented
+  as a class rather than a function). This allows user-defined `NewType`s to be
+  pickled. Patch by Alex Waygood.
 
 # Release 4.5.0 (February 14, 2023)
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ Certain objects were changed after they were added to `typing`, and
   caching bug was fixed in 3.10.1/3.9.8. The `typing_extensions` version
   flattens and deduplicates parameters on all Python versions, and the caching
   bug is also fixed on all versions.
+- `NewType` has been in the `typing` module since Python 3.5.2, but
+  user-defined `NewType`s are only pickleable on Python 3.10+.
+  `typing_extensions.NewType` backports this feature to all Python versions.
 
 There are a few types whose interface was modified between different
 versions of typing. For example, `typing.Sequence` was modified to

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3913,11 +3913,11 @@ class AllTests(BaseTestCase):
             'get_type_hints',
         }
         if sys.version_info < (3, 10):
-            exclude |= {'get_args', 'get_origin', 'NewType'}
+            exclude |= {'get_args', 'get_origin'}
         if sys.version_info < (3, 10, 1):
             exclude |= {"Literal"}
         if sys.version_info < (3, 11):
-            exclude |= {'final', 'Any'}
+            exclude |= {'final', 'Any', 'NewType'}
         if sys.version_info < (3, 12):
             exclude |= {
                 'Protocol', 'runtime_checkable', 'SupportsAbs', 'SupportsBytes',

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -440,7 +440,6 @@ else:
 Counter = typing.Counter
 ChainMap = typing.ChainMap
 AsyncGenerator = typing.AsyncGenerator
-NewType = typing.NewType
 Text = typing.Text
 TYPE_CHECKING = typing.TYPE_CHECKING
 
@@ -2546,3 +2545,57 @@ else:
                 raise TypeError(
                     f'Expected an instance of type, not {type(__cls).__name__!r}'
                 ) from None
+
+
+# NewType is a class on Python 3.10+, making it pickleable
+if sys.version_info >= (3, 10):
+    NewType = typing.NewType
+else:
+    class NewType:
+        """NewType creates simple unique types with almost zero
+        runtime overhead. NewType(name, tp) is considered a subtype of tp
+        by static type checkers. At runtime, NewType(name, tp) returns
+        a dummy callable that simply returns its argument. Usage::
+            UserId = NewType('UserId', int)
+            def name_by_id(user_id: UserId) -> str:
+                ...
+            UserId('user')          # Fails type check
+            name_by_id(42)          # Fails type check
+            name_by_id(UserId(42))  # OK
+            num = UserId(5) + 1     # type: int
+        """
+
+        def __call__(self, obj):
+            return obj
+
+        def __init__(self, name, tp):
+            self.__qualname__ = name
+            if '.' in name:
+                name = name.rpartition('.')[-1]
+            self.__name__ = name
+            self.__supertype__ = tp
+            def_mod = _caller()
+            if def_mod != 'typing_extensions':
+                self.__module__ = def_mod
+
+        def __mro_entries__(self, bases):
+            # We defined __mro_entries__ to get a better error message
+            # if a user attempts to subclass a NewType instance. bpo-46170
+            supercls_name = self.__name__
+
+            class Dummy:
+                def __init_subclass__(cls):
+                    subcls_name = cls.__name__
+                    raise TypeError(
+                        f"Cannot subclass an instance of NewType. "
+                        f"Perhaps you were looking for: "
+                        f"`{subcls_name} = NewType({subcls_name!r}, {supercls_name})`"
+                    )
+
+            return (Dummy,)
+
+        def __repr__(self):
+            return f'{self.__module__}.{self.__qualname__}'
+
+        def __reduce__(self):
+            return self.__qualname__

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2548,7 +2548,8 @@ else:
 
 
 # NewType is a class on Python 3.10+, making it pickleable
-if sys.version_info >= (3, 10):
+# The error message for subclassing instances of NewType was improved on 3.11+
+if sys.version_info >= (3, 11):
     NewType = typing.NewType
 else:
     class NewType:
@@ -2599,3 +2600,13 @@ else:
 
         def __reduce__(self):
             return self.__qualname__
+
+        if sys.version_info >= (3, 10):
+            # PEP 604 methods
+            # It doesn't make sense to have these methods on Python <3.10
+
+            def __or__(self, other):
+                return typing.Union[self, other]
+
+            def __ror__(self, other):
+                return typing.Union[other, self]


### PR DESCRIPTION
Fixes #156. The implementation and tests are basically just copied from CPython, with a few tweaks