### PR TITLE
Fix most tests on Python 3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Unreleased
 
-- Fix tests on Python 3.13.0a6 and newer. 3.13.0a6 adds a new
+- Backport the `typing.NoDefault` sentinel object from Python 3.13.
+  TypeVars, ParamSpecs and TypeVarTuples without default values now have
+  their `__default__` attribute set to this sentinel value.
+- TypeVars, ParamSpecs and TypeVarTuples now have a `has_default()`
+  method, matching `typing.TypeVar`, `typing.ParamSpec` and
+  `typing.TypeVarTuple` on Python 3.13+.
+- TypeVars, ParamSpecs and TypeVarTuples with `default=None` passed to
+  their constructors now have their `__default__` attribute set to `None`
+  at runtime rather than `types.NoneType`.
+- Fix most tests for `TypeVar`, `ParamSpec` and `TypeVarTuple` on Python
+  3.13.0b1 and newer.
+- Fix `Protocol` tests on Python 3.13.0a6 and newer. 3.13.0a6 adds a new
   `__static_attributes__` attribute to all classes in Python,
   which broke some assumptions made by the implementation of
   `typing_extensions.Protocol`. Similarly, 3.13.0b1 adds the new

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -301,7 +301,7 @@ Special typing primitives
 
    .. versionchanged:: 4.12.0
 
-      ParamSpecs now have a ``nodefault()`` method, for compatibility
+      ParamSpecs now have a ``has_default()`` method, for compatibility
       with :py:class:`typing.ParamSpec` on Python 3.13+.
 
 .. class:: ParamSpecArgs
@@ -515,7 +515,7 @@ Special typing primitives
 
    .. versionchanged:: 4.12.0
 
-      TypeVars now have a ``nodefault()`` method, for compatibility
+      TypeVars now have a ``has_default()`` method, for compatibility
       with :py:class:`typing.TypeVar` on Python 3.13+.
 
 .. class:: TypeVarTuple(name, *, default=NoDefault)
@@ -546,7 +546,7 @@ Special typing primitives
 
    .. versionchanged:: 4.12.0
 
-      TypeVarTuples now have a ``nodefault()`` method, for compatibility
+      TypeVarTuples now have a ``has_default()`` method, for compatibility
       with :py:class:`typing.TypeVarTuple` on Python 3.13+.
 
 .. data:: Unpack

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -253,13 +253,19 @@ Special typing primitives
 
       The improvements from Python 3.10 and 3.11 were backported.
 
+.. data:: NoDefault
+
+   See :py:class:`typing.NoDefault`. In ``typing`` since 3.13.0.
+
+   .. versionadded:: 4.12.0
+
 .. data:: NotRequired
 
    See :py:data:`typing.NotRequired` and :pep:`655`. In ``typing`` since 3.11.
 
    .. versionadded:: 4.0.0
 
-.. class:: ParamSpec(name, *, default=...)
+.. class:: ParamSpec(name, *, default=NoDefault)
 
    See :py:class:`typing.ParamSpec` and :pep:`612`. In ``typing`` since 3.10.
 
@@ -283,6 +289,20 @@ Special typing primitives
 
       Passing an ellipsis literal (``...``) to *default* now works on Python
       3.10 and lower.
+
+   .. versionchanged:: 4.12.0
+
+      The :attr:`!__default__` attribute is now set to ``None`` if
+      ``default=None`` is passed, and to :data:`NoDefault` if no value is passed.
+
+      Previously, passing ``None`` would result in :attr:`!__default__` being set
+      to :py:class:`types.NoneType`, and passing no value for the parameter would
+      result in :attr:`!__default__` being set to ``None``.
+
+   .. versionchanged:: 4.12.0
+
+      ParamSpecs now have a ``nodefault()`` method, for compatibility
+      with :py:class:`typing.ParamSpec` on Python 3.13+.
 
 .. class:: ParamSpecArgs
 
