### PR TITLE
Run tests on py312 for more third-party projects

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -128,7 +128,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -145,6 +145,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install pyanalyze test requirements
         run: pip install ./pyanalyze[tests]
       - name: Install typing_extensions latest
@@ -266,7 +267,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -283,6 +284,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install mypy test requirements
         run: |
           cd mypy
@@ -312,7 +314,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.9"]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -332,6 +334,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install pdm for cattrs
         run: pip install pdm
       - name: Add latest typing-extensions as a dependency

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -322,10 +322,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: python-attrs/cattrs
-      - name: Edit cattrs pyproject.toml
-        # cattrs's python-requires means pdm won't let us add typing-extensions-latest
-        # as a requirement unless we do this
-        run: sed -i 's/^requires-python = .*/requires-python = ">=3.8"/' pyproject.toml
       - name: Checkout typing_extensions
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -314,7 +314,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy3.9"]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -330,7 +330,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
       - name: Install pdm for cattrs
         run: pip install pdm
       - name: Add latest typing-extensions as a dependency


### PR DESCRIPTION
~~cattrs,~~ mypy and pyanalyze all now support Python 3.12, and run tests on Python 3.12 in CI.

Also, get rid of a hack that's no longer necessary for running the cattrs tests, since cattrs now requires Python 3.8+