### PR TITLE
Further simplify the implementations of the TypeVarLikes

### DIFF
--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1474,7 +1474,7 @@ if hasattr(typing, 'ParamSpec'):
     class ParamSpec(metaclass=_TypeVarLikeMeta):
         """Parameter specification."""
 
-        backported_typevarlike = typing.ParamSpec
+        _backported_typevarlike = typing.ParamSpec
 
         def __new__(cls, name, *, bound=None,
                     covariant=False, contravariant=False,


### PR DESCRIPTION
Use one metaclass instead of three. Do the magic in `__new__` on the class instead of `__call__` on the metaclass.