### PR TITLE
Allow Protocols to inherit from typing_extensions.Buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Fix tests on Python 3.13, which removes support for creating
   `TypedDict` classes through the keyword-argument syntax. Patch by
   Jelle Zijlstra.
+- Allow `Protocol` classes to inherit from `typing_extensions.Buffer`. Patch by
+  Alex Waygood (backporting https://github.com/python/cpython/pull/104827, by
+  Jelle Zijlstra).
 
 # Release 4.6.3 (June 1, 2023)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -2745,6 +2745,23 @@ class ProtocolTests(BaseTestCase):
         class CustomContextManager(typing.ContextManager, Protocol):
             pass
 
+    def test_typing_extensions_protocol_allowlist(self):
+        @runtime_checkable
+        class ReleasableBuffer(Buffer, Protocol):
+            def __release_buffer__(self, mv: memoryview) -> None: ...
+
+        class C: pass
+        class D:
+            def __buffer__(self, flags: int) -> memoryview:
+                return memoryview(b'')
+            def __release_buffer__(self, mv: memoryview) -> None:
+                pass
+
+        self.assertIsSubclass(D, ReleasableBuffer)
+        self.assertIsInstance(D(), ReleasableBuffer)
+        self.assertNotIsSubclass(C, ReleasableBuffer)
+        self.assertNotIsInstance(C(), ReleasableBuffer)
+
     def test_non_runtime_protocol_isinstance_check(self):
         class P(Protocol):
             x: int

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -456,6 +456,7 @@ _PROTO_ALLOWLIST = {
         'Hashable', 'Sized', 'Container', 'Collection', 'Reversible',
     ],
     'contextlib': ['AbstractContextManager', 'AbstractAsyncContextManager'],
+    'typing_extensions': ['Buffer'],
 }
 
 


### PR DESCRIPTION
Backport of https://github.com/python/cpython/pull/104827