### PR TITLE
Fix runtime behaviour of PEP 696

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix the runtime behavior of type parameters with defaults (PEP 696).
+  Patch by Nadir Chowdhury.
 - Fix minor discrepancy between error messages produced by `typing`
   and `typing_extensions` on Python 3.10. Patch by Jelle Zijlstra.
 - When `include_extra=False`, `get_type_hints()` now strips `ReadOnly` from the annotation.

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5605,6 +5605,23 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         class A(Generic[Unpack[Ts]]): ...
         Alias = Optional[Unpack[Ts]]
 
+    def test_erroneous_generic(self):
+        DefaultStrT = TypeVar('DefaultStrT', default=str)
+        T = TypeVar('T')
+
+        with self.assertRaises(TypeError):
+            Test = Generic[DefaultStrT, T]
+
+    def test_need_more_params(self):
+        DefaultStrT = typing_extensions.TypeVar('DefaultStrT', default=str)
+        T = typing_extensions.TypeVar('T')
+        U = typing_extensions.TypeVar('U')
+
+        class A(Generic[T, U, DefaultStrT]): ...
+
+        with self.assertRaises(TypeError):
+            Test = A[int]
+
     def test_pickle(self):
         global U, U_co, U_contra, U_default  # pickle wants to reference the class by name
         U = typing_extensions.TypeVar('U')

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3262,10 +3262,7 @@ class ProtocolTests(BaseTestCase):
         self.assertEqual(MemoizedFunc.__parameters__, (Ts, T, T2))
         self.assertTrue(MemoizedFunc._is_protocol)
 
-        # 3.11+ moves where this exception is thrown
-        # 3.11: TypeVarTuple.__typing_prepare_subst__
-        # 3.12+: typing._typevartuple_prepare_subst
-        things = "arguments" if sys.version_info >= (3, 11) else "parameters"
+        things = "arguments"
 
         # A bug was fixed in 3.11.1
         # (https://github.com/python/cpython/commit/74920aa27d0c57443dd7f704d6272cca9c507ab3)
@@ -5714,7 +5711,7 @@ class NamedTupleTests(BaseTestCase):
                 self.assertIsInstance(a, G)
                 self.assertEqual(a.x, 3)
 
-                with self.assertRaisesRegex(TypeError, 'Too many parameters'):
+                with self.assertRaisesRegex(TypeError, 'Too many arguments'):
                     G[int, str]
 
     @skipUnless(TYPING_3_9_0, "tuple.__class_getitem__ was added in 3.9")
@@ -6229,8 +6226,12 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         U = typing_extensions.TypeVar('U')
 
         class A(Generic[T, U, DefaultStrT]): ...
+        A[int, bool]
+        A[int, bool, str]
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(
+            TypeError, "Too few arguments for .+; actual 1, expected at least 2"
+        ):
             Test = A[int]
 
     def test_pickle(self):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3262,14 +3262,12 @@ class ProtocolTests(BaseTestCase):
         self.assertEqual(MemoizedFunc.__parameters__, (Ts, T, T2))
         self.assertTrue(MemoizedFunc._is_protocol)
 
-        things = "arguments"
-
         # A bug was fixed in 3.11.1
         # (https://github.com/python/cpython/commit/74920aa27d0c57443dd7f704d6272cca9c507ab3)
         # That means this assertion doesn't pass on 3.11.0,
         # but it passes on all other Python versions
         if sys.version_info[:3] != (3, 11, 0):
-            with self.assertRaisesRegex(TypeError, f"Too few {things}"):
+            with self.assertRaisesRegex(TypeError, "Too few arguments"):
                 MemoizedFunc[int]
 
         X = MemoizedFunc[int, T, T2]

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6230,7 +6230,7 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         A[int, bool, str]
 
         with self.assertRaises(
-            TypeError, "Too few arguments for .+; actual 1, expected at least 2"
+            TypeError, msg="Too few arguments for .+; actual 1, expected at least 2"
         ):
             Test = A[int]
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5714,7 +5714,7 @@ class NamedTupleTests(BaseTestCase):
                 self.assertIsInstance(a, G)
                 self.assertEqual(a.x, 3)
 
