### PR TITLE
Clarify error message for non `@runtime_checkable` decorated protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Change deprecated `@runtime` to formal API `@runtime_checkable` in the error
+  message. Patch by Xuehai Pan.
+
 # Release 4.6.0 (May 22, 2023)
 
 - `typing_extensions` is now documented at

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -701,7 +701,7 @@ else:
                     if _allow_reckless_class_checks():
                         return NotImplemented
                     raise TypeError("Instance and class checks can only be used with"
-                                    " @runtime protocols")
+                                    " @runtime_checkable protocols")
                 if not isinstance(other, type):
                     # Same error as for issubclass(1, int)
                     raise TypeError('issubclass() arg 1 must be a class')


### PR DESCRIPTION
Hi `typing-extension` team. `typing-extension` version 4.6.0 just came out. It has caused some of the CI failures on our side (https://github.com/metaopt/optree/actions/runs/5054617196/jobs/9069750456). We are going to fix this misusage as a bug on our side (as the new behavior will be the standard API in future Python releases). But I found the error message that was raised is not very clear.

https://github.com/python/typing_extensions/blob/356934ca69a223416a199c2b26c19315382738db/src/typing_extensions.py#L703-L704

https://github.com/python/typing_extensions/blob/356934ca69a223416a199c2b26c19315382738db/src/typing_extensions.py#L759-L760

This PR changes deprecated `@runtime` to formal API `@runtime_checkable` in the error message.

------

The error in https://github.com/metaopt/optree/actions/runs/5054617196/jobs/9069750456 was raised by:

```python
class MyProtocol(Protocol[T]):
    ...

class MyClass(MyProtocal[T]):
    ...

MyProtocal.register(MyClass)  # raises TypeError for `MyProtocol` is not `runtime_checkable`
```

Refs:

- python/typing_extensions#161
- python/cpython#26067
- python/typing_extensions#132
- python/typing_extensions#134
- metaopt/optree#56