@@ -395,7 +415,7 @@ Special typing primitives
       are mutable if they do not carry the :data:`ReadOnly` qualifier.
 
       .. versionadded:: 4.9.0
-    
+
    The experimental ``closed`` keyword argument and the special key
    ``__extra_items__`` proposed in :pep:`728` are supported.
 
@@ -466,7 +486,7 @@ Special typing primitives
       when ``closed=True`` is given were supported.
 
 .. class:: TypeVar(name, *constraints, bound=None, covariant=False,
-                   contravariant=False, infer_variance=False, default=...)
+                   contravariant=False, infer_variance=False, default=NoDefault)
 
    See :py:class:`typing.TypeVar`.
 
@@ -484,7 +504,21 @@ Special typing primitives
 
       The implementation was changed for compatibility with Python 3.12.
 
-.. class:: TypeVarTuple(name, *, default=...)
+   .. versionchanged:: 4.12.0
+
+      The :attr:`!__default__` attribute is now set to ``None`` if
+      ``default=None`` is passed, and to :data:`NoDefault` if no value is passed.
+
+      Previously, passing ``None`` would result in :attr:`!__default__` being set
+      to :py:class:`types.NoneType`, and passing no value for the parameter would
+      result in :attr:`!__default__` being set to ``None``.
+
+   .. versionchanged:: 4.12.0
+
+      TypeVars now have a ``nodefault()`` method, for compatibility
+      with :py:class:`typing.TypeVar` on Python 3.13+.
+
+.. class:: TypeVarTuple(name, *, default=NoDefault)
 
    See :py:class:`typing.TypeVarTuple` and :pep:`646`. In ``typing`` since 3.11.
 
@@ -500,6 +534,20 @@ Special typing primitives
    .. versionchanged:: 4.6.0
 
       The implementation was changed for compatibility with Python 3.12.
+
+   .. versionchanged:: 4.12.0
+
+      The :attr:`!__default__` attribute is now set to ``None`` if
+      ``default=None`` is passed, and to :data:`NoDefault` if no value is passed.
+
+      Previously, passing ``None`` would result in :attr:`!__default__` being set
+      to :py:class:`types.NoneType`, and passing no value for the parameter would
+      result in :attr:`!__default__` being set to ``None``.
+
+   .. versionchanged:: 4.12.0
+
+      TypeVarTuples now have a ``nodefault()`` method, for compatibility
+      with :py:class:`typing.TypeVarTuple` on Python 3.13+.
 
 .. data:: Unpack
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6300,6 +6300,14 @@ class NoDefaultTests(BaseTestCase):
         with self.assertRaises(TypeError):
             NoDefault()
 
+    @skipIf(
+        sys.version_info[:5] == (3, 13, 0, "beta", 1),
+        "incorrectly raises TypeError in the first 3.13 beta"
+    )
+    def test_immutable(self):
+        with self.assertRaises(AttributeError):
+            NoDefault.foo = 'bar'
+
 
 class TypeVarInferVarianceTests(BaseTestCase):
     def test_typevar(self):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -59,9 +59,9 @@ TYPING_3_13_0 = sys.version_info[:3] >= (3, 13, 0)
 # versions, but not all
 HAS_FORWARD_MODULE = "module" in inspect.signature(typing._type_check).parameters
 
