### PR TITLE
Don't reimplement `runtime_checkable` on py38+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+- Due to changes in the implementation of `typing_extensions.Protocol`,
+  `typing.runtime_checkable` can now be used on `typing_extensions.Protocol`
+  (previously, users had to use `typing_extensions.runtime_checkable` if they
+  were using `typing_extensions.Protocol`).
+
 # Release 4.6.2 (May 25, 2023)
 
 - Fix use of `@deprecated` on classes with `__new__` but no `__init__`.
@@ -5,10 +11,6 @@
 - Fix regression in version 4.6.1 where comparing a generic class against a
   runtime-checkable protocol using `isinstance()` would cause `AttributeError`
   to be raised if using Python 3.7.
-- Due to changes in the implementation of `typing_extensions.Protocol`,
-  `typing.runtime_checkable` can now be used on `typing_extensions.Protocol`
-  (previously, users had to use `typing_extensions.runtime_checkable` if they
-  were using `typing_extensions.Protocol`).
 
 # Release 4.6.1 (May 23, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Fix regression in version 4.6.1 where comparing a generic class against a
   runtime-checkable protocol using `isinstance()` would cause `AttributeError`
   to be raised if using Python 3.7.
+- Due to changes in the implementation of `typing_extensions.Protocol`,
+  `typing.runtime_checkable` can now be used on `typing_extensions.Protocol`
+  (previously, users had to use `typing_extensions.runtime_checkable` if they
+  were using `typing_extensions.Protocol`).
 
 # Release 4.6.1 (May 23, 2023)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -531,6 +531,20 @@ Decorators
    improved, and ``typing_extensions`` backports these performance
    improvements.
 
+   .. versionchanged:: 4.6.0
+
+      Due to changes in the implementation of :class:`typing_extensions.Protocol`,
+      :py:func:`typing.runtime_checkable` will no longer work on classes inheriting
+      from :class:`typing_extensions.Protocol` on Python 3.8-3.11. Use
+      ``typing_extensions.runtime_checkable`` instead.
+
+   .. versionchanged:: 4.7.0
+
+      Due to changes in the implementation of :class:`typing_extensions.Protocol`,
+      :py:func:`typing.runtime_checkable` can now again be used on classes inheriting
+      from :class:`typing_extensions.Protocol`. ``typing_extensions.runtime_checkable``
+      now simply re-exports :py:func:`typing.runtime_checkable` on Python 3.8+.
+
 Functions
 ~~~~~~~~~
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -531,20 +531,6 @@ Decorators
    improved, and ``typing_extensions`` backports these performance
    improvements.
 
-   .. versionchanged:: 4.6.0
-
-      Due to changes in the implementation of :class:`typing_extensions.Protocol`,
-      :py:func:`typing.runtime_checkable` will no longer work on classes inheriting
-      from :class:`typing_extensions.Protocol` on Python 3.8-3.11. Use
-      ``typing_extensions.runtime_checkable`` instead.
-
-   .. versionchanged:: 4.7.0
-
-      Due to changes in the implementation of :class:`typing_extensions.Protocol`,
-      :py:func:`typing.runtime_checkable` can now again be used on classes inheriting
-      from :class:`typing_extensions.Protocol`. ``typing_extensions.runtime_checkable``
-      now simply re-exports :py:func:`typing.runtime_checkable` on Python 3.8+.
-
 Functions
 ~~~~~~~~~
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -1767,6 +1767,22 @@ class ProtocolTests(BaseTestCase):
         self.assertIsInstance(Bar(), Foo)
         self.assertNotIsInstance(object(), Foo)
 
+    @skipUnless(
+        hasattr(typing, "runtime_checkable"),
+        "Test is only relevant if typing.runtime_checkable exists"
+    )
+    def test_typing_dot_runtimecheckable_on_Protocol(self):
+        @typing.runtime_checkable
+        class Foo(Protocol):
+            x: int
+
+        class Bar:
+            def __init__(self):
+                self.x = 42
+
+        self.assertIsInstance(Bar(), Foo)
+        self.assertNotIsInstance(object(), Foo)
+
     def test_no_instantiation(self):
         class P(Protocol): pass
         with self.assertRaises(TypeError):
@@ -4187,7 +4203,7 @@ class AllTests(BaseTestCase):
             exclude |= {'final', 'Any', 'NewType'}
         if sys.version_info < (3, 12):
             exclude |= {
-                'Protocol', 'runtime_checkable', 'SupportsAbs', 'SupportsBytes',
+                'Protocol', 'SupportsAbs', 'SupportsBytes',
                 'SupportsComplex', 'SupportsFloat', 'SupportsIndex', 'SupportsInt',
                 'SupportsRound', 'TypedDict', 'is_typeddict', 'NamedTuple', 'Unpack',
             }

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -545,7 +545,6 @@ def _caller(depth=2):
 # so we backport the 3.12 version of Protocol to Python <=3.11
 if sys.version_info >= (3, 12):
     Protocol = typing.Protocol
-    runtime_checkable = typing.runtime_checkable
 else:
     def _allow_reckless_class_checks(depth=4):
         """Allow instance and class checks for special stdlib modules.
@@ -799,6 +798,10 @@ else:
                 if cls.__init__ is Protocol.__init__:
                     cls.__init__ = _no_init
 
+
+if sys.version_info >= (3, 8):
+    runtime_checkable = typing.runtime_checkable
+else:
     def runtime_checkable(cls):
         """Mark a protocol class as a runtime protocol, so that it
         can be used with isinstance() and issubclass(). Raise TypeError


### PR DESCRIPTION
Re-export it from `typing` instead.

Prior to #184, `typing.runtime_checkable` didn't work on `typing_extensions.Protocol`. Now that `typing_extensions.Protocol` inherits from `typing.Generic` on py38+, however, it does! This means that we can just re-export `typing.runtime_checkable` on py38+, rather than reimplementing it on all versions <3.12.