### PR TITLE
Fix third-party workflow

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -49,6 +49,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: pydantic/pydantic
+      - name: Edit pydantic pyproject.toml
+        # pydantic's python-requires means pdm won't let us add typing-extensions-latest
+        # as a requirement unless we do this
+        run: sed -i 's/^requires-python = .*/requires-python = ">=3.8"/' pyproject.toml
       - name: Checkout typing_extensions
         uses: actions/checkout@v3
         with:
@@ -316,6 +320,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: python-attrs/cattrs
+      - name: Edit cattrs pyproject.toml
+        # cattrs's python-requires means pdm won't let us add typing-extensions-latest
+        # as a requirement unless we do this
+        run: sed -i 's/^requires-python = .*/requires-python = ">=3.8"/' pyproject.toml
       - name: Checkout typing_extensions
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
pdm now won't let us add the `main` branch of typing_extensions as a dependency to pydantic or cattrs, because they both still have `requires-python = ">= 3.7"` in their pyproject.toml files, and we now have `requires-python = ">= 3.8"` in ours. To me it seems silly that pdm's locking mechanism is working this way, since we're not trying to actually install or run pydantic or cattrs on Python 3.7. But anyway, here's a hacky workaround to get things green again.

Fixes #268