### PR TITLE
Add module name to doc source (to allow intersphinx usage)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,6 +26,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 intersphinx_mapping = {'py': ('https://docs.python.org/3.12', None)}
 
+add_module_names = False
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,4 +32,17 @@ add_module_names = False
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'alabaster'
-html_static_path = ['_static']
+
+from sphinx.writers.html import HTMLTranslator
+from docutils.nodes import Element, Node, Text
+
+class MyTranslator(HTMLTranslator):
+    """Adds a link target to name without `typing_extensions.` prefix."""
+    def visit_desc_signature(self, node: Element) -> None:
+        desc_name = node.get("fullname")
+        if desc_name:
+            self.body.append(f'<span id="{desc_name}"></span>')
+        super().visit_desc_signature(node)
+
+def setup(app):
+     app.set_translator('html', MyTranslator)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -33,10 +33,10 @@ add_module_names = False
 
 html_theme = 'alabaster'
 
-from sphinx.writers.html import HTMLTranslator
+from sphinx.writers.html5 import HTML5Translator
 from docutils.nodes import Element, Node, Text
 
-class MyTranslator(HTMLTranslator):
+class MyTranslator(HTML5Translator):
     """Adds a link target to name without `typing_extensions.` prefix."""
     def visit_desc_signature(self, node: Element) -> None:
         desc_name = node.get("fullname")

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,6 +5,8 @@
 
 import os.path
 import sys
+from sphinx.writers.html5 import HTML5Translator
+from docutils.nodes import Element
 
 sys.path.insert(0, os.path.abspath('.'))
 
@@ -33,8 +35,6 @@ add_module_names = False
 
 html_theme = 'alabaster'
 
-from sphinx.writers.html5 import HTML5Translator
-from docutils.nodes import Element, Node, Text
 
 class MyTranslator(HTML5Translator):
     """Adds a link target to name without `typing_extensions.` prefix."""
@@ -44,5 +44,6 @@ class MyTranslator(HTML5Translator):
             self.body.append(f'<span id="{desc_name}"></span>')
         super().visit_desc_signature(node)
 
+
 def setup(app):
-     app.set_translator('html', MyTranslator)
+    app.set_translator('html', MyTranslator)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,3 +1,4 @@
+.. module:: typing_extensions
 
 Welcome to typing_extensions's documentation!
 =============================================


### PR DESCRIPTION
Fixes #341. With this change, `typing_extensions` can be used from other libraries' documentation via intersphinx.

I included `add_module_names = False`, which means that the `typing_extensions.` prefix will *not* show up in the docs before identifiers, because that was the consensus on the issue report.

However, while testing I did notice another: even with that setting turned on, the anchors are still changed to include the prefix. For example:

* Current link: https://typing-extensions.readthedocs.io/en/latest/#Literal
* New link: https://typing-extensions.readthedocs.io/en/latest/#typing_extensions.Literal

That will break any existing external pages that link directly to an anchor within the docs.