### PR TITLE
Improve some docstrings

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -4526,6 +4526,9 @@ class TypeVarTests(BaseTestCase):
         with self.assertRaises(ValueError):
             TypeVar('T', contravariant=True, infer_variance=True)
 
+    def test_docstring(self):
+        self.assertEqual(TypeVar.__doc__, typing.TypeVar.__doc__)
+
 
 class TypeVarLikeDefaultsTests(BaseTestCase):
     def test_typevar(self):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3425,6 +3425,10 @@ class ParamSpecTests(BaseTestCase):
         # won't be the same.
         self.assertNotEqual(hash(ParamSpec('P')), hash(P))
 
+    @skipUnless(hasattr(typing, "ParamSpec"), "Only relevant if typing.ParamSpec exists")
+    def test_consistent_docstring(self):
+        self.assertEqual(ParamSpec.__doc__, typing.ParamSpec.__doc__)
+
 
 class ConcatenateTests(BaseTestCase):
     def test_basics(self):
@@ -3786,6 +3790,10 @@ class TypeVarTupleTests(BaseTestCase):
                 z = pickle.loads(pickle.dumps(typevartuple, proto))
                 self.assertEqual(z.__name__, typevartuple.__name__)
                 self.assertEqual(z.__default__, typevartuple.__default__)
+
+    @skipUnless(hasattr(typing, "TypeVarTuple"), "Only relevant if typing.TypeVarTuple exists")
+    def test_consistent_docstring(self):
+        self.assertEqual(TypeVarTuple.__doc__, typing.TypeVarTuple.__doc__)
 
 
 class FinalDecoratorTests(BaseTestCase):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1388,8 +1388,7 @@ class _TypeVarMeta(type):
 
 
 class TypeVar(metaclass=_TypeVarMeta):
-    """Type variable."""
-
+    __doc__ = typing.TypeVar.__doc__
     __module__ = 'typing'
 
 
@@ -1477,8 +1476,7 @@ if hasattr(typing, 'ParamSpec'):
             return isinstance(__instance, typing.ParamSpec)
 
     class ParamSpec(metaclass=_ParamSpecMeta):
-        """Parameter specification."""
-
+        __doc__ = typing.ParamSpec.__doc__
         __module__ = 'typing'
 
 # 3.7-3.9
@@ -2098,8 +2096,7 @@ if hasattr(typing, "TypeVarTuple"):  # 3.11+
             return isinstance(__instance, typing.TypeVarTuple)
 
     class TypeVarTuple(metaclass=_TypeVarTupleMeta):
-        """Type variable tuple."""
-
+        __doc__ = typing.TypeVarTuple.__doc__
         __module__ = 'typing'
 
         def __init_subclass__(self, *args, **kwds):


### PR DESCRIPTION
`help(typing_extensions.TypeVar)` gives quite poor results at the moment.

~~N.B. I haven't included a test for `TypeVar.__doc__`, as it feels like the test I'd add would fit most naturally into the `TestCase` subclass @JelleZijlstra is adding in #165.~~

^Tests added for all three classes.