### PR TITLE
Catch a deprecation warning on Python 3.13

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3553,7 +3553,8 @@ class TypedDictTests(BaseTestCase):
     @skipIf(sys.version_info < (3, 13), "Change in behavior in 3.13")
     def test_keywords_syntax_raises_on_3_13(self):
         with self.assertRaises(TypeError):
-            Emp = TypedDict('Emp', name=str, id=int)
+            with self.assertWarns(DeprecationWarning):
+                Emp = TypedDict('Emp', name=str, id=int)
 
     @skipIf(sys.version_info >= (3, 13), "3.13 removes support for kwargs")
     def test_basics_keywords_syntax(self):


### PR DESCRIPTION
Suppresses the following deprecation warning, but asserts its presence:

```
test_typing_extensions.py:4003: DeprecationWarning: Failing to pass a value for the 'fields' parameter is deprecated and will be disallowed in Python 3.15. To create a TypedDict class with 0 fields using the functional syntax, pass an empty dictionary, e.g. `Emp = TypedDict('Emp', {})`.
  Emp = TypedDict("Emp", name=str, id=int)
```
