### PR TITLE
Make `NewType.__call__` params positional-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 4.9.0
+# Release 4.9.0 (???)
 
 - All parameters on `NewType.__call__` are now positional-only. This means that
   the signature of `typing_extensions.NewType.__call__` now exactly matches the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Release 4.9.0
+
+- All parameters on `NewType.__call__` are now positional-only. This means that
+  the signature of `typing_extensions.NewType.__call__` now exactly matches the
+  signature of `typing.NewType.__call__`. Patch by Alex Waygood.
+
 # Release 4.8.0 (September 17, 2023)
 
 No changes since 4.8.0rc1.

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2600,7 +2600,7 @@ else:
             num = UserId(5) + 1     # type: int
         """
 
-        def __call__(self, obj):
+        def __call__(self, obj, /):
             return obj
 
         def __init__(self, name, tp):


### PR DESCRIPTION
This is really minor, but it means that the signature of `typing_extensions.NewType.__call__` exactly matches that of `typing.NewType.__call__` on all Python versions we support:

```pycon
Python 3.8.16 (default, Mar  2 2023, 03:18:16) [MSC v.1916 64 bit (AMD64)] :: Anaconda, Inc. on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from typing import NewType
>>> x = NewType("x", int)
>>> x(obj=42)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: new_type() got an unexpected keyword argument 'obj'
```

```pycon
Python 3.10.8 | packaged by conda-forge | (main, Nov 24 2022, 14:07:00) [MSC v.1916 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> x = NewType("x", int)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'NewType' is not defined
>>> from typing import NewType
>>> x = NewType("x", int)
>>> x(obj=42)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: NewType.__call__() got an unexpected keyword argument 'obj'
```