### PR TITLE
Run some mypyc tests in the third-party workflow

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -247,8 +247,8 @@ jobs:
           cd typed-argument-parser
           pytest
 
-  stubtest:
-    name: stubtest tests
+  mypy:
+    name: stubtest & mypyc tests
     if: >-
       # if 'schedule' was the trigger,
       # don't run it on contributors' forks
@@ -266,7 +266,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - name: Checkout mypy for stubtest tests
+      - name: Checkout mypy for stubtest and mypyc tests
         uses: actions/checkout@v3
         with:
           repository: python/mypy
@@ -288,10 +288,10 @@ jobs:
         run: pip install ./typing-extensions-latest
       - name: List all installed dependencies
         run: pip freeze --all
-      - name: Run stubtest tests
+      - name: Run stubtest & mypyc tests
         run: |
           cd mypy
-          pytest ./mypy/test/teststubtest.py
+          pytest -n 2 ./mypy/test/teststubtest.py ./mypyc/test/test_run.py ./mypyc/test/test_external.py
 
   cattrs:
     name: cattrs tests
@@ -347,7 +347,7 @@ jobs:
       - pyanalyze
       - typeguard
       - typed-argument-parser
-      - stubtest
+      - mypy
       - cattrs
 
     if: >-
@@ -361,7 +361,7 @@ jobs:
             || needs.pyanalyze.result == 'failure'
             || needs.typeguard.result == 'failure'
             || needs.typed-argument-parser.result == 'failure'
-            || needs.stubtest.result == 'failure'
+            || needs.mypy.result == 'failure'
             || needs.cattrs.result == 'failure'
           )
         }}


### PR DESCRIPTION
We unexpectedly broke mypyc on Python 3.7 with the 4.7.0 release (https://github.com/python/mypy/issues/15542). Let's run some mypyc tests as part of the third-party workflow, to reduce the risk of that happening again withour prior warning.