### PR TITLE
Backport assert_never change to include repr of value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   `__static_attributes__` attribute to all classes in Python,
   which broke some assumptions made by the implementation of
   `typing_extensions.Protocol`.
+- At runtime, `assert_never` now includes the repr of the argument
+  in the `AssertionError`. Patch by Hashem, backporting of the original
+  fix https://github.com/python/cpython/pull/91720 by Jelle Zijlstra.
 
 # Release 4.11.0 (April 5, 2024)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -293,7 +293,7 @@ class AssertNeverTests(BaseTestCase):
             assert_never(huge_value)
         self.assertLess(
             len(cm.exception.args[0]),
-            typing._ASSERT_NEVER_REPR_MAX_LENGTH * 2,
+            typing_extensions._ASSERT_NEVER_REPR_MAX_LENGTH * 2,
         )
 
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -283,6 +283,19 @@ class AssertNeverTests(BaseTestCase):
         with self.assertRaises(AssertionError):
             assert_never(None)
 
+        value = "some value"
+        with self.assertRaisesRegex(AssertionError, value):
+            assert_never(value)
+
+        # Make sure a huge value doesn't get printed in its entirety
+        huge_value = "a" * 10000
+        with self.assertRaises(AssertionError) as cm:
+            assert_never(huge_value)
+        self.assertLess(
+            len(cm.exception.args[0]),
+            typing._ASSERT_NEVER_REPR_MAX_LENGTH * 2,
+        )
+
 
 class OverrideTests(BaseTestCase):
     def test_override(self):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2356,10 +2356,14 @@ else:  # <=3.10
 
 
 if hasattr(typing, "assert_never"):  # 3.11+
-    assert_never = typing.assert_never
+    _ASSERT_NEVER_REPR_MAX_LENGTH = typing._ASSERT_NEVER_REPR_MAX_LENGTH
 else:  # <=3.10
     _ASSERT_NEVER_REPR_MAX_LENGTH = 100
 
+
+if hasattr(typing, "assert_never"):  # 3.11+
+    assert_never = typing.assert_never
+else:  # <=3.10
     def assert_never(arg: Never, /) -> Never:
         """Assert to the type checker that a line of code is unreachable.
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2355,7 +2355,7 @@ else:  # <=3.10
         return obj
 
 
-if hasattr(typing, "assert_never"):  # 3.11+
+if hasattr(typing, "_ASSERT_NEVER_REPR_MAX_LENGTH"):  # 3.11+
     _ASSERT_NEVER_REPR_MAX_LENGTH = typing._ASSERT_NEVER_REPR_MAX_LENGTH
 else:  # <=3.10
     _ASSERT_NEVER_REPR_MAX_LENGTH = 100

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2358,6 +2358,8 @@ else:  # <=3.10
 if hasattr(typing, "assert_never"):  # 3.11+
     assert_never = typing.assert_never
 else:  # <=3.10
+    _ASSERT_NEVER_REPR_MAX_LENGTH = 100
+
     def assert_never(arg: Never, /) -> Never:
         """Assert to the type checker that a line of code is unreachable.
 
@@ -2378,7 +2380,10 @@ else:  # <=3.10
         At runtime, this throws an exception when called.
 
         """
-        raise AssertionError("Expected code to be unreachable")
+        value = repr(arg)
+        if len(value) > _ASSERT_NEVER_REPR_MAX_LENGTH:
+            value = value[:_ASSERT_NEVER_REPR_MAX_LENGTH] + '...'
+        raise AssertionError(f"Expected code to be unreachable, but got: {value}")
 
 
 if sys.version_info >= (3, 12):  # 3.12+


### PR DESCRIPTION
This helps to debug what bad data you have.

Via https://github.com/python/cpython/commit/93d280141c369fd1906569ff605148b6e22f6a43#diff-ddb987fca5f5df0c9a2f5521ed687919d70bb3d64eaeb8021f98833a2a716887

```pycon
$ PYTHONPATH=src python3.10
>>> import typing_extensions
>>> typing_extensions.__file__
'typing_extensions/src/typing_extensions.py'
>>> typing_extensions.assert_never("boo!")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "typing_extensions/src/typing_extensions.py", line 2387, in assert_never
    raise AssertionError(f"Expected code to be unreachable, but got: {value}")
AssertionError: Expected code to be unreachable, but got: 'boo!'
```