-skip_if_early_py313_alpha = skipIf(
-    sys.version_info[:4] == (3, 13, 0, 'alpha') and sys.version_info.serial < 3,
-    "Bugfixes will be released in 3.13.0a3"
+skip_if_py313_beta_1 = skipIf(
+    sys.version_info[:5] == (3, 13, 0, 'beta', 1),
+    "Bugfixes will be released in 3.13.0b2"
 )
 
 ANN_MODULE_SOURCE = '''\
@@ -3485,7 +3485,6 @@ class ProtocolTests(BaseTestCase):
         self.assertIsInstance(Foo(), ProtocolWithMixedMembers)
         self.assertNotIsInstance(42, ProtocolWithMixedMembers)
 
-    @skip_if_early_py313_alpha
     def test_protocol_issubclass_error_message(self):
         @runtime_checkable
         class Vec2D(Protocol):
@@ -5917,7 +5916,6 @@ class NamedTupleTests(BaseTestCase):
 
         self.assertEqual(CallNamedTuple.__orig_bases__, (NamedTuple,))
 
-    @skip_if_early_py313_alpha
     def test_setname_called_on_values_in_class_dictionary(self):
         class Vanilla:
             def __set_name__(self, owner, name):
@@ -5989,7 +5987,6 @@ class NamedTupleTests(BaseTestCase):
         TYPING_3_12_0,
         "__set_name__ behaviour changed on py312+ to use BaseException.add_note()"
     )
-    @skip_if_early_py313_alpha
     def test_setname_raises_the_same_as_on_other_classes_py312_plus(self):
         class CustomException(BaseException): pass
 
@@ -6029,7 +6026,6 @@ class NamedTupleTests(BaseTestCase):
             normal_exception.__notes__[0].replace("NormalClass", "NamedTupleClass")
         )
 
-    @skip_if_early_py313_alpha
     def test_strange_errors_when_accessing_set_name_itself(self):
         class CustomException(Exception): pass
 
@@ -6282,6 +6278,7 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
 
 
 class NoDefaultTests(BaseTestCase):
+    @skip_if_py313_beta_1
     def test_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             s = pickle.dumps(NoDefault, proto)
@@ -6291,7 +6288,7 @@ class NoDefaultTests(BaseTestCase):
     def test_constructor(self):
         self.assertIs(NoDefault, type(NoDefault)())
         with self.assertRaises(TypeError):
-            NoDefault(1)
+            type(NoDefault)(1)
 
     def test_repr(self):
         self.assertRegex(repr(NoDefault), r'typing(_extensions)?\.NoDefault')
@@ -6300,10 +6297,7 @@ class NoDefaultTests(BaseTestCase):
         with self.assertRaises(TypeError):
             NoDefault()
 
-    @skipIf(
-        sys.version_info[:5] == (3, 13, 0, "beta", 1),
-        "incorrectly raises TypeError in the first 3.13 beta"
-    )
+    @skip_if_py313_beta_1
     def test_immutable(self):
         with self.assertRaises(AttributeError):
             NoDefault.foo = 'bar'

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1361,6 +1361,8 @@ if hasattr(typing, "NoDefault"):
     NoDefault = typing.NoDefault
 else:
     class NoDefaultType:
+        __slots__ = ()
+
         def __new__(cls):
             return globals().get("NoDefault") or object.__new__(cls)
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2709,7 +2709,10 @@ if not hasattr(typing, "TypeVarTuple"):
                 if alen < elen:
                     # since we validate TypeVarLike default in _collect_type_vars
                     # or _collect_parameters we can safely check parameters[alen]
-                    if getattr(parameters[alen], '__default__', NoDefault) is not NoDefault:
+                    if (
+                        getattr(parameters[alen], '__default__', NoDefault)
+                        is not NoDefault
+                    ):
                         return
 
                     num_default_tv = sum(getattr(p, '__default__', NoDefault)
@@ -2743,7 +2746,10 @@ else:
                 if alen < elen:
                     # since we validate TypeVarLike default in _collect_type_vars
                     # or _collect_parameters we can safely check parameters[alen]
-                    if getattr(parameters[alen], '__default__', NoDefault) is not NoDefault:
+                    if (
+                        getattr(parameters[alen], '__default__', NoDefault)
+                        is not NoDefault
+                    ):
                         return
 
                     num_default_tv = sum(getattr(p, '__default__', NoDefault)


### PR DESCRIPTION
Helps with #377. Lots of changes to reflect changes in the PEP-696 implementation that were made upstream but had yet to be backported here.

There's still a couple of failing tests on Python 3.13 even with this PR, but this gets us a lot closer to a clean bill of health.