### PR TITLE
Raise if a non-`str` is passed as the first parameter to `@deprecated`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - All parameters on `NewType.__call__` are now positional-only. This means that
   the signature of `typing_extensions.NewType.__call__` now exactly matches the
   signature of `typing.NewType.__call__`. Patch by Alex Waygood.
+- `typing.deprecated` now gives a better error message if you pass a non-`str`
+  argument to the `msg` parameter. Patch by Alex Waygood.
 
 # Release 4.8.0 (September 17, 2023)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -480,6 +480,21 @@ class DeprecatedTests(BaseTestCase):
             warnings.simplefilter("error")
             d()
 
+    def test_only_strings_allowed(self):
+        with self.assertRaisesRegex(
+            TypeError,
+            "Expected an object of type str for 'msg', not 'type'"
+        ):
+            @deprecated
+            class Foo: ...
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "Expected an object of type str for 'msg', not 'function'"
+        ):
+            @deprecated
+            def foo(): ...
+
 
 class AnyTests(BaseTestCase):
     def test_can_subclass(self):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2331,6 +2331,11 @@ else:
         See PEP 702 for details.
 
         """
+        if not isinstance(msg, str):
+            raise TypeError(
+                f"Expected an object of type str for 'msg', not {type(msg).__name__!r}"
+            )
+
         def decorator(arg: _T, /) -> _T:
             if category is None:
                 arg.__deprecated__ = msg


### PR DESCRIPTION
Fixes #295