### PR TITLE
Revert "Skip running `cattrs` tests on PyPy (#272)"

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -312,9 +312,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Add pypy3.9 back to this matrix
-        # After PyYAML/PyPy issues are fixed (see #271)
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy3.9"]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
This reverts commit 8dfa0a5dc31b298252d001304b9107be76e4de4c.

It seems like the PyYAML/PyPy issues either got fixed or fixed themselves (I didn't investigate too deeply).