### PR TITLE
Allow typing_extensions.Protocol and typing.Protocol to mix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@
 - Allow `Protocol` classes to inherit from `typing_extensions.Buffer` or
   `collections.abc.Buffer`. Patch by Alex Waygood (backporting
   https://github.com/python/cpython/pull/104827, by Jelle Zijlstra).
-- Allow classes to have both `typing.Protocol` and `typing_extensions.Protocol`
-  in their mro. Since v4.6.0, this caused `TypeError` to be raised due to a
+- Allow classes to inherit from both `typing.Protocol` and `typing_extensions.Protocol`
+  simultaneously. Since v4.6.0, this caused `TypeError` to be raised due to a
   metaclass conflict. Patch by Alex Waygood.
 
 # Release 4.6.3 (June 1, 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 - Allow `Protocol` classes to inherit from `typing_extensions.Buffer` or
   `collections.abc.Buffer`. Patch by Alex Waygood (backporting
   https://github.com/python/cpython/pull/104827, by Jelle Zijlstra).
+- Allow classes to have both `typing.Protocol` and `typing_extensions.Protocol`
+  in their mro. Since v4.6.0, this cause `TypeError` to be raised due to a
+  metaclass conflict. Patch by Alex Waygood.
 
 # Release 4.6.3 (June 1, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
   `collections.abc.Buffer`. Patch by Alex Waygood (backporting
   https://github.com/python/cpython/pull/104827, by Jelle Zijlstra).
 - Allow classes to have both `typing.Protocol` and `typing_extensions.Protocol`
-  in their mro. Since v4.6.0, this cause `TypeError` to be raised due to a
+  in their mro. Since v4.6.0, this caused `TypeError` to be raised due to a
   metaclass conflict. Patch by Alex Waygood.
 
 # Release 4.6.3 (June 1, 2023)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -284,8 +284,8 @@ Special typing primitives
 
    .. versionchanged:: 4.7.0
 
-      Classes can now have both :py:class:`typing.Protocol` and
-      ``typing_extensions.Protocol`` in their mro. Previously, this led to
+      Classes can now inherit from both :py:class:`typing.Protocol` and
+      ``typing_extensions.Protocol`` simultaneously. Previously, this led to
       :py:exc:`TypeError` being raised due to a metaclass conflict.
 
 .. data:: Required

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -282,6 +282,12 @@ Special typing primitives
       Backported changes to runtime-checkable protocols from Python 3.12,
       including :pr-cpy:`103034` and :pr-cpy:`26067`.
 
+   .. versionchanged:: 4.7.0
+
+      Classes can now have both :py:class:`typing.Protocol` and
+      ``typing_extensions.Protocol`` in their mro. Previously, this led to
+      :py:exc:`TypeError` being raised due to a metaclass conflict.
+
 .. data:: Required
 
    See :py:data:`typing.Required` and :pep:`655`. In ``typing`` since 3.11.

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -1799,6 +1799,23 @@ class ProtocolTests(BaseTestCase):
         self.assertIsInstance(Bar(), Foo)
         self.assertNotIsInstance(object(), Foo)
 
+    @skipUnless(
+        hasattr(typing, "Protocol"),
+        "Test is only relevant if typing.Protocol exists"
+    )
+    def test_typing_Protocol_and_extensions_Protocol_can_mix(self):
+        class TypingProto(typing.Protocol):
+            x: int
+
+        class ExtensionsProto(Protocol):
+            y: int
+
+        class Subclass1(TypingProto, ExtensionsProto, typing.Protocol):
+            z: int
+
+        class Subclass2(TypingProto, ExtensionsProto, Protocol):
+            z: int
+
     def test_no_instantiation(self):
         class P(Protocol): pass
         with self.assertRaises(TypeError):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -1816,8 +1816,16 @@ class ProtocolTests(BaseTestCase):
         class SubProto2(TypingProto, ExtensionsProto, Protocol):
             z: int
 
+        class SubProto3(ExtensionsProto, TypingProto, typing.Protocol):
+            z: int
+
+        class SubProto4(ExtensionsProto, TypingProto, Protocol):
+            z: int
+
         class Concrete(SubProto): pass
         class Concrete2(SubProto2): pass
+        class Concrete3(SubProto3): pass
+        class Concrete4(SubProto4): pass
 
     def test_no_instantiation(self):
         class P(Protocol): pass

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -1810,11 +1810,14 @@ class ProtocolTests(BaseTestCase):
         class ExtensionsProto(Protocol):
             y: int
 
-        class Subclass1(TypingProto, ExtensionsProto, typing.Protocol):
+        class SubProto(TypingProto, ExtensionsProto, typing.Protocol):
             z: int
 
-        class Subclass2(TypingProto, ExtensionsProto, Protocol):
+        class SubProto2(TypingProto, ExtensionsProto, Protocol):
             z: int
+
+        class Concrete(SubProto): pass
+        class Concrete2(SubProto2): pass
 
     def test_no_instantiation(self):
         class P(Protocol): pass

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -601,7 +601,7 @@ else:
         # but is necessary to allow typing.Protocol and typing_extensions.Protocol
         # to mix without getting TypeErrors about "metaclass conflict"
         _typing_Protocol = typing.Protocol
-        _ProtocolBase = type(_typing_Protocol)
+        _ProtocolMetaBase = type(_typing_Protocol)
 
         def _is_protocol(cls):
             return (
@@ -611,7 +611,7 @@ else:
             )
     else:
         _typing_Protocol = _marker
-        _ProtocolBase = abc.ABCMeta
+        _ProtocolMetaBase = abc.ABCMeta
 
         def _is_protocol(cls):
             return (
@@ -619,7 +619,7 @@ else:
                 and getattr(cls, "_is_protocol", False)
             )
 
-    class _ProtocolMeta(_ProtocolBase):
+    class _ProtocolMeta(_ProtocolMetaBase):
         # This metaclass is somewhat unfortunate,
         # but is necessary for several reasons...
         #

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -596,30 +596,52 @@ else:
         if type(self)._is_protocol:
             raise TypeError('Protocols cannot be instantiated')
 
-    class _ProtocolMeta(abc.ABCMeta):
+    if sys.version_info >= (3, 8):
+        # Inheriting from typing._ProtocolMeta isn't actually desirable,
+        # but is necessary to allow typing.Protocol and typing_extensions.Protocol
+        # to mix without getting TypeErrors about "metaclass conflict"
+        _ProtocolBase = type(typing.Protocol)
+
+        def _is_protocol(cls):
+            return (
+                isinstance(cls, type)
+                and issubclass(cls, typing.Generic)
+                and getattr(cls, "_is_protocol", False)
+            )
+    else:
+        _ProtocolBase = abc.ABCMeta
+
+        def _is_protocol(cls):
+            return (
+                isinstance(cls, _ProtocolMeta)
+                and getattr(cls, "_is_protocol", False)
+            )
+
+    class _ProtocolMeta(_ProtocolBase):
         # This metaclass is somewhat unfortunate,
         # but is necessary for several reasons...
+        #
+        # NOTE: DO NOT call super() in any methods in this class
+        # That would call the methods on typing._ProtocolMeta on Python 3.8-3.11
+        # and those are slow
         def __new__(mcls, name, bases, namespace, **kwargs):
             if name == "Protocol" and len(bases) < 2:
                 pass
-            elif Protocol in bases:
+            elif Protocol in bases or getattr(typing, "Protocol", _marker) in bases:
                 for base in bases:
                     if not (
                         base in {object, typing.Generic}
                         or base.__name__ in _PROTO_ALLOWLIST.get(base.__module__, [])
-                        or (
-                            isinstance(base, _ProtocolMeta)
-                            and getattr(base, "_is_protocol", False)
-                        )
+                        or _is_protocol(base)
                     ):
                         raise TypeError(
                             f"Protocols can only inherit from other protocols, "
                             f"got {base!r}"
                         )
-            return super().__new__(mcls, name, bases, namespace, **kwargs)
+            return abc.ABCMeta.__new__(mcls, name, bases, namespace, **kwargs)
 
         def __init__(cls, *args, **kwargs):
-            super().__init__(*args, **kwargs)
+            abc.ABCMeta.__init__(cls, *args, **kwargs)
             if getattr(cls, "_is_protocol", False):
                 cls.__protocol_attrs__ = _get_protocol_attrs(cls)
                 # PEP 544 prohibits using issubclass()
@@ -647,7 +669,7 @@ else:
                         "Instance and class checks can only be used with "
                         "@runtime_checkable protocols"
                     )
-            return super().__subclasscheck__(other)
+            return abc.ABCMeta.__subclasscheck__(cls, other)
 
         def __instancecheck__(cls, instance):
             # We need this method for situations where attributes are
@@ -656,7 +678,7 @@ else:
                 return type.__instancecheck__(cls, instance)
             if not getattr(cls, "_is_protocol", False):
                 # i.e., it's a concrete subclass of a protocol
-                return super().__instancecheck__(instance)
+                return abc.ABCMeta.__instancecheck__(cls, instance)
 
             if (
                 not getattr(cls, '_is_runtime_protocol', False) and
@@ -665,7 +687,7 @@ else:
                 raise TypeError("Instance and class checks can only be used with"
                                 " @runtime_checkable protocols")
 
-            if super().__instancecheck__(instance):
+            if abc.ABCMeta.__instancecheck__(cls, instance):
                 return True
 
             for attr in cls.__protocol_attrs__:
@@ -684,7 +706,7 @@ else:
             # Hack so that typing.Generic.__class_getitem__
             # treats typing_extensions.Protocol
             # as equivalent to typing.Protocol on Python 3.8+
-            if super().__eq__(other) is True:
+            if abc.ABCMeta.__eq__(cls, other) is True:
                 return True
             return (
                 cls is Protocol and other is getattr(typing, "Protocol", object())

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -600,7 +600,8 @@ else:
         # Inheriting from typing._ProtocolMeta isn't actually desirable,
         # but is necessary to allow typing.Protocol and typing_extensions.Protocol
         # to mix without getting TypeErrors about "metaclass conflict"
-        _ProtocolBase = type(typing.Protocol)
+        _typing_Protocol = typing.Protocol
+        _ProtocolBase = type(_typing_Protocol)
 
         def _is_protocol(cls):
             return (
@@ -609,6 +610,7 @@ else:
                 and getattr(cls, "_is_protocol", False)
             )
     else:
+        _typing_Protocol = _marker
         _ProtocolBase = abc.ABCMeta
 
         def _is_protocol(cls):
@@ -627,7 +629,7 @@ else:
         def __new__(mcls, name, bases, namespace, **kwargs):
             if name == "Protocol" and len(bases) < 2:
                 pass
-            elif Protocol in bases or getattr(typing, "Protocol", _marker) in bases:
+            elif {Protocol, _typing_Protocol} & set(bases):
                 for base in bases:
                     if not (
                         base in {object, typing.Generic}


### PR DESCRIPTION
Fixes #236.

I don't really like this patch; it feels like it makes the code hackier and more fragile, and I'm not sure what the use case is. I feel like I'd prefer to just document that you can't mix the two `Protocol` versions. This is just a proof of concept to show how it could be fixed.