### PR TITLE
Skip cattrs tests on 3.8

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -298,7 +298,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        # TODO: Add 3.8 back to this matrix (see #230)
+        python-version: ["3.7", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
I haven't had a chance to look into the exact cause of the failures in #230, but here's a stopgap PR