### PR TITLE
Backport parameter defaults for `(Async)Generator` and `(Async)ContextManager`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@
 - At runtime, `assert_never` now includes the repr of the argument
   in the `AssertionError`. Patch by Hashem, backporting of the original
   fix https://github.com/python/cpython/pull/91720 by Jelle Zijlstra.
+- The second and third parameters of `typing_extensions.Generator`,
+  and the second parameter of `typing_extensions.AsyncGenerator`,
+  now default to `None`. This matches the behaviour of `typing.Generator`
+  and `typing.AsyncGenerator` on Python 3.13+.
+- `typing.ContextManager` and `typing.AsyncContextManager` now have an
+  optional second parameter, which defaults to `Optional[bool]`. The new
+  parameter signifies the return type of the `__(a)exit__` method,
+  matching `typing.ContextManager` and `typing.AsyncContextManager` on
+  Python 3.13+.
 
 # Release 4.11.0 (April 5, 2024)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -885,8 +885,8 @@ Annotation metadata
 Pure aliases
 ~~~~~~~~~~~~
 
-These are simply re-exported from the :mod:`typing` module on all supported
-versions of Python. They are listed here for completeness.
+Most of these are simply re-exported from the :mod:`typing` module on all supported
+versions of Python, but all are listed here for completeness.
 
 .. class:: AbstractSet
 
@@ -904,9 +904,18 @@ versions of Python. They are listed here for completeness.
 
    See :py:class:`typing.AsyncContextManager`. In ``typing`` since 3.5.4 and 3.6.2.
 
+   .. versionchanged:: 4.12.0
+
+      ``AsyncContextManager`` now has an optional second parameter, defaulting to
+      ``Optional[bool]``, signifying the return type of the ``__aexit__`` method.
+
 .. class:: AsyncGenerator
 
    See :py:class:`typing.AsyncGenerator`. In ``typing`` since 3.6.1.
+
+   .. versionchanged:: 4.12.0
+
+      The second type parameter is now optional (it defaults to ``None``).
 
 .. class:: AsyncIterable
 
@@ -956,6 +965,11 @@ versions of Python. They are listed here for completeness.
 
    See :py:class:`typing.ContextManager`. In ``typing`` since 3.5.4.
 
+   .. versionchanged:: 4.12.0
+
+      ``AsyncContextManager`` now has an optional second parameter, defaulting to
+      ``Optional[bool]``, signifying the return type of the ``__aexit__`` method.
+
 .. class:: Coroutine
 
    See :py:class:`typing.Coroutine`. In ``typing`` since 3.5.3.
@@ -995,6 +1009,11 @@ versions of Python. They are listed here for completeness.
    See :py:class:`typing.Generator`.
 
    .. versionadded:: 4.7.0
+
+   .. versionchanged:: 4.12.0
+
+      The second type and third type parameters are now optional
+      (they both default to ``None``).
 
 .. class:: Generic
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -423,7 +423,9 @@ else:
     def _is_dunder(attr):
         return attr.startswith('__') and attr.endswith('__')
 
-    _special_generic_alias_base = getattr(typing, "_SpecialGenericAlias", typing._GenericAlias)
+    _special_generic_alias_base = getattr(
+        typing, "_SpecialGenericAlias", typing._GenericAlias
+    )
 
     class _SpecialGenericAlias(_special_generic_alias_base, _root=True):
         def __init__(self, origin, nparams, *, inst=True, name=None, defaults=()):
@@ -450,7 +452,8 @@ else:
                 params = (params,)
             msg = "Parameters to generic types must be types."
             params = tuple(typing._type_check(p, msg) for p in params)