-                with self.assertRaisesRegex(TypeError, f'Too many parameters'):
+                with self.assertRaisesRegex(TypeError, 'Too many parameters'):
                     G[int, str]
 
     @skipUnless(TYPING_3_9_0, "tuple.__class_getitem__ was added in 3.9")

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3096,6 +3096,9 @@ class ProtocolTests(BaseTestCase):
         self.assertEqual(MemoizedFunc.__parameters__, (Ts, T, T2))
         self.assertTrue(MemoizedFunc._is_protocol)
 
+        # 3.11+ moves where this exception is thrown
+        # 3.11: TypeVarTuple.__typing_prepare_subst__
+        # 3.12+: typing._typevartuple_prepare_subst
         things = "arguments" if sys.version_info >= (3, 11) else "parameters"
 
         # A bug was fixed in 3.11.1
@@ -5231,9 +5234,7 @@ class NamedTupleTests(BaseTestCase):
                 self.assertIsInstance(a, G)
                 self.assertEqual(a.x, 3)
 
-                things = "arguments" if sys.version_info >= (3, 11) else "parameters"
-
-                with self.assertRaisesRegex(TypeError, f'Too many {things}'):
+                with self.assertRaisesRegex(TypeError, f'Too many parameters'):
                     G[int, str]
 
     @skipUnless(TYPING_3_9_0, "tuple.__class_getitem__ was added in 3.9")
@@ -5606,7 +5607,7 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         Alias = Optional[Unpack[Ts]]
 
     def test_erroneous_generic(self):
-        DefaultStrT = TypeVar('DefaultStrT', default=str)
+        DefaultStrT = typing_extensions.TypeVar('DefaultStrT', default=str)
         T = TypeVar('T')
 
         with self.assertRaises(TypeError):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2700,9 +2700,6 @@ else:
             expect_val = elen
             if hasattr(cls, "__parameters__"):
                 parameters = [p for p in cls.__parameters__ if not _is_unpack(p)]
-                num_tv_tuples = sum(isinstance(p, TypeVarTuple) for p in parameters)
-                if (num_tv_tuples > 0) and (alen >= elen - num_tv_tuples):
-                    return
 
                 # deal with TypeVarLike defaults
                 # required TypeVarLikes cannot appear after a defaulted one.
@@ -2788,9 +2785,9 @@ else:
 
                     parameters.append(t)
             else:
-                if _should_collect_from_parameters(t):
-                    parameters.extend(
-                        [t for t in t.__parameters__ if t not in parameters])
+                for x in getattr(t, '__parameters__', ()):
+                    if x not in parameters:
+                        parameters.append(x)
 
         return tuple(parameters)
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2682,7 +2682,8 @@ if not hasattr(typing, "TypeVarTuple"):
 
                     expect_val = f"at least {elen}"
 
