### PR TITLE
Improve the backport of `NoDefault`

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6439,6 +6439,9 @@ class NoDefaultTests(BaseTestCase):
             loaded = pickle.loads(s)
             self.assertIs(NoDefault, loaded)
 
+    def test_doc(self):
+        self.assertIsInstance(NoDefault.__doc__, str)
+
     def test_constructor(self):
         self.assertIs(NoDefault, type(NoDefault)())
         with self.assertRaises(TypeError):
@@ -6455,6 +6458,14 @@ class NoDefaultTests(BaseTestCase):
     def test_immutable(self):
         with self.assertRaises(AttributeError):
             NoDefault.foo = 'bar'
+        with self.assertRaises(AttributeError):
+            NoDefault.foo
+
+        # TypeError is consistent with the behavior of NoneType
+        with self.assertRaises(TypeError):
+            type(NoDefault).foo = 3
+        with self.assertRaises(AttributeError):
+            type(NoDefault).foo
 
 
 class TypeVarInferVarianceTests(BaseTestCase):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6439,6 +6439,7 @@ class NoDefaultTests(BaseTestCase):
             loaded = pickle.loads(s)
             self.assertIs(NoDefault, loaded)
 
+    @skip_if_py313_beta_1
     def test_doc(self):
         self.assertIsInstance(NoDefault.__doc__, str)
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1440,7 +1440,16 @@ else:
 if hasattr(typing, "NoDefault"):
     NoDefault = typing.NoDefault
 else:
-    class NoDefaultType:
+    class NoDefaultTypeMeta(type):
+        def __setattr__(cls, attr, value):
+            # TypeError is consistent with the behavior of NoneType
+            raise TypeError(
+                f"cannot set {attr!r} attribute of immutable type {cls.__name__!r}"
+            )
+
+    class NoDefaultType(metaclass=NoDefaultTypeMeta):
+        """The type of the NoDefault singleton."""
+
         __slots__ = ()
 
         def __new__(cls):
@@ -1453,7 +1462,7 @@ else:
             return "NoDefault"
 
     NoDefault = NoDefaultType()
-    del NoDefaultType
+    del NoDefaultType, NoDefaultTypeMeta
 
 
 def _set_default(type_param, default):


### PR DESCRIPTION
Adds a few tests that were added to CPython in https://github.com/python/cpython/commit/13d7cf997bc9c22cf67c42fd799413e8325e0039 (and tweaks the implementation so they pass)