### PR TITLE
Run typed-argument-parser tests on 3.12 in the daily workflow

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -217,7 +217,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
They declared support for Python 3.12 in https://github.com/swansonk14/typed-argument-parser/commit/0789b251e58892ca0fb6c18ade046c8a960c3268