-            raise TypeError(f"Too {'many' if alen > elen else 'few'} arguments"
+            things = "arguments" if sys.version_info >= (3, 10) else "parameters"
+            raise TypeError(f"Too {'many' if alen > elen else 'few'} {things}"
                             f" for {cls}; actual {alen}, expected {expect_val}")
 else:
     # Python 3.11+

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2357,13 +2357,13 @@ if not hasattr(typing, "TypeVarTuple"):
                 # deal with TypeVarLike defaults
                 # required TypeVarLikes cannot appear after a defaulted one.
                 if alen < elen:
-                    # since we validate TypeVarLike default in _collect_type_vars / _collect_parameters
-                    # we can safely check parameters[alen]
+                    # since we validate TypeVarLike default in _collect_type_vars
+                    # or _collect_parameters we can safely check parameters[alen]
                     if getattr(parameters[alen], '__default__', None) is not None:
                         return
 
-            raise TypeError(f"Too {'many' if alen > elen else 'few'} parameters for {cls};"
-                            f" actual {alen}, expected {elen}")
+            raise TypeError(f"Too {'many' if alen > elen else 'few'} parameters"
+                            f" for {cls}; actual {alen}, expected {elen}")
 
     typing._check_generic = _check_generic
 else:
@@ -2387,13 +2387,13 @@ else:
                 # deal with TypeVarLike defaults
                 # required TypeVarLikes cannot appear after a defaulted one.
                 if alen < elen:
-                    # since we validate TypeVarLike default in _collect_type_vars / _collect_parameters
-                    # we can safely check parameters[alen]
+                    # since we validate TypeVarLike default in _collect_type_vars
+                    # or _collect_parameters we can safely check parameters[alen]
                     if getattr(parameters[alen], '__default__', None) is not None:
                         return
 
-            raise TypeError(f"Too {'many' if alen > elen else 'few'} arguments for {cls};"
-                            f" actual {alen}, expected {elen}")
+            raise TypeError(f"Too {'many' if alen > elen else 'few'} parameters"
+                            f" for {cls}; actual {alen}, expected {elen}")
 
     typing._check_generic = _check_generic
 
@@ -2457,12 +2457,14 @@ else:
                         if not default_encountered:
                             default_encountered = True
                     elif default_encountered:
-                        raise TypeError(f'expected TypeVar with default type, found {t!r}')
+                        raise TypeError('expected TypeVar with default type, found'
+                                        f' {t!r}')
 
                     parameters.append(t)
             else:
                 if _should_collect_from_parameters(t):
-                    parameters.extend([t for t in t.__parameters__ if t not in parameters])
+                    parameters.extend(
+                        [t for t in t.__parameters__ if t not in parameters])
 
         return tuple(parameters)
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -158,27 +158,6 @@ else:
         return isinstance(t, typing._GenericAlias) and not t._special
 
 
-def _collect_type_vars(types, typevar_types=None):
-    """Collect all type variable contained in types in order of
-    first appearance (lexicographic order). For example::
-
-        _collect_type_vars((T, List[S, T])) == (T, S)
-    """
-    if typevar_types is None:
-        typevar_types = typing.TypeVar
-    tvars = []
-    for t in types:
-        if (
-            isinstance(t, typevar_types) and
-            t not in tvars and
-            not _is_unpack(t)
-        ):
-            tvars.append(t)
-        if _should_collect_from_parameters(t):
-            tvars.extend([t for t in t.__parameters__ if t not in tvars])
-    return tuple(tvars)
-
-
 NoReturn = typing.NoReturn
 
 # Some unconstrained type variables.  These are used by the container types.
@@ -2357,7 +2336,6 @@ else:
 #   counting generic parameters, so that when we subscript a generic,
 #   the runtime doesn't try to substitute the Unpack with the subscripted type.
 if not hasattr(typing, "TypeVarTuple"):
-    typing._collect_type_vars = _collect_type_vars
     def _check_generic(cls, parameters, elen=_marker):
         """Check correct count for parameters of a generic cls (internal helper).
         This gives a nice error message in case of count mismatch.
@@ -2376,11 +2354,13 @@ if not hasattr(typing, "TypeVarTuple"):
                 if (num_tv_tuples > 0) and (alen >= elen - num_tv_tuples):
                     return
 
-            # deal with TypeVarLike defaults
-            # required TypeVarLikes cannot appear after a defaulted one.
-            if alen < elen:
-                if all(hasattr(p, '__default__') for p in parameters[alen:]):
-                    return
+                # deal with TypeVarLike defaults
+                # required TypeVarLikes cannot appear after a defaulted one.
+                if alen < elen:
+                    # since we validate TypeVarLike default in _collect_type_vars / _collect_parameters
+                    # we can safely check parameters[alen]
+                    if getattr(parameters[alen], '__default__', None) is not None:
+                        return
 
             raise TypeError(f"Too {'many' if alen > elen else 'few'} parameters for {cls};"
                             f" actual {alen}, expected {elen}")
@@ -2398,17 +2378,95 @@ else:
             raise TypeError(f"{cls} is not a generic class")
         alen = len(parameters)
         if alen != elen:
-            # deal with TypeVarLike defaults
-            # required TypeVarLikes cannot appear after a defaulted one.
-            if alen < elen:
-                if all(hasattr(p, '__default__') for p in parameters[alen:]):
+            if hasattr(cls, "__parameters__"):
+                parameters = [p for p in cls.__parameters__ if not _is_unpack(p)]
+                num_tv_tuples = sum(isinstance(p, TypeVarTuple) for p in parameters)
+                if (num_tv_tuples > 0) and (alen >= elen - num_tv_tuples):
                     return
+
+                # deal with TypeVarLike defaults
+                # required TypeVarLikes cannot appear after a defaulted one.
+                if alen < elen:
+                    # since we validate TypeVarLike default in _collect_type_vars / _collect_parameters
+                    # we can safely check parameters[alen]
+                    if getattr(parameters[alen], '__default__', None) is not None:
+                        return
 
             raise TypeError(f"Too {'many' if alen > elen else 'few'} arguments for {cls};"
                             f" actual {alen}, expected {elen}")
 
     typing._check_generic = _check_generic
 
+# Python 3.11+ _collect_type_vars was renamed to _collect_parameters
+if hasattr(typing, '_collect_type_vars'):
+    def _collect_type_vars(types, typevar_types=None):
+        """Collect all type variable contained in types in order of
+        first appearance (lexicographic order). For example::
+
+            _collect_type_vars((T, List[S, T])) == (T, S)
+        """
+        if typevar_types is None:
+            typevar_types = typing.TypeVar
+        tvars = []
+        # required TypeVarLike cannot appear after TypeVarLike with default
+        default_encountered = False
+        for t in types:
+            if (
+                isinstance(t, typevar_types) and
+                t not in tvars and
+                not _is_unpack(t)
+            ):
+                if getattr(t, '__default__', None) is not None:
+                    if not default_encountered:
+                        default_encountered = True
+                elif default_encountered:
+                    raise TypeError(f'expected TypeVar with default type, found {t!r}')
+
+                tvars.append(t)
+            if _should_collect_from_parameters(t):
+                tvars.extend([t for t in t.__parameters__ if t not in tvars])
+        return tuple(tvars)
+
+    typing._collect_type_vars = _collect_type_vars
+else:
+    def _collect_parameters(args):
+        """Collect all type variables and parameter specifications in args
+        in order of first appearance (lexicographic order).
+
+        For example::
+
+            assert _collect_parameters((T, Callable[P, T])) == (T, P)
+        """
+        parameters = []
+        # required TypeVarLike cannot appear after TypeVarLike with default
+        default_encountered = False
+        for t in args:
+            if isinstance(t, type):
+                # We don't want __parameters__ descriptor of a bare Python class.
+                pass
+            elif isinstance(t, tuple):
+                # `t` might be a tuple, when `ParamSpec` is substituted with
+                # `[T, int]`, or `[int, *Ts]`, etc.
+                for x in t:
+                    for collected in _collect_parameters([x]):
+                        if collected not in parameters:
+                            parameters.append(collected)
+            elif hasattr(t, '__typing_subst__'):
+                if t not in parameters:
+                    if getattr(t, '__default__', None) is not None:
+                        if not default_encountered:
+                            default_encountered = True
+                    elif default_encountered:
+                        raise TypeError(f'expected TypeVar with default type, found {t!r}')
+
+                    parameters.append(t)
+            else:
+                if _should_collect_from_parameters(t):
+                    parameters.extend([t for t in t.__parameters__ if t not in parameters])
+
+        return tuple(parameters)
+
+    typing._collect_parameters = _collect_parameters
 
 # Backport typing.NamedTuple as it exists in Python 3.13.
 # In 3.11, the ability to define generic `NamedTuple`s was supported.

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2649,6 +2649,7 @@ else:
 if not hasattr(typing, "TypeVarTuple"):
     def _check_generic(cls, parameters, elen=_marker):
         """Check correct count for parameters of a generic cls (internal helper).
+
         This gives a nice error message in case of count mismatch.
         """
         if not elen:
@@ -2681,7 +2682,7 @@ if not hasattr(typing, "TypeVarTuple"):
 
                     expect_val = f"at least {elen}"
 
-            raise TypeError(f"Too {'many' if alen > elen else 'few'} parameters"
+            raise TypeError(f"Too {'many' if alen > elen else 'few'} arguments"
                             f" for {cls}; actual {alen}, expected {expect_val}")
 else:
     # Python 3.11+
@@ -2717,7 +2718,7 @@ else:
 
                     expect_val = f"at least {elen}"
 
-            raise TypeError(f"Too {'many' if alen > elen else 'few'} parameters"
+            raise TypeError(f"Too {'many' if alen > elen else 'few'} arguments"
                             f" for {cls}; actual {alen}, expected {expect_val}")
 
 typing._check_generic = _check_generic
@@ -2742,10 +2743,9 @@ if hasattr(typing, '_collect_type_vars'):
                 not _is_unpack(t)
             ):
                 if getattr(t, '__default__', None) is not None:
-                    if not default_encountered:
-                        default_encountered = True
+                    default_encountered = True
                 elif default_encountered:
-                    raise TypeError(f'type parameter {t!r} without a default'
+                    raise TypeError(f'Type parameter {t!r} without a default'
                                     ' follows type parameter with a default')
 
                 tvars.append(t)
@@ -2780,10 +2780,9 @@ else:
             elif hasattr(t, '__typing_subst__'):
                 if t not in parameters:
                     if getattr(t, '__default__', None) is not None:
-                        if not default_encountered:
-                            default_encountered = True
+                        default_encountered = True
                     elif default_encountered:
-                        raise TypeError(f'type parameter {t!r} without a default'
+                        raise TypeError(f'Type parameter {t!r} without a default'
                                         ' follows type parameter with a default')
 
                     parameters.append(t)

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2363,7 +2363,8 @@ if not hasattr(typing, "TypeVarTuple"):
                     if getattr(parameters[alen], '__default__', None) is not None:
                         return
 
-                    num_default_tv = sum(getattr(p, '__default__', None) is not None for p in parameters)
+                    num_default_tv = sum(getattr(p, '__default__', None)
+                                         is not None for p in parameters)
 
                     elen -= num_default_tv
 
@@ -2398,7 +2399,8 @@ else:
                     if getattr(parameters[alen], '__default__', None) is not None:
                         return
 
-                    num_default_tv = sum(getattr(p, '__default__', None) is not None for p in parameters)
+                    num_default_tv = sum(getattr(p, '__default__', None)
+                                         is not None for p in parameters)
 
                     elen -= num_default_tv
 
@@ -2433,7 +2435,7 @@ if hasattr(typing, '_collect_type_vars'):
                         default_encountered = True
                 elif default_encountered:
                     raise TypeError(f'type parameter {t!r} without a default'
-                                     ' follows type parameter with a default')
+                                    ' follows type parameter with a default')
 
                 tvars.append(t)
             if _should_collect_from_parameters(t):
@@ -2472,7 +2474,6 @@ else:
                     elif default_encountered:
                         raise TypeError(f'type parameter {t!r} without a default'
                                         ' follows type parameter with a default')
-
 
                     parameters.append(t)
             else:


### PR DESCRIPTION
In [PEP 696](https://peps.python.org/pep-0696/) there are two failure modes specified:

```py
DefaultStrT = TypeVar("DefaultStrT", default=str)
DefaultIntT = TypeVar("DefaultIntT", default=int)
DefaultBoolT = TypeVar("DefaultBoolT", default=bool)
T = TypeVar("T")
T2 = TypeVar("T2")

 # 1. Invalid: non-default TypeVars cannot follow ones with defaults
class NonDefaultFollowsDefault(Generic[DefaultStrT, T]): ...

class AllTheDefaults(Generic[T1, T2, DefaultStrT, DefaultIntT, DefaultBoolT]): ...

# 2. Invalid: expected 2 arguments to AllTheDefaults
AllTheDefaults[int]
```

This PR aims to implement the runtime behaviour for this PEP that was missed out in the initial support PR #77. 
It also brings support for this to Python 3.11+.

One note I had was that the current error will say `Too few parameters for AllTheDefaults; actual 1, expected 5`.
For TypeVarLikes with defaults they aren't actually required, so is it worth computing the minimum required then saying `expected at least 2` for this case?

Let me know if you have any suggestions!