### PR TITLE
gitignore `.python-version`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ venv*/
 .tox/
 .venv*/
 .vscode/
+.python-version
 
 *.swp
 *.pyc


### PR DESCRIPTION
This allows you to easily use pyenv in local clones of the repo with a clean git history