### PR TITLE
Have `Protocol` inherit from `typing.Generic` on 3.8+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Change deprecated `@runtime` to formal API `@runtime_checkable` in the error
   message. Patch by Xuehai Pan.
+- Fix regression in 4.6.0 where attempting to define a `Protocol` that was
+  generic over a `ParamSpec` or a `TypeVarTuple` would cause `TypeError` to be
+  raised. Patch by Alex Waygood.
 
 # Release 4.6.0 (May 22, 2023)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3827,9 +3827,11 @@ class UnpackTests(BaseTestCase):
                 self.assertEqual(
                     klass[int, str, float, bool].__args__, (int, str, float, bool)
                 )
-                # TODO This should probably also fail on 3.11,
-                # pending changes to CPython.
-                if not TYPING_3_11_0:
+                # A bug was fixed in 3.11.1
+                # (https://github.com/python/cpython/commit/74920aa27d0c57443dd7f704d6272cca9c507ab3)
+                # That means this assertion doesn't pass on 3.11.0,
+                # but it passes on all other Python versions
+                if sys.version_info[:3] != (3, 11, 0):
                     with self.assertRaises(TypeError):
                         klass[int]
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -2625,16 +2625,19 @@ class ProtocolTests(BaseTestCase):
         self.assertEqual(MemoizedFunc.__parameters__, (P, T, T2))
         self.assertTrue(MemoizedFunc._is_protocol)
 
-        with self.assertRaisesRegex(TypeError, "Too few arguments"):
+        with self.assertRaises(TypeError):
             MemoizedFunc[[int, str, str]]
 
-        X = MemoizedFunc[[int, str, str], T, T2]
-        self.assertEqual(X.__parameters__, (T, T2))
-        self.assertEqual(X.__args__, ((int, str, str), T, T2))
+        if sys.version_info >= (3, 10):
+            # These unfortunately don't pass on <=3.9,
+            # due to typing._type_check on older Python versions
+            X = MemoizedFunc[[int, str, str], T, T2]
+            self.assertEqual(X.__parameters__, (T, T2))
+            self.assertEqual(X.__args__, ((int, str, str), T, T2))
 
-        Y = X[bytes, memoryview]
-        self.assertEqual(Y.__parameters__, ())
-        self.assertEqual(Y.__args__, ((int, str, str), bytes, memoryview))
+            Y = X[bytes, memoryview]
+            self.assertEqual(Y.__parameters__, ())
+            self.assertEqual(Y.__args__, ((int, str, str), bytes, memoryview))
 
     def test_protocol_generic_over_typevartuple(self):
         Ts = TypeVarTuple("Ts")
@@ -2648,7 +2651,9 @@ class ProtocolTests(BaseTestCase):
         self.assertEqual(MemoizedFunc.__parameters__, (Ts, T, T2))
         self.assertTrue(MemoizedFunc._is_protocol)
 
-        with self.assertRaisesRegex(TypeError, "Too few arguments"):
+        things = "arguments" if sys.version_info >= (3, 11) else "parameters"
+
+        with self.assertRaisesRegex(TypeError, f"Too few {things}"):
             MemoizedFunc[int]
 
         X = MemoizedFunc[int, T, T2]

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -726,7 +726,8 @@ else:
                 func(C())  # Passes static type check
 
             See PEP 544 for details. Protocol classes decorated with
-            @typing_extensions.runtime act as simple-minded runtime protocol that checks
+            @typing_extensions.runtime_checkable act
+            as simple-minded runtime-checkable protocols that check
             only the presence of given attributes, ignoring their type signatures.
 
             Protocol classes can be generic, they are defined as::


### PR DESCRIPTION
Fixes #181.

The diff GitHub is displaying for this PR is a mess to read, but it's actually a fairly simple change. We branch on whether `sys.version_info >= (3, 8)` or not. If we're on 3.8+, we inherit from `typing.Generic` (like `Protocol` does in CPython). If we're on 3.7, we don't (because `typing.Generic` won't let us on Python 3.7).

Inheriting from `typing.Generic` is _very_ useful for us, because it means that we no longer have to worry about keeping `typing_extensions.Protocol.__class_getitem__` in sync with the logic in `typing.Generic.__class_getitem__`. The root cause of #181 was that the two methods got out of sync; changes that were made to `typing.Generic.__class_getitem__` were never backported to `typing_extensions.Protocol.__class_getitem__`.

Other than the fact that `Protocol` defines `__class_getitem__` on 3.7, but doesn't on 3.8, the implementations of `Protocol` across the two branches are broadly the same (and broadly the same as they were before this PR).

The one complication is that I had to work around this line in CPython here: https://github.com/python/cpython/blob/08b4eb83aadcbdb389b5970b51cac9be95146c2a/Lib/typing.py#L1024. `typing.py` does this to determine whether a class is `Generic` or `Protocol`, and we go down the wrong code path if `typing.py` determines that `typing_extensions.Protocol` is a different class to `typing.Protocol`

```py
is_generic_or_protocol = cls in (Generic, Protocol)
```

To work around that, I define `__eq__` on `_ProtocolMeta` so that `typing.Protocol == typing_extensions.Protocol` evaluates to `True`. This is a ghastly hack, but, well, it works. (As a result of defining `__eq__`, I end up also having to define `__hash__`, or Python starts complaining that `typing_extensions.Protocol` isn't hashable, and loads of tests start failing.)