### PR TITLE
Add introspection helper functions for third-party libraries

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -37,7 +37,7 @@ from typing_extensions import assert_type, get_type_hints, get_origin, get_args,
 from typing_extensions import clear_overloads, get_overloads, overload
 from typing_extensions import NamedTuple
 from typing_extensions import override, deprecated, Buffer, TypeAliasType, TypeVar
-from typing_extensions import get_typing_objects_by_name_of
+from typing_extensions import get_typing_objects_by_name_of, is_typing_name
 from _typed_dict_test_helper import Foo, FooGeneric
 
 # Flags used to mark tests that only apply after a specific
@@ -5040,6 +5040,14 @@ class IntrospectionHelperTests(BaseTestCase):
         self.assertEqual(len(protocol_objs), 2)
         modules = {obj.__module__ for obj in protocol_objs}
         self.assertEqual(modules, {"typing", "typing_extensions"})
+
+    def test_is_typing_name(self):
+        for name in typing_extensions.__all__:
+            te_obj = getattr(typing_extensions, name)
+            self.assertTrue(is_typing_name(te_obj, name))
+            if hasattr(typing, name):
+                typing_obj = getattr(typing, name)
+                self.assertTrue(is_typing_name(typing_obj, name))
 
 
 if __name__ == '__main__':

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -37,7 +37,7 @@ from typing_extensions import assert_type, get_type_hints, get_origin, get_args,
 from typing_extensions import clear_overloads, get_overloads, overload
 from typing_extensions import NamedTuple
 from typing_extensions import override, deprecated, Buffer, TypeAliasType, TypeVar
-from typing_extensions import typing_extensions_reexports_name, get_typing_objects_by_name_of
+from typing_extensions import get_typing_objects_by_name_of
 from _typed_dict_test_helper import Foo, FooGeneric
 
 # Flags used to mark tests that only apply after a specific
@@ -4990,20 +4990,6 @@ class TypeAliasTypeTests(BaseTestCase):
 
 
 class IntrospectionHelperTests(BaseTestCase):
-    def test_typing_extensions_reexports(self):
-        for name in typing_extensions.__all__:
-            with self.subTest(name=name):
-                self.assertIs(type(typing_extensions_reexports_name(name)), bool)
-
-        self.assertTrue(typing_extensions_reexports_name("ClassVar"))
-
-        with self.assertRaisesRegex(ValueError, "no object called 'foo'"):
-            typing_extensions_reexports_name("foo")
-
-    @skipIf(TYPING_3_12_0, "We reexport TypeAliasType from typing on 3.12+")
-    def test_typing_extensions_doesnt_reexport(self):
-        self.assertFalse(typing_extensions_reexports_name("TypeAliasType"))
-
     def test_typing_objects_by_name_of(self):
         for name in typing_extensions.__all__:
             with self.subTest(name=name):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -88,7 +88,6 @@ __all__ = [
 
     # Introspection helpers unique to typing_extensions
     # These will never be added to typing.py in CPython
-    'typing_extensions_reexports_name',
     'get_typing_objects_by_name_of',
 ]
 
@@ -2898,11 +2897,6 @@ def _get_name_from_globals(name: str) -> object:
             f"The typing_extensions module has no object called {name!r}!"
         ) from None
     return obj
-
-
-@functools.lru_cache(maxsize=None)
-def typing_extensions_reexports_name(name: str) -> bool:
-    return _get_name_from_globals(name) is getattr(typing, name, object())
 
 
 @functools.lru_cache(maxsize=None)

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2895,18 +2895,23 @@ def get_typing_objects_by_name_of(name: str) -> typing.Tuple[Any, ...]:
     try:
         te_obj = globals()[name]
     except KeyError:
-        raise ValueError(
-            f"The typing_extensions module has no object called {name!r}!"
-        ) from None
-    objs = [te_obj]
-    if hasattr(typing, name):
-        typing_obj = getattr(typing, name)
-        # Some typing objects compare equal to the equivalent typing_extensions object,
-        # but aren't actually the exact same object,
-        # so we can't use a set here; a list is better
-        if typing_obj is not te_obj:
-            objs.append(typing_obj)
-    return tuple(objs)
+        try:
+            typing_obj = getattr(typing, name)
+        except AttributeError:
+            raise ValueError(
+                f"Neither typing nor typing_extensions has an object called {name!r}!"
+            ) from None
+        else:
+            return (typing_obj,)
+    else:
+        if hasattr(typing, name):
+            typing_obj = getattr(typing, name)
+            # Some typing objects compare equal to the equivalent typing_extensions object,
+            # but aren't actually the exact same object,
+            # so we can't use a set here
+            if typing_obj is not te_obj:
+                return (te_obj, typing_obj)
+        return (te_obj,)
 
 
 def is_typing_name(obj: object, name: str) -> bool:

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2906,9 +2906,6 @@ def get_typing_objects_by_name_of(name: str) -> typing.Tuple[Any, ...]:
     else:
         if hasattr(typing, name):
             typing_obj = getattr(typing, name)
-            # Some typing objects compare equal to the equivalent typing_extensions object,
-            # but aren't actually the exact same object,
-            # so we can't use a set here
             if typing_obj is not te_obj:
                 return (te_obj, typing_obj)
         return (te_obj,)


### PR DESCRIPTION
This is a proof-of-concept for the idea that I mentioned in https://github.com/python/typing_extensions/issues/185#issuecomment-1561317825. The proposal is that we could provide two simple introspection helper functions for third-party libraries, and could recommend that they use these utilities as building blocks for their own introspection functions.

For example, pydantic has a function called `is_literal_type`, and typing_inspect does also. Both functions broke with the release of typing_extensions 4.6.0:

- https://github.com/pydantic/pydantic/pull/5826/
- https://github.com/ilevkivskyi/typing_inspect/pull/101

With these introspection helpers, both libraries could rewrite their `is_literal_type` functions as:

```py
from typing_extensions import get_origin, is_typing_name

def is_literal_type(tp) -> bool:
    return is_typing_name(tp, "Literal") or is_typing_name(get_origin(tp), "Literal")
```

And you could use the utility functions in this PR as building blocks for all kinds of similar introspection capabilities, if you're a library that's doing that kind of thing. We could advertise and recommend these functions in the docs as the preferred way to do this kind of thing while avoiding breakage.

I'll add docs to this PR if there's interest in this idea -- didn't want to invest _too_ much time into it if it's not something we want to pursue :)