### PR TITLE
Third-party tests: don't run pydantic tests on pypy

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -41,7 +41,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.9", "pypy3.10"]
+        # PyPy is deliberately omitted here,
+        # since pydantic's tests intermittently segfault on PyPy,
+        # and it's nothing to do with typing_extensions
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
they keep segfaulting and it's nothing to do with us