### PR TITLE
Minor improvements to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -25,7 +28,7 @@ jobs:
         # Python version, because typing sometimes changed between bugfix releases.
         # For available versions, see:
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-        python-version: ["3.7", "3.7.1", "3.8", "3.8.0", "3.9", "3.9.0", "3.10", "3.10.0", "3.11", "3.11.0", "3.12-dev", "pypy3.9"]
+        python-version: ["3.7", "3.7.1", "3.8", "3.8.0", "3.9", "3.9.0", "3.10", "3.10.0", "3.11", "3.11.0", "3.12", "pypy3.9"]
 
     runs-on: ubuntu-20.04
 
@@ -36,9 +39,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Test typing_extensions
-        continue-on-error: ${{ matrix.python-version == '3.12-dev' }}
+        continue-on-error: ${{ matrix.python-version == '3.12' }}
         run: |
           # Be wary of running `pip install` here, since it becomes easy for us to
           # accidentally pick up typing_extensions as installed by a dependency
@@ -61,14 +65,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --upgrade pip
           pip install -r test-requirements.txt
           # not included in test-requirements.txt as it depends on typing-extensions,
           # so it's a pain to have it installed locally
           pip install flake8-noqa
 
       - name: Lint implementation
-        run: flake8
+        run: flake8 --color always
 
       - name: Lint tests
-        run: flake8 --config=.flake8-tests src/test_typing_extensions.py
+        run: flake8 --config=.flake8-tests src/test_typing_extensions.py --color always


### PR DESCRIPTION
- Use the new `allow-prereleases` key for `actions/setup-python`. If we set this to `true`, then we can just use `3.12` in our CI matrix, instead of `3.12-dev`. That means we won't have to worry about updating the matrix from `3.12-dev` to `3.12` when 3.12.0 comes out in the autumn; our CI will automatically start using the latest version of Python 3.12.
- Colorise the output of flake8.
- Don't bother upgrading pip in CI. It's not really necessary, and wastes a few seconds. Disable the "you're using an older version of pip" message instead, using the `PIP_DISABLE_PIP_VERSION_CHECK` environment variable.