### PR TITLE
Re-export all names from typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+- `typing_extensions` now re-exports all names in the standard library's
+  `typing` module, except the deprecated `ByteString`. Patch by Jelle
+  Zijlstra.
+
 # Release 4.6.2 (May 25, 2023)
 
 - Fix use of `@deprecated` on classes with `__new__` but no `__init__`.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -572,7 +572,7 @@ Functions
 Pure aliases
 ~~~~~~~~~~~~
 
-These are the same as their :mod:`typing` counterparts in all supported
+These are simply re-exported from the :mod:`typing` module on all supported
 versions of Python. They are listed here for completeness.
 
 .. class:: AbstractSet

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,6 +22,13 @@ figured out how to deal with that possibility.
 Bugfixes and new typing features that don't require a PEP may be added to
 ``typing_extensions`` once they are merged into CPython's main branch.
 
+``typing_extensions`` also re-exports all names from the :py:mod:`typing` module,
+including those that have always been present in the module. This allows users to
+import names from ``typing_extensions`` without having to remember exactly when
+each object was added to :py:mod:`typing`. There is one exception:
+:py:class:`typing.ByteString`, which is deprecated and due to be removed in Python
+3.14, is not re-exported.
+
 Versioning and backwards compatibility
 --------------------------------------
 
@@ -99,10 +106,6 @@ Special typing primitives
 
       Added to support inheritance from ``Any``.
 
-.. data:: ClassVar
-
-   See :py:data:`typing.ClassVar` and :pep:`526`. In ``typing`` since 3.5.3.
-
 .. data:: Concatenate
 
    See :py:data:`typing.Concatenate` and :pep:`612`. In ``typing`` since 3.10.
@@ -167,10 +170,6 @@ Special typing primitives
 
       The improvements from Python 3.10 and 3.11 were backported.
 
-.. data:: NoReturn
-
-   See :py:data:`typing.NoReturn`. In ``typing`` since 3.5.4 and 3.6.2.
-
 .. data:: NotRequired
 
    See :py:data:`typing.NotRequired` and :pep:`655`. In ``typing`` since 3.11.
@@ -231,10 +230,6 @@ Special typing primitives
    See :py:data:`typing.Self` and :pep:`673`. In ``typing`` since 3.11.
 
    .. versionadded:: 4.0.0
-
-.. class:: Type
-
-   See :py:class:`typing.Type`. In ``typing`` since 3.5.2.
 
 .. data:: TypeAlias
 
@@ -333,22 +328,6 @@ Special typing primitives
 Generic concrete collections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. class:: ChainMap
-
-   See :py:class:`typing.ChainMap`. In ``typing`` since 3.5.4 and 3.6.1.
-
-.. class:: Counter
-
-   See :py:class:`typing.Counter`. In ``typing`` since 3.5.4 and 3.6.1.
-
-.. class:: DefaultDict
-
-   See :py:class:`typing.DefaultDict`. In ``typing`` since 3.5.2.
-
-.. class:: Deque
-
-   See :py:class:`typing.Deque`. In ``typing`` since 3.5.4 and 3.6.1.
-
 .. class:: OrderedDict
 
    See :py:class:`typing.OrderedDict`. In ``typing`` since 3.7.2.
@@ -356,40 +335,12 @@ Generic concrete collections
 Abstract Base Classes
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. class:: AsyncContextManager
-
-   See :py:class:`typing.AsyncContextManager`. In ``typing`` since 3.5.4 and 3.6.2.
-
-.. class:: AsyncGenerator
-
-   See :py:class:`typing.AsyncGenerator`. In ``typing`` since 3.6.1.
-
-.. class:: AsyncIterable
-
-   See :py:class:`typing.AsyncIterable`. In ``typing`` since 3.5.2.
-
-.. class:: AsyncIterator
-
-   See :py:class:`typing.AsyncIterator`. In ``typing`` since 3.5.2.
-
-.. class:: Awaitable
-
-   See :py:class:`typing.Awaitable`. In ``typing`` since 3.5.2.
-
 .. class:: Buffer
 
    See :py:class:`collections.abc.Buffer`. Added to the standard library
    in Python 3.12.
 
    .. versionadded:: 4.6.0
