### PR TITLE
Add a cron job for testing third-party users of typing_extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Test and lint
 
 on:
+  schedule:
+    - cron: "0 2 * * *"  # 2am UTC
   push:
     branches:
       - main
@@ -20,6 +22,14 @@ concurrency:
 jobs:
   tests:
     name: Run tests
+
+    if: >-
+      # if 'schedule' was the trigger,
+      # don't run it on contributors' forks
+      ${{
+        github.repository == 'python/typing_extensions'
+        || github.event_name != 'schedule'
+      }}
 
     strategy:
       fail-fast: false
@@ -51,6 +61,9 @@ jobs:
   linting:
     name: Lint
 
+    # no reason to run this as a cron job
+    if: github.event_name != 'schedule'
+
     runs-on: ubuntu-latest
 
     steps:
@@ -74,3 +87,32 @@ jobs:
 
       - name: Lint tests
         run: flake8 --config=.flake8-tests src/test_typing_extensions.py --color always
+
+  create-issue-on-failure:
+    name: Create an issue if daily tests failed
+    runs-on: ubuntu-latest
+
+    needs: [tests]
+
+    if: >-
+        ${{
+          github.repository == 'python/typing_extensions'
+          && always()
+          && github.event_name == 'schedule'
+          && needs.tests.result == 'failure'
+        }}
+
+    permissions:
+      issues: write
+
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.create({
+              owner: "python",
+              repo: "typing_extensions",
+              title: `Daily tests failed on ${new Date().toDateString()}`,
+              body: "Runs listed here: https://github.com/python/typing_extensions/actions/workflows/ci.yml",
+            })

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -169,8 +169,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install pyanalyze test requirements
         run: |
-          pip install .
-          pip install pytest mypy_extensions attrs
+          pip install .[tests]
       - name: Install typing_extensions latest
         run: pip install ./typing-extensions-latest
       - name: List all installed dependencies

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -171,8 +171,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install pyanalyze test requirements
-        run: |
-          pip install .[tests]
+        run: pip install .[tests]
       - name: Install typing_extensions latest
         run: pip install ./typing-extensions-latest
       - name: List all installed dependencies

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -9,7 +9,7 @@ name: Daily tests
 
 on:
   schedule:
