### PR TITLE
Fix tests on Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
   using the new release, and vice versa. Most users are unlikely to be affected
   by this change. Patch by Alex Waygood.
 - Backport the ability to define `__init__` methods on Protocol classes, a
-  change made in Python 3.11 (originally implemented in 
+  change made in Python 3.11 (originally implemented in
   https://github.com/python/cpython/pull/31628 by Adrian Garcia Badaracco).
   Patch by Alex Waygood.
 - Speedup `isinstance(3, typing_extensions.SupportsIndex)` by >10x on Python
@@ -73,6 +73,8 @@
 - Backport the implementation of `NewType` from 3.10 (where it is implemented
   as a class rather than a function). This allows user-defined `NewType`s to be
   pickled. Patch by Alex Waygood.
+- Fix tests and import on Python 3.12, where `typing.TypeVar` can no longer be
+  subclassed.
 
 # Release 4.5.0 (February 14, 2023)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -4476,10 +4476,13 @@ class BufferTests(BaseTestCase):
                 return memoryview(b'')
 
         # On 3.12, collections.abc.Buffer does a structural compatibility check
-        if not TYPING_3_12_0:
+        if TYPING_3_12_0:
+            self.assertIsInstance(MyRegisteredBuffer(), Buffer)
+            self.assertIsSubclass(MyRegisteredBuffer, Buffer)
+        else:
             self.assertNotIsInstance(MyRegisteredBuffer(), Buffer)
             self.assertNotIsSubclass(MyRegisteredBuffer, Buffer)
-            Buffer.register(MyRegisteredBuffer)
+        Buffer.register(MyRegisteredBuffer)
         self.assertIsInstance(MyRegisteredBuffer(), Buffer)
         self.assertIsSubclass(MyRegisteredBuffer, Buffer)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -4266,7 +4266,12 @@ class NamedTupleTests(BaseTestCase):
 class TypeVarLikeDefaultsTests(BaseTestCase):
     def test_typevar(self):
         T = typing_extensions.TypeVar('T', default=int)
+        typing_T = TypeVar('T')
         self.assertEqual(T.__default__, int)
+        self.assertIsInstance(T, typing_extensions.TypeVar)
+        self.assertIsInstance(T, typing.TypeVar)
+        self.assertIsInstance(typing_T, typing.TypeVar)
+        self.assertIsInstance(typing_T, typing_extensions.TypeVar)
 
         class A(Generic[T]): ...
         Alias = Optional[T]
@@ -4280,6 +4285,12 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
     def test_paramspec(self):
         P = ParamSpec('P', default=(str, int))
         self.assertEqual(P.__default__, (str, int))
+        self.assertIsInstance(P, ParamSpec)
+        if hasattr(typing, "ParamSpec"):
+            self.assertIsInstance(P, typing.ParamSpec)
+            typing_P = typing.ParamSpec('P')
+            self.assertIsInstance(typing_P, typing.ParamSpec)
+            self.assertIsInstance(typing_P, ParamSpec)
 
         class A(Generic[P]): ...
         Alias = typing.Callable[P, None]
@@ -4287,6 +4298,12 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
     def test_typevartuple(self):
         Ts = TypeVarTuple('Ts', default=Unpack[Tuple[str, int]])
         self.assertEqual(Ts.__default__, Unpack[Tuple[str, int]])
+        self.assertIsInstance(Ts, TypeVarTuple)
+        if hasattr(typing, "TypeVarTuple"):
+            self.assertIsInstance(Ts, typing.TypeVarTuple)
+            typing_Ts = typing.TypeVarTuple('Ts')
+            self.assertIsInstance(typing_Ts, typing.TypeVarTuple)
+            self.assertIsInstance(typing_Ts, TypeVarTuple)
 
         class A(Generic[Unpack[Ts]]): ...
         Alias = Optional[Unpack[Ts]]

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -14,6 +14,7 @@ import pickle
 import re
 import subprocess
 import tempfile
+import textwrap
 import types
 from pathlib import Path
 from unittest import TestCase, main, skipUnless, skipIf

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -2400,7 +2400,7 @@ class ProtocolTests(BaseTestCase):
             with self.assertRaises(TypeError):
                 PR[int, ClassVar]
 
-    if sys.version_info >= (3, 12):
+    if hasattr(typing, "TypeAliasType"):
         exec(textwrap.dedent(
             """
             def test_pep695_generic_protocol_callable_members(self):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -7,7 +7,6 @@ import operator
 import sys
 import types as _types
 import typing
-from typing import Any
 import warnings
 
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1449,8 +1449,8 @@ if hasattr(typing, 'ParamSpec'):
     # Add default parameter - PEP 696
     class _ParamSpecMeta(type):
         def __call__(self, name, *, bound=None,
-                    covariant=False, contravariant=False,
-                    default=_marker):
+                     covariant=False, contravariant=False,
+                     default=_marker):
             paramspec = typing.ParamSpec(name, bound=bound,
                                          covariant=covariant, contravariant=contravariant)
             _set_default(paramspec, default)


### PR DESCRIPTION
On current Python main, TypeVar cannot be subclassed. However, we still need to enhance TypeVar to add the `default=` argument. This PR introduces an alternative approach to achieve that: we create a dummy class that wraps `typing.TypeVar` and when instantiated, returns an instance of `typing.TypeVar`, possibly with some additional attributes. We also set `__instancecheck__` so that `isinstance(x, typing_extensions.TypeVar)` continues to work.

Also fix a few other minor test failures on current CPython main.