### PR TITLE
Add a few more tests for interactions between `typing.Protocol` and `typing_extensions.Protocol`

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -1842,7 +1842,7 @@ class ProtocolTests(BaseTestCase):
             with self.subTest(cls=cls.__name__):
                 self.assertFalse(is_protocol(cls))
                 # Check that this doesn't raise:
-                cls()
+                self.assertIsInstance(cls(), cls)
                 with self.assertRaises(TypeError):
                     runtime_checkable(cls)
                 with self.assertRaises(TypeError):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -1829,6 +1829,9 @@ class ProtocolTests(BaseTestCase):
                     TypeError, "Protocols cannot be instantiated"
                 ):
                     proto()
+                # check these don't raise
+                runtime_checkable(proto)
+                typing.runtime_checkable(proto)
 
         class Concrete(SubProto): pass
         class Concrete2(SubProto2): pass
@@ -1840,6 +1843,10 @@ class ProtocolTests(BaseTestCase):
                 self.assertFalse(is_protocol(cls))
                 # Check that this doesn't raise:
                 cls()
+                with self.assertRaises(TypeError):
+                    runtime_checkable(cls)
+                with self.assertRaises(TypeError):
+                    typing.runtime_checkable(cls)
 
     def test_no_instantiation(self):
         class P(Protocol): pass

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -1822,7 +1822,8 @@ class ProtocolTests(BaseTestCase):
         ):
             with self.subTest(proto=proto.__name__):
                 self.assertTrue(is_protocol(proto))
-                self.assertIsInstance(proto, typing_extensions._ProtocolMeta)
+                if Protocol is not typing.Protocol:
+                    self.assertIsInstance(proto, typing_extensions._ProtocolMeta)
                 self.assertIsInstance(proto.__protocol_attrs__, set)
                 with self.assertRaisesRegex(
                     TypeError, "Protocols cannot be instantiated"

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -1817,10 +1817,28 @@ class ProtocolTests(BaseTestCase):
         class SubProto4(ExtensionsProto, TypingProto, Protocol):
             z: int
 
+        for proto in (
+            ExtensionsProto, SubProto, SubProto2, SubProto3, SubProto4
+        ):
+            with self.subTest(proto=proto.__name__):
+                self.assertTrue(is_protocol(proto))
+                self.assertIsInstance(proto, typing_extensions._ProtocolMeta)
+                self.assertIsInstance(proto.__protocol_attrs__, set)
+                with self.assertRaisesRegex(
+                    TypeError, "Protocols cannot be instantiated"
+                ):
+                    proto()
+
         class Concrete(SubProto): pass
         class Concrete2(SubProto2): pass
         class Concrete3(SubProto3): pass
         class Concrete4(SubProto4): pass
+
+        for cls in Concrete, Concrete2, Concrete3, Concrete4:
+            with self.subTest(cls=cls.__name__):
+                self.assertFalse(is_protocol(cls))
+                # Check that this doesn't raise:
+                cls()
 
     def test_no_instantiation(self):
         class P(Protocol): pass


### PR DESCRIPTION
I was looking at lines like these:

https://github.com/python/typing_extensions/blob/af89916a21b0b720b413e5618dd119f55c53f7b7/src/typing_extensions.py#L747-L749

https://github.com/python/typing_extensions/blob/af89916a21b0b720b413e5618dd119f55c53f7b7/src/typing_extensions.py#L759-L761

And realised that I wasn't at all sure how the interaction between `typing.Protocol.__init_subclass__` and `typing_extensions.Protocol.__init_subclass__` would work out. It _looks_ to me like it's fine, but I thought a few extra tests might be good anyway.