-
-.. class:: ContextManager
-
-   See :py:class:`typing.ContextManager`. In ``typing`` since 3.5.4.
-
-.. class:: Coroutine
-
-   See :py:class:`typing.Coroutine`. In ``typing`` since 3.5.3.
 
 Protocols
 ~~~~~~~~~
@@ -499,6 +450,18 @@ Decorators
    .. versionchanged:: 4.1.0
 
       The decorator now attempts to set the ``__final__`` attribute on decorated objects.
+
+.. decorator:: no_type_check
+
+   See :py:class:`typing.no_type_check`.
+
+   .. versionadded:: 4.7.0
+
+.. decorator:: no_type_check_decorator
+
+   See :py:class:`typing.no_type_check_decorator`.
+
+   .. versionadded:: 4.7.0
 
 .. decorator:: overload
 
@@ -617,13 +580,283 @@ Functions
 
    .. versionadded:: 4.1.0
 
-Other
-~~~~~
+Pure aliases
+~~~~~~~~~~~~
+
+These are the same as their :mod:`typing` counterparts in all supported
+versions of Python. They are listed here for completeness.
+
+.. class:: AbstractSet
+
+   See :py:class:`typing.AbstractSet`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: AnyStr
+
+   See :py:class:`typing.AnyStr`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: AsyncContextManager
+
+   See :py:class:`typing.AsyncContextManager`. In ``typing`` since 3.5.4 and 3.6.2.
+
+.. class:: AsyncGenerator
+
+   See :py:class:`typing.AsyncGenerator`. In ``typing`` since 3.6.1.
+
+.. class:: AsyncIterable
+
+   See :py:class:`typing.AsyncIterable`. In ``typing`` since 3.5.2.
+
+.. class:: AsyncIterator
+
+   See :py:class:`typing.AsyncIterator`. In ``typing`` since 3.5.2.
+
+.. class:: Awaitable
+
+   See :py:class:`typing.Awaitable`. In ``typing`` since 3.5.2.
+
+.. class:: BinaryIO
+
+   See :py:class:`typing.BinaryIO`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: Callable
+
+   See :py:class:`typing.Callable`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: ChainMap
+
+   See :py:class:`typing.ChainMap`. In ``typing`` since 3.5.4 and 3.6.1.
+
+.. data:: ClassVar
+
+   See :py:data:`typing.ClassVar` and :pep:`526`. In ``typing`` since 3.5.3.
+
+.. class:: Collection
+
+   See :py:class:`typing.Collection`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: Container
+
+   See :py:class:`typing.Container`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: ContextManager
+
+   See :py:class:`typing.ContextManager`. In ``typing`` since 3.5.4.
+
+.. class:: Coroutine
+
+   See :py:class:`typing.Coroutine`. In ``typing`` since 3.5.3.
+
+.. class:: Counter
+
+   See :py:class:`typing.Counter`. In ``typing`` since 3.5.4 and 3.6.1.
+
+.. class:: DefaultDict
+
+   See :py:class:`typing.DefaultDict`. In ``typing`` since 3.5.2.
+
+.. class:: Deque
+
+   See :py:class:`typing.Deque`. In ``typing`` since 3.5.4 and 3.6.1.
+
+.. class:: Dict
+
+   See :py:class:`typing.Dict`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: ForwardRef
+
+   See :py:class:`typing.ForwardRef`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: FrozenSet
+
+   See :py:class:`typing.FrozenSet`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: Generator
+
+   See :py:class:`typing.Generator`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: Generic
+
+   See :py:class:`typing.Generic`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: Hashable
+
+   See :py:class:`typing.Hashable`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: IO
+
+   See :py:class:`typing.IO`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: ItemsView
+
+   See :py:class:`typing.ItemsView`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: Iterable
+
+   See :py:class:`typing.Iterable`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: Iterator
+
+   See :py:class:`typing.Iterator`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: KeysView
+
+   See :py:class:`typing.KeysView`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: List
+
+   See :py:class:`typing.List`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: Mapping
+
+   See :py:class:`typing.Mapping`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: MappingView
+
+   See :py:class:`typing.MappingView`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: Match
+
+   See :py:class:`typing.Match`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: MutableMapping
+
+   See :py:class:`typing.MutableMapping`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: MutableSequence
+
+   See :py:class:`typing.MutableSequence`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: MutableSet
+
+   See :py:class:`typing.MutableSet`.
+
+   .. versionadded::: 4.7.0
+
+.. data:: NoReturn
+
+   See :py:data:`typing.NoReturn`. In ``typing`` since 3.5.4 and 3.6.2.
+
+.. class:: Optional
+
+   See :py:class:`typing.Optional`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: Pattern
+
+   See :py:class:`typing.Pattern`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: Reversible
+
+   See :py:class:`typing.Reversible`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: Sequence
+
+   See :py:class:`typing.Sequence`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: Set
+
+   See :py:class:`typing.Set`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: Sized
+
+   See :py:class:`typing.Sized`.
+
+   .. versionadded::: 4.7.0
 
 .. class:: Text
 
    See :py:class:`typing.Text`. In ``typing`` since 3.5.2.
 