-    - cron: "0 0 * * *"  # Midnight UTC
+    - cron: "30 2 * * *"  # 02:30 UTC
   pull_request:
     paths:
       - ".github/workflows/daily.yml"

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,341 @@
+# This workflow is a daily cron job
+# As well as running our own tests,
+# we also run the tests of various third-party libraries that use us.
+# This helps us spot regressions early,
+# and helps flag when third-party libraries are making incorrect assumptions
+# that might cause them to break when we cut a new release.
+
+name: Daily tests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"  # Midnight UTC
+  pull_request:
+    paths:
+      - ".github/workflows/daily.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
+  FORCE_COLOR: 1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  typing-extensions:
+    name: Run our own tests
+    # Only run if 'schedule' was the trigger,
+    # and we're not running on a fork
+    if: >-
+      ${{
+        github.repository == 'python/typing_extensions'
+        && github.event_name == 'schedule'
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.7"
+          - "3.7.1"
+          - "3.8"
+          - "3.8.0"
+          - "3.9"
+          - "3.9.0"
+          - "3.10"
+          - "3.10.0"
+          - "3.11"
+          - "3.11.0"
+          - "3.12"
+          - "pypy3.9"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - name: Test typing_extensions
+        run: |
+          # Be wary of running `pip install` here, since it becomes easy for us to
+          # accidentally pick up typing_extensions as installed by a dependency
+          cd src
+          python -m unittest test_typing_extensions.py
+
+  pydantic:
+    name: pydantic tests
+    if: >-
+      # if 'schedule' was the trigger,
+      # don't run it on contributors' forks
+      ${{
+        github.repository == 'python/typing_extensions'
+        || github.event_name != 'schedule'
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pydantic
+        uses: actions/checkout@v3
+        with:
+          repository: pydantic/pydantic
+      - name: Checkout typing_extensions
+        uses: actions/checkout@v3
+        with:
+          path: typing-extensions-latest
+      - name: Setup pdm for pydantic tests
+        uses: pdm-project/setup-pdm@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: true
+      - name: Add local version of typing_extensions as a dependency
+        run: pdm add ./typing-extensions-latest
+      - name: Install pydantic test dependencies
+        run: pdm install -G testing -G email
+      - name: List installed dependencies
+        run: pdm list -vv  # pdm equivalent to `pip list`
+      - name: Run pydantic tests
+        run: pdm run pytest
+
+  typing_inspect:
+    name: typing_inspect tests
+    if: >-
+      # if 'schedule' was the trigger,
+      # don't run it on contributors' forks
+      ${{
+        github.repository == 'python/typing_extensions'
+        || github.event_name != 'schedule'
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout typing_inspect
+        uses: actions/checkout@v3
+        with:
+          repository: ilevkivskyi/typing_inspect
+      - name: Checkout typing_extensions
+        uses: actions/checkout@v3
+        with:
+          path: typing-extensions-latest
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install typing_inspect test dependencies
+        run: pip install -r test-requirements.txt
+      - name: Install typing_extensions latest
+        run: pip install ./typing-extensions-latest
+      - name: List all installed dependencies
+        run: pip freeze --all
+      - name: Run typing_inspect tests
+        run: pytest
+
+  pyanalyze:
+    name: pyanalyze tests
+    if: >-
+      # if 'schedule' was the trigger,
+      # don't run it on contributors' forks
+      ${{
+        github.repository == 'python/typing_extensions'
+        || github.event_name != 'schedule'
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pyanalyze
+        uses: actions/checkout@v3
+        with:
+          repository: quora/pyanalyze
+      - name: Checkout typing_extensions
+        uses: actions/checkout@v3
+        with:
+          path: typing-extensions-latest
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install pyanalyze test requirements
+        run: |
+          pip install .
+          pip install pytest mypy_extensions attrs
+      - name: Install typing_extensions latest
+        run: pip install ./typing-extensions-latest
+      - name: List all installed dependencies
+        run: pip freeze --all
+      - name: Run pyanalyze tests
+        run: pytest pyanalyze/
+
+  typeguard:
+    name: typeguard tests
+    if: >-
+      # if 'schedule' was the trigger,
+      # don't run it on contributors' forks
+      ${{
+        github.repository == 'python/typing_extensions'
+        || github.event_name != 'schedule'
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out typeguard
+        uses: actions/checkout@v3
+        with:
+          repository: agronholm/typeguard
+      - name: Checkout typing_extensions
+        uses: actions/checkout@v3
+        with:
+          path: typing-extensions-latest
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install typeguard test requirements
+        run: pip install -e .[test]
+      - name: Install typing_extensions latest
+        run: pip install ./typing-extensions-latest
+      - name: List all installed dependencies
+        run: pip freeze --all
+      - name: Run typeguard tests
+        run: pytest
+
+  typed-argument-parser:
+    name: typed-argument-parser tests
+    if: >-
+      # if 'schedule' was the trigger,
+      # don't run it on contributors' forks
+      ${{
+        github.repository == 'python/typing_extensions'
+        || github.event_name != 'schedule'
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out typed-argument-parser
+        uses: actions/checkout@v3
+        with:
+          repository: swansonk14/typed-argument-parser
+      - name: Checkout typing_extensions
+        uses: actions/checkout@v3
+        with:
+          path: typing-extensions-latest
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Configure git for typed-argument-parser tests
+        # typed-argument parser does this in their CI,
+        # and the tests fail unless we do this
+        run: |
+          git config --global user.email "you@example.com"
+          git config --global user.name "Your Name"
+      - name: Install typed-argument-parser test requirements
+        run: |
+          pip install -e .
+          pip install pytest
+      - name: Install typing_extensions latest
+        run: pip install ./typing-extensions-latest
+      - name: List all installed dependencies
+        run: pip freeze --all
+      - name: Run typed-argument-parser tests
+        run: pytest
+
+  stubtest:
+    name: stubtest tests
+    if: >-
+      # if 'schedule' was the trigger,
+      # don't run it on contributors' forks
+      ${{
+        github.repository == 'python/typing_extensions'
+        || github.event_name != 'schedule'
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout mypy for stubtest tests
+        uses: actions/checkout@v3
+        with:
+          repository: python/mypy
+      - name: Checkout typing_extensions
+        uses: actions/checkout@v3
+        with:
+          path: typing-extensions-latest
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install mypy test requirements
+        run: |
+          pip install -r test-requirements.txt
+          pip install -e .
+      - name: Install typing_extensions latest
+        run: pip install ./typing-extensions-latest
+      - name: List all installed dependencies
+        run: pip freeze --all
+      - name: Run stubtest tests
+        run: pytest ./mypy/test/teststubtest.py
+
+  create-issue-on-failure:
+    name: Create an issue if daily tests failed
+    runs-on: ubuntu-latest
+
+    needs:
+      - typing-extensions
+      - pydantic
+      - typing_inspect
+      - pyanalyze
+      - typeguard
+      - typed-argument-parser
+      - stubtest
+
+    if: >-
+        ${{
+          github.repository == 'python/typing_extensions'
+          && always()
+          && github.event_name == 'schedule'
+          && (
+            needs.typing-extensions == 'failure'
+            || needs.pydantic.result == 'failure'
+            || needs.typing_inspect.result == 'failure'
+            || needs.pyanalyze.result == 'failure'
+            || needs.typeguard.result == 'failure'
+            || needs.typed-argument-parser.result == 'failure'
+            || needs.stubtest.result == 'failure'
+          )
+        }}
+
+    permissions:
+      issues: write
+
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.create({
+              owner: "python",
+              repo: "typing_extensions",
+              title: `Daily tests failed on ${new Date().toDateString()}`,
+              body: "Runs listed here: https://github.com/python/typing_extensions/actions/workflows/daily.yml",
+            })

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -180,13 +180,7 @@ jobs:
 
   typeguard:
     name: typeguard tests
-    if: >-
-      # if 'schedule' was the trigger,
-      # don't run it on contributors' forks
-      ${{
-        github.repository == 'python/typing_extensions'
-        || github.event_name != 'schedule'
-      }}
+    if: false  # TODO: unskip when typeguard's tests pass on typing_extensions>=4.6.0
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,4 +1,4 @@
-# This workflow is a daily cron job
+# This workflow is a daily cron job.
 # As well as running our own tests,
 # we also run the tests of various third-party libraries that use us.
 # This helps us spot regressions early,
@@ -81,6 +81,7 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout pydantic
         uses: actions/checkout@v3
@@ -118,6 +119,7 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout typing_inspect
         uses: actions/checkout@v3
@@ -154,6 +156,7 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Check out pyanalyze
         uses: actions/checkout@v3
@@ -185,6 +188,7 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Check out typeguard
         uses: actions/checkout@v3
@@ -221,6 +225,7 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Check out typed-argument-parser
         uses: actions/checkout@v3
@@ -265,6 +270,7 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout mypy for stubtest tests
         uses: actions/checkout@v3
@@ -303,6 +309,7 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout cattrs
         uses: actions/checkout@v3

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -296,6 +296,44 @@ jobs:
       - name: Run stubtest tests
         run: pytest ./mypy/test/teststubtest.py
 
+  cattrs:
+    name: cattrs tests
+    if: >-
+      # if 'schedule' was the trigger,
+      # don't run it on contributors' forks
+      ${{
+        github.repository == 'python/typing_extensions'
+        || github.event_name != 'schedule'
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cattrs
+        uses: actions/checkout@v3
+        with:
+          repository: python-attrs/cattrs
+      - name: Checkout typing_extensions
+        uses: actions/checkout@v3
+        with:
+          path: typing-extensions-latest
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install poetry for cattrs
+        run: pip install poetry
+      - name: Add latest typing-extensions as a dependency
+        run: poetry add ./typing-extensions-latest
+      - name: Install cattrs test dependencies
+        run: poetry install -v --all-extras
+      - name: List all installed dependencies
+        run: poetry show
+      - name: Run cattrs tests
+        run: poetry run pytest tests
+
   create-issue-on-failure:
     name: Create an issue if daily tests failed
     runs-on: ubuntu-latest
@@ -308,6 +346,7 @@ jobs:
       - typeguard
       - typed-argument-parser
       - stubtest
+      - cattrs
 
     if: >-
         ${{
@@ -322,6 +361,7 @@ jobs:
             || needs.typeguard.result == 'failure'
             || needs.typed-argument-parser.result == 'failure'
             || needs.stubtest.result == 'failure'
+            || needs.cattrs.result == 'failure'
           )
         }}
 

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -1,18 +1,17 @@
-# This workflow is a daily cron job.
-# As well as running our own tests,
-# we also run the tests of various third-party libraries that use us.
+# This workflow is a daily cron job,
+# running the tests of various third-party libraries that use us.
 # This helps us spot regressions early,
 # and helps flag when third-party libraries are making incorrect assumptions
 # that might cause them to break when we cut a new release.
 
-name: Daily tests
+name: Third-party tests
 
 on:
   schedule:
     - cron: "30 2 * * *"  # 02:30 UTC
   pull_request:
     paths:
-      - ".github/workflows/daily.yml"
+      - ".github/workflows/third_party.yml"
   workflow_dispatch:
 
 permissions:
@@ -27,46 +26,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  typing-extensions:
-    name: Run our own tests
-    # Only run if 'schedule' was the trigger,
-    # and we're not running on a fork
-    if: >-
-      ${{
-        github.repository == 'python/typing_extensions'
-        && github.event_name == 'schedule'
-      }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version:
-          - "3.7"
-          - "3.7.1"
-          - "3.8"
-          - "3.8.0"
-          - "3.9"
-          - "3.9.0"
-          - "3.10"
-          - "3.10.0"
-          - "3.11"
-          - "3.11.0"
-          - "3.12"
-          - "pypy3.9"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
-      - name: Test typing_extensions
-        run: |
-          # Be wary of running `pip install` here, since it becomes easy for us to
-          # accidentally pick up typing_extensions as installed by a dependency
-          cd src
-          python -m unittest test_typing_extensions.py
-
   pydantic:
     name: pydantic tests
     if: >-
@@ -353,8 +312,7 @@ jobs:
           && always()
           && github.event_name == 'schedule'
           && (
-            needs.typing-extensions == 'failure'
-            || needs.pydantic.result == 'failure'
+            needs.pydantic.result == 'failure'
             || needs.typing_inspect.result == 'failure'
             || needs.pyanalyze.result == 'failure'
             || needs.typeguard.result == 'failure'
@@ -375,6 +333,6 @@ jobs:
             await github.rest.issues.create({
               owner: "python",
               repo: "typing_extensions",
-              title: `Daily tests failed on ${new Date().toDateString()}`,
-              body: "Runs listed here: https://github.com/python/typing_extensions/actions/workflows/daily.yml",
+              title: `Third-party tests failed on ${new Date().toDateString()}`,
+              body: "Runs listed here: https://github.com/python/typing_extensions/actions/workflows/third_party.yml",
             })

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -297,7 +297,6 @@ jobs:
     runs-on: ubuntu-latest
 
     needs:
-      - typing-extensions
       - pydantic
       - typing_inspect
       - pyanalyze


### PR DESCRIPTION
Fixes #198.

As well as the packages suggested by Jelle in #198, I also added `typeguard` and `cattrs`. Both are popular packages that use `typing_extensions` extensively. `typeguard`, as you can see by the CI on this PR, is currently broken by the same change that broke `pydantic`, `typing_inspect` and `typed-argument-parse` (reimplementing `Literal` on 3.8 and 3.9, as well as 3.7). `cattrs` wasn't broken by v4.6.0, but given the way they're peering into our internals, it wouldn't surprise me if we broke them at some point.

Note that while the `typeguard` failures show the usefulness of having a CI job like this, the `typed-argument-parser` tests are currently passing despite us [apparently having broken them](https://github.com/swansonk14/typed-argument-parser/issues/106). That shows the limits of a CI job like this: we're dependent on third-party projects having reasonable test coverage, or this won't help us much.

I didn't include `beartype`, as their CI is currently failing on their `main` branch, their CI setup is somewhat complicated, and they don't fully support `typing_extensions` anyway.

My thinking is that if a third-party test starts failing:
- If we're not "at fault" (e.g. the `Literal` change), we immediately skip the test in CI, open an issue over at the third-party project, and unskip the test as soon as the issue is fixed in the third-party project. A release shouldn't necessarily be considered blocked if a test is skipped, but we should at least make the third-party project aware of the breakage before the release, and give them a reasonable amount of time to fix it before we cut a release.
- If it is a regression on our side, we also immediately skip the test in CI, but a release is considered blocked until the regression is fixed and the test can be unskipped.