-            if (self._defaults
+            if (
+                self._defaults
                 and len(params) < self._nparams
                 and len(params) + len(self._defaults) >= self._nparams
             ):
@@ -464,10 +467,12 @@ else:
                     expected = str(self._nparams)
                 if not self._nparams:
                     raise TypeError(f"{self} is not a generic class")
-                raise TypeError(f"Too {'many' if actual_len > self._nparams else 'few'} arguments for {self};"
-                                f" actual {actual_len}, expected {expected}")
+                raise TypeError(
+                    f"Too {'many' if actual_len > self._nparams else 'few'}"
+                    f" arguments for {self};"
+                    f" actual {actual_len}, expected {expected}"
+                )
             return self.copy_with(params)
-
 
     _NoneType = type(None)
     Generator = _SpecialGenericAlias(

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -423,6 +423,7 @@ else:
     def _is_dunder(attr):
         return attr.startswith('__') and attr.endswith('__')
 
+    # Python <3.9 doesn't have typing._SpecialGenericAlias
     _special_generic_alias_base = getattr(
         typing, "_SpecialGenericAlias", typing._GenericAlias
     )
@@ -430,16 +431,19 @@ else:
     class _SpecialGenericAlias(_special_generic_alias_base, _root=True):
         def __init__(self, origin, nparams, *, inst=True, name=None, defaults=()):
             if _special_generic_alias_base is typing._GenericAlias:
+                # Python <3.9
                 self.__origin__ = origin
                 self._nparams = nparams
                 super().__init__(origin, nparams, special=True, inst=inst, name=name)
             else:
+                # Python >= 3.9
                 super().__init__(origin, nparams, inst=inst, name=name)
             self._defaults = defaults
 
         def __setattr__(self, attr, val):
             allowed_attrs = {'_name', '_inst', '_nparams', '_defaults'}
             if _special_generic_alias_base is typing._GenericAlias:
+                # Python <3.9
                 allowed_attrs.add("__origin__")
             if _is_dunder(attr) or attr in allowed_attrs:
                 object.__setattr__(self, attr, val)

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1,6 +1,7 @@
 import abc
 import collections
 import collections.abc
+import contextlib
 import functools
 import inspect
 import operator
@@ -408,15 +409,85 @@ Coroutine = typing.Coroutine
 AsyncIterable = typing.AsyncIterable
 AsyncIterator = typing.AsyncIterator
 Deque = typing.Deque
-ContextManager = typing.ContextManager
-AsyncContextManager = typing.AsyncContextManager
 DefaultDict = typing.DefaultDict
 OrderedDict = typing.OrderedDict
 Counter = typing.Counter
 ChainMap = typing.ChainMap
-AsyncGenerator = typing.AsyncGenerator
 Text = typing.Text
 TYPE_CHECKING = typing.TYPE_CHECKING
+
+
+if sys.version_info >= (3, 13, 0, "beta"):
+    from typing import ContextManager, AsyncContextManager, Generator, AsyncGenerator
+else:
+    def _is_dunder(attr):
+        return attr.startswith('__') and attr.endswith('__')
+
+    _special_generic_alias_base = getattr(typing, "_SpecialGenericAlias", typing._GenericAlias)
+
+    class _SpecialGenericAlias(_special_generic_alias_base, _root=True):
+        def __init__(self, origin, nparams, *, inst=True, name=None, defaults=()):
+            if _special_generic_alias_base is typing._GenericAlias:
+                self.__origin__ = origin
+                self._nparams = nparams
+                super().__init__(origin, nparams, special=True, inst=inst, name=name)
+            else:
+                super().__init__(origin, nparams, inst=inst, name=name)
+            self._defaults = defaults
+
+        def __setattr__(self, attr, val):
+            allowed_attrs = {'_name', '_inst', '_nparams', '_defaults'}
+            if _special_generic_alias_base is typing._GenericAlias:
+                allowed_attrs.add("__origin__")
+            if _is_dunder(attr) or attr in allowed_attrs:
+                object.__setattr__(self, attr, val)
+            else:
+                setattr(self.__origin__, attr, val)
+
+        @typing._tp_cache
+        def __getitem__(self, params):
+            if not isinstance(params, tuple):
+                params = (params,)
+            msg = "Parameters to generic types must be types."
+            params = tuple(typing._type_check(p, msg) for p in params)
+            if (self._defaults
+                and len(params) < self._nparams
+                and len(params) + len(self._defaults) >= self._nparams
+            ):
+                params = (*params, *self._defaults[len(params) - self._nparams:])
+            actual_len = len(params)
+
+            if actual_len != self._nparams:
+                if self._defaults:
+                    expected = f"at least {self._nparams - len(self._defaults)}"
+                else:
+                    expected = str(self._nparams)
+                if not self._nparams:
+                    raise TypeError(f"{self} is not a generic class")
+                raise TypeError(f"Too {'many' if actual_len > self._nparams else 'few'} arguments for {self};"
+                                f" actual {actual_len}, expected {expected}")
+            return self.copy_with(params)
+
+
+    _NoneType = type(None)
+    Generator = _SpecialGenericAlias(
+        collections.abc.Generator, 3, defaults=(_NoneType, _NoneType)
+    )
+    AsyncGenerator = _SpecialGenericAlias(
+        collections.abc.AsyncGenerator, 2, defaults=(_NoneType,)
+    )
+    ContextManager = _SpecialGenericAlias(
+        contextlib.AbstractContextManager,
+        2,
+        name="ContextManager",
+        defaults=(typing.Optional[bool],)
+    )
+    AsyncContextManager = _SpecialGenericAlias(
+        contextlib.AbstractAsyncContextManager,
+        2,
+        name="AsyncContextManager",
+        defaults=(typing.Optional[bool],)
+    )
 
 
 _PROTO_ALLOWLIST = {
@@ -3344,7 +3415,6 @@ Container = typing.Container
 Dict = typing.Dict
 ForwardRef = typing.ForwardRef
 FrozenSet = typing.FrozenSet
-Generator = typing.Generator
 Generic = typing.Generic
 Hashable = typing.Hashable
 IO = typing.IO


### PR DESCRIPTION
This was not a fun experience 😥

Fixes https://github.com/python/typing_extensions/issues/380
Closes #377