### PR TITLE
fix typo in `override()` docstring

### DIFF
--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2252,7 +2252,7 @@ else:  # <=3.11
         Usage:
 
             class Base:
-                def method(self) -> None: ...
+                def method(self) -> None:
                     pass
 
             class Child(Base):


### PR DESCRIPTION
backport of https://github.com/python/cpython/commit/12c7e9d573de57343cf018fb4e67521aba46c90f