### PR TITLE
Fix `Protocol` tests on Python 3.13.0b1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Unreleased
 
-- Fix tests on Python 3.13.0a6. 3.13.0a6 adds a new
+- Fix tests on Python 3.13.0a6 and newer. 3.13.0a6 adds a new
   `__static_attributes__` attribute to all classes in Python,
   which broke some assumptions made by the implementation of
-  `typing_extensions.Protocol`.
+  `typing_extensions.Protocol`. Similarly, 3.13.0b1 adds the new
+  `__firstlineno__` attribute to all classes.
 - Fix `AttributeError` when using `typing_extensions.runtime_checkable`
   in combination with `typing.Protocol` on Python 3.12.2 or newer.
   Patch by Alex Waygood.

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -427,25 +427,10 @@ _PROTO_ALLOWLIST = {
 }
 
 
-_EXCLUDED_ATTRS = {
-    "__abstractmethods__", "__annotations__", "__weakref__", "_is_protocol",
-    "_is_runtime_protocol", "__dict__", "__slots__", "__parameters__",
-    "__orig_bases__", "__module__", "_MutableMapping__marker", "__doc__",
-    "__subclasshook__", "__orig_class__", "__init__", "__new__",
-    "__protocol_attrs__", "__non_callable_proto_members__",
-    "__match_args__",
+_EXCLUDED_ATTRS = frozenset(typing.EXCLUDED_ATTRIBUTES) | {
+    "__match_args__", "__protocol_attrs__", "__non_callable_proto_members__",
+    "__final__",
 }
-
-if sys.version_info >= (3, 9):
-    _EXCLUDED_ATTRS.add("__class_getitem__")
-
-if sys.version_info >= (3, 12):
-    _EXCLUDED_ATTRS.add("__type_params__")
-
-if sys.version_info >= (3, 13):
-    _EXCLUDED_ATTRS.add("__static_attributes__")
-
-_EXCLUDED_ATTRS = frozenset(_EXCLUDED_ATTRS)
 
 
 def _get_protocol_attrs(cls):


### PR DESCRIPTION
I assume https://github.com/python/cpython/commit/153b3f75306b5d26e29ea157105d0fdc247ef853 is going to cause our tests to start failing as soon as 3.13.0b1 is available in GitHub Actions. I've tried to fix the soon-to-be-failing tests in such a way that our Protocol implementation is more resilient to future changes in this genre.