### PR TITLE
Fix readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,8 +6,8 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: doc/conf.py
 


### PR DESCRIPTION
The folder is called doc, not docs.

Also use 3.12 while I'm here.