### PR TITLE
Improve the repr() of `_marker`

### DIFF
--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -95,6 +95,7 @@ GenericMeta = type
 # The functions below are modified copies of typing internal helpers.
 # They are needed by _ProtocolMeta and they provide support for PEP 646.
 
+
 class _Sentinel:
     def __repr__(self):
         return "<sentinel>"

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -95,7 +95,12 @@ GenericMeta = type
 # The functions below are modified copies of typing internal helpers.
 # They are needed by _ProtocolMeta and they provide support for PEP 646.
 
-_marker = object()
+class _Sentinel:
+    def __repr__(self):
+        return "<sentinel>"
+
+
+_marker = _Sentinel()
 
 
 def _check_generic(cls, parameters, elen=_marker):


### PR DESCRIPTION
This makes the output from `help(typing_extensions.TypeVar)` much more readable.

Before:

```pycon
>>> help(typing_extensions.TypeVar)
Help on class TypeVar in module typing:

class TypeVar(builtins.object)
 |  TypeVar(name, *constraints, bound=None, covariant=False, contravariant=False, default=<object object at 0x0000028D453A8760>, infer_variance=False)
```

After:

```pycon
>>> help(typing_extensions.TypeVar)
Help on class TypeVar in module typing:

class TypeVar(builtins.object)
 |  TypeVar(name, *constraints, bound=None, covariant=False, contravariant=False, default=<sentinel>, infer_variance=False)
```