+.. class:: TextIO
+
+   See :py:class:`typing.TextIO`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: Tuple
+
+   See :py:class:`typing.Tuple`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: Type
+
+   See :py:class:`typing.Type`. In ``typing`` since 3.5.2.
+
 .. data:: TYPE_CHECKING
 
    See :py:data:`typing.TYPE_CHECKING`. In ``typing`` since 3.5.2.
+
+.. class:: Union
+
+   See :py:class:`typing.Union`.
+
+   .. versionadded::: 4.7.0
+
+.. class:: ValuesView
+
+   See :py:class:`typing.ValuesView`.
+
+   .. versionadded::: 4.7.0
+
+.. function:: cast
+
+   See :py:func:`typing.cast`.
+
+   .. versionadded::: 4.7.0
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,9 +25,10 @@ Bugfixes and new typing features that don't require a PEP may be added to
 ``typing_extensions`` also re-exports all names from the :py:mod:`typing` module,
 including those that have always been present in the module. This allows users to
 import names from ``typing_extensions`` without having to remember exactly when
-each object was added to :py:mod:`typing`. There is one exception:
+each object was added to :py:mod:`typing`. There are a few exceptions:
 :py:class:`typing.ByteString`, which is deprecated and due to be removed in Python
-3.14, is not re-exported.
+3.14, is not re-exported. Similarly, the ``typing.io`` and ``typing.re`` submodules,
+which are removed in Python 3.13, are excluded.
 
 Versioning and backwards compatibility
 --------------------------------------
@@ -451,18 +452,6 @@ Decorators
 
       The decorator now attempts to set the ``__final__`` attribute on decorated objects.
 
-.. decorator:: no_type_check
-
-   See :py:class:`typing.no_type_check`.
-
-   .. versionadded:: 4.7.0
-
-.. decorator:: no_type_check_decorator
-
-   See :py:class:`typing.no_type_check_decorator`.
-
-   .. versionadded:: 4.7.0
-
 .. decorator:: overload
 
    See :py:func:`typing.overload`.
@@ -590,13 +579,13 @@ versions of Python. They are listed here for completeness.
 
    See :py:class:`typing.AbstractSet`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
-.. class:: AnyStr
+.. data:: AnyStr
 
-   See :py:class:`typing.AnyStr`.
+   See :py:data:`typing.AnyStr`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: AsyncContextManager
 
@@ -622,13 +611,13 @@ versions of Python. They are listed here for completeness.
 
    See :py:class:`typing.BinaryIO`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
-.. class:: Callable
+.. data:: Callable
 
-   See :py:class:`typing.Callable`.
+   See :py:data:`typing.Callable`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: ChainMap
 
@@ -642,13 +631,13 @@ versions of Python. They are listed here for completeness.
 
    See :py:class:`typing.Collection`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: Container
 
    See :py:class:`typing.Container`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: ContextManager
 
@@ -674,149 +663,149 @@ versions of Python. They are listed here for completeness.
 
    See :py:class:`typing.Dict`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: ForwardRef
 
    See :py:class:`typing.ForwardRef`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: FrozenSet
 
    See :py:class:`typing.FrozenSet`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: Generator
 
    See :py:class:`typing.Generator`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: Generic
 
    See :py:class:`typing.Generic`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: Hashable
 
    See :py:class:`typing.Hashable`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: IO
 
    See :py:class:`typing.IO`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: ItemsView
 
    See :py:class:`typing.ItemsView`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: Iterable
 
    See :py:class:`typing.Iterable`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: Iterator
 
    See :py:class:`typing.Iterator`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: KeysView
 
    See :py:class:`typing.KeysView`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: List
 
    See :py:class:`typing.List`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: Mapping
 
    See :py:class:`typing.Mapping`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: MappingView
 
    See :py:class:`typing.MappingView`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: Match
 
    See :py:class:`typing.Match`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: MutableMapping
 
    See :py:class:`typing.MutableMapping`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: MutableSequence
 
    See :py:class:`typing.MutableSequence`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: MutableSet
 
    See :py:class:`typing.MutableSet`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. data:: NoReturn
 
    See :py:data:`typing.NoReturn`. In ``typing`` since 3.5.4 and 3.6.2.
 
-.. class:: Optional
+.. data:: Optional
 
-   See :py:class:`typing.Optional`.
+   See :py:data:`typing.Optional`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: Pattern
 
    See :py:class:`typing.Pattern`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: Reversible
 
    See :py:class:`typing.Reversible`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: Sequence
 
    See :py:class:`typing.Sequence`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: Set
 
    See :py:class:`typing.Set`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: Sized
 
    See :py:class:`typing.Sized`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: Text
 
@@ -826,13 +815,13 @@ versions of Python. They are listed here for completeness.
 
    See :py:class:`typing.TextIO`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
-.. class:: Tuple
+.. data:: Tuple
 
-   See :py:class:`typing.Tuple`.
+   See :py:data:`typing.Tuple`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: Type
 
@@ -842,21 +831,32 @@ versions of Python. They are listed here for completeness.
 
    See :py:data:`typing.TYPE_CHECKING`. In ``typing`` since 3.5.2.
 
-.. class:: Union
+.. data:: Union
 
-   See :py:class:`typing.Union`.
+   See :py:data:`typing.Union`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. class:: ValuesView
 
    See :py:class:`typing.ValuesView`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
 .. function:: cast
 
    See :py:func:`typing.cast`.
 
-   .. versionadded::: 4.7.0
+   .. versionadded:: 4.7.0
 
+.. decorator:: no_type_check
+
+   See :py:func:`typing.no_type_check`.
+
+   .. versionadded:: 4.7.0
+
+.. decorator:: no_type_check_decorator
+
+   See :py:func:`typing.no_type_check_decorator`.
+
+   .. versionadded:: 4.7.0

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -4118,6 +4118,12 @@ class AllTests(BaseTestCase):
         te_all = set(typing_extensions.__all__)
         exceptions = {"ByteString"}
         self.assertGreaterEqual(te_all, t_all - exceptions)
+        # Deprecated, to be removed in 3.14
+        self.assertFalse(hasattr(typing_extensions, "ByteString"))
+        # These were never included in `typing.__all__`,
+        # and have been removed in Python 3.13
+        self.assertNotIn('re', te_all)
+        self.assertNotIn('io', te_all)
 
     def test_typing_extensions_includes_standard(self):
         a = typing_extensions.__all__

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -4111,6 +4111,14 @@ class DataclassTransformTests(BaseTestCase):
 
 class AllTests(BaseTestCase):
 
+    def test_drop_in_for_typing(self):
+        # Check that the typing_extensions.__all__ is a superset of
+        # typing.__all__.
+        t_all = set(typing.__all__)
+        te_all = set(typing_extensions.__all__)
+        exceptions = {"ByteString"}
+        self.assertGreaterEqual(te_all, t_all - exceptions)
+
     def test_typing_extensions_includes_standard(self):
         a = typing_extensions.__all__
         self.assertIn('ClassVar', a)

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2914,7 +2914,10 @@ else:
                 return typing.Union[left, self]
 
 
-# Aliases for items that have always been in typing
+# Aliases for items that have always been in typing.
+# Explicitly assign these (rather than using `from typing import *` at the top),
+# so that we get a CI error if one of these is deleted from typing.py
+# in a future version of Python
 AbstractSet = typing.AbstractSet
 AnyStr = typing.AnyStr
 BinaryIO = typing.BinaryIO

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -85,6 +85,45 @@ __all__ = [
     'NoReturn',
     'Required',
     'NotRequired',
+
+    # Pure aliases, have always been in typing
+    'AbstractSet',
+    'AnyStr',
+    'BinaryIO',
+    'Callable',
+    'Collection',
+    'Container',
+    'Dict',
+    'ForwardRef',
+    'FrozenSet',
+    'Generator',
+    'Generic',
+    'Hashable',
+    'IO',
+    'ItemsView',
+    'Iterable',
+    'Iterator',
+    'KeysView',
+    'List',
+    'Mapping',
+    'MappingView',
+    'Match',
+    'MutableMapping',
+    'MutableSequence',
+    'MutableSet',
+    'Optional',
+    'Pattern',
+    'Reversible',
+    'Sequence',
+    'Set',
+    'Sized',
+    'TextIO',
+    'Tuple',
+    'Union',
+    'ValuesView',
+    'cast',
+    'no_type_check',
+    'no_type_check_decorator',
 ]
 
 # for backward compatibility
@@ -2873,3 +2912,43 @@ else:
                 if not _is_unionable(left):
                     return NotImplemented
                 return typing.Union[left, self]
+
+
+# Aliases for items that have always been in typing
+AbstractSet = typing.AbstractSet
+AnyStr = typing.AnyStr
+BinaryIO = typing.BinaryIO
+Callable = typing.Callable
+Collection = typing.Collection
+Container = typing.Container
+Dict = typing.Dict
+ForwardRef = typing.ForwardRef
+FrozenSet = typing.FrozenSet
+Generator = typing.Generator
+Generic = typing.Generic
+Hashable = typing.Hashable
+IO = typing.IO
+ItemsView = typing.ItemsView
+Iterable = typing.Iterable
+Iterator = typing.Iterator
+KeysView = typing.KeysView
+List = typing.List
+Mapping = typing.Mapping
+MappingView = typing.MappingView
+Match = typing.Match
+MutableMapping = typing.MutableMapping
+MutableSequence = typing.MutableSequence
+MutableSet = typing.MutableSet
+Optional = typing.Optional
+Pattern = typing.Pattern
+Reversible = typing.Reversible
+Sequence = typing.Sequence
+Set = typing.Set
+Sized = typing.Sized
+TextIO = typing.TextIO
+Tuple = typing.Tuple
+Union = typing.Union
+ValuesView = typing.ValuesView
+cast = typing.cast
+no_type_check = typing.no_type_check
+no_type_check_decorator = typing.no_type_check_decorator


### PR DESCRIPTION
Fixes #50.

I decided to exclude top-level names that have a definite removal
timeline (io, re, ByteString); there's no point in re-exporting them
now.

Many other names are deprecated without a definite removal plan
(PEP 585). If they do get removed eventually, typing-extensions can
simply re-export the builtin/collections.abc names.

In the documentation, I add a separate section listing all the names
that are pure aliases for typing. This makes it easier to distinguish
the cases where there is something more interesting going on in
typing-extensions.
