### PR TITLE
Skip a problematic test on CPython 3.12.0b1

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -2267,6 +2267,10 @@ class ProtocolTests(BaseTestCase):
         del f.x
         self.assertNotIsInstance(f, HasX)
 
+    @skipIf(
+        sys.version_info == (3, 12, 0, 'beta', 1),
+        "CPython had a bug in 3.12.0b1"
+    )
     def test_protocols_isinstance_generic_classes(self):
         T = TypeVar("T")
 


### PR DESCRIPTION
Fixes #199
Unblocks #173

We could probably just wait for 3.12.0b2, where the bug will be fixed in CPython (due to https://github.com/python/cpython/commit/2b7027d0b2ee2e102a24a0da27d01b8221f9351c). But this approach might make it easier for Linux distros etc. to test with Python 3.12.

Cc. @mgorny