### PR TITLE
Don't clobber user-defined `__init__` methods on protocol classes, even when `typing.Protocol` is in the mro

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -1879,6 +1879,24 @@ class ProtocolTests(BaseTestCase):
         P.__init__(c, 1)
         self.assertEqual(c.x, 1)
 
+    @only_with_typing_Protocol
+    def test_protocol_defining_init_does_not_get_overridden_2(self):
+        # Same as the test immediately above,
+        # but typing.Protocol is also in the mro
+
+        class P(typing.Protocol): pass
+
+        class Q(P, Protocol):
+            x: int
+            def __init__(self, x: int) -> None:
+                self.x = x
+
+        class C: pass
+
+        c = C()
+        Q.__init__(c, 1)
+        self.assertEqual(c.x, 1)
+
     def test_concrete_class_inheriting_init_from_protocol(self):
         class P(Protocol):
             x: int
@@ -1890,6 +1908,24 @@ class ProtocolTests(BaseTestCase):
         c = C(1)
         self.assertIsInstance(c, C)
         self.assertEqual(c.x, 1)
+
+    @only_with_typing_Protocol
+    def test_concrete_class_inheriting_init_from_protocol_2(self):
+        # Same as the test immediately above,
+        # but typing.Protocol is also in the mro
+
+        class P(typing.Protocol): pass
+
+        class Q(P, Protocol):
+            x: int
+            def __init__(self, x: int) -> None:
+                self.x = x
+
+        class C(Q): pass
+
+        c = C(1)
+        self.assertIsInstance(c, C)
+        self.assertEqual(C(1).x, 1)
 
     def test_cannot_instantiate_abstract(self):
         @runtime_checkable


### PR DESCRIPTION
Rather than trying to stop `typing.Protocol.__init_subclass__` from replacing the `__init__` method on a user-defined protocol, we let it go ahead with that. We just swap it back after `typing.Protocol.__init_subclass__` has done so, to what the `__init__` method was before.

The "fun" thing here is that we have to be able to figure out what the class's `__init__` method is going to be before the class has actually been created. That requires knowing what the class's mro will be before it's been created. I used Steven D'Aprano's recipe here to accomplish this: https://code.activestate.com/recipes/577748-calculate-the-mro-of-a-class/.

This PR fixes the first problem I mentioned in #245. (I think we should still keep the docs note I added in #246, though -- the second problem I mentioned in #246 still exists, and in general it feels kind of unpredictable what kinds of issues might arise from mixing the two `Protocol` implementations.)

In general, while it was fun to write this PR, I'm not sure the extra complexity is actually worth it here, since this is something of an edge-case bug. (Adding this much complexity to the protocol-class creation process could definitely just lead to more bugs!)

Feedback is very much welcome. I think I definitely don't have enough tests right now.