### PR TITLE
Backport `types.CapsuleType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   signifies the return type of the `__(a)exit__` method, matching
   `typing.ContextManager` and `typing.AsyncContextManager` on Python
   3.13+.
+- Backport `types.CapsuleType` from Python 3.13.
 
 # Release 4.11.0 (April 5, 2024)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -882,6 +882,17 @@ Annotation metadata
       The documentation string passed to :class:`Doc`.
 
 
+Capsule objects
+~~~~~~~~~~~~~~~
+
+.. class:: CapsuleType
+
+   The type of :py:ref:`capsule objects <capsules>`.
+   See :py:class:`types.CapsuleType`, where it has existed since Python 3.13.
+
+   .. versionadded:: 4.12.0
+
+
 Pure aliases
 ~~~~~~~~~~~~
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -890,6 +890,9 @@ Capsule objects
    The type of :py:ref:`capsule objects <capsules>`.
    See :py:class:`types.CapsuleType`, where it has existed since Python 3.13.
 
+   Note that this may not exist on all implementations of Python; it is only
+   guaranteed to exist on CPython.
+
    .. versionadded:: 4.12.0
 
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -31,7 +31,7 @@ from typing_extensions import Protocol, runtime, runtime_checkable, Annotated, f
 from typing_extensions import TypeVarTuple, Unpack, dataclass_transform, reveal_type, Never, assert_never, LiteralString
 from typing_extensions import assert_type, get_type_hints, get_origin, get_args, get_original_bases
 from typing_extensions import clear_overloads, get_overloads, overload
-from typing_extensions import NamedTuple, TypeIs, no_type_check, Dict, CapsuleType
+from typing_extensions import NamedTuple, TypeIs, no_type_check, Dict
 from typing_extensions import override, deprecated, Buffer, TypeAliasType, TypeVar, get_protocol_members, is_protocol
 from typing_extensions import Doc, NoDefault, List, Union, AnyStr, Iterable, Generic, Optional, Set, Tuple, Callable
 from _typed_dict_test_helper import Foo, FooGeneric, VeryAnnotated
@@ -6765,10 +6765,14 @@ class DocTests(BaseTestCase):
             self.assertEqual(doc_info, pickle.loads(pickled))
 
 
+@skipUnless(
+    hasattr(typing_extensions, "CapsuleType"),
+    "CapsuleType is not available on all platforms"
+)
 class CapsuleTypeTests(BaseTestCase):
     def test_capsule_type(self):
         import _datetime
-        self.assertIsInstance(_datetime.datetime_CAPI, CapsuleType)
+        self.assertIsInstance(_datetime.datetime_CAPI, typing_extensions.CapsuleType)
 
 
 if __name__ == '__main__':

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -31,7 +31,7 @@ from typing_extensions import Protocol, runtime, runtime_checkable, Annotated, f
 from typing_extensions import TypeVarTuple, Unpack, dataclass_transform, reveal_type, Never, assert_never, LiteralString
 from typing_extensions import assert_type, get_type_hints, get_origin, get_args, get_original_bases
 from typing_extensions import clear_overloads, get_overloads, overload
-from typing_extensions import NamedTuple, TypeIs, no_type_check, Dict
+from typing_extensions import NamedTuple, TypeIs, no_type_check, Dict, CapsuleType
 from typing_extensions import override, deprecated, Buffer, TypeAliasType, TypeVar, get_protocol_members, is_protocol
 from typing_extensions import Doc, NoDefault, List, Union, AnyStr, Iterable, Generic, Optional, Set, Tuple, Callable
 from _typed_dict_test_helper import Foo, FooGeneric, VeryAnnotated
@@ -6763,6 +6763,12 @@ class DocTests(BaseTestCase):
         for proto in range(pickle.HIGHEST_PROTOCOL):
             pickled = pickle.dumps(doc_info, protocol=proto)
             self.assertEqual(doc_info, pickle.loads(pickled))
+
+
+class CapsuleTypeTests(BaseTestCase):
+    def test_capsule_type(self):
+        import _datetime
+        self.assertIsInstance(_datetime.datetime_CAPI, CapsuleType)
 
 
 if __name__ == '__main__':

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6767,7 +6767,7 @@ class DocTests(BaseTestCase):
 
 @skipUnless(
     hasattr(typing_extensions, "CapsuleType"),
-    "CapsuleType is not available on all platforms"
+    "CapsuleType is not available on all Python implementations"
 )
 class CapsuleTypeTests(BaseTestCase):
     def test_capsule_type(self):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1,4 +1,3 @@
-import _socket
 import abc
 import collections
 import collections.abc
@@ -57,7 +56,6 @@ __all__ = [
 
     # One-off things.
     'Annotated',
-    'CapsuleType',
     'assert_never',
     'assert_type',
     'clear_overloads',
@@ -3413,7 +3411,21 @@ else:
             return self.documentation == other.documentation
 
 
-CapsuleType = getattr(_types, "CapsuleType", type(_socket.CAPI))
+_CapsuleType = getattr(_types, "CapsuleType", None)
+
+if _CapsuleType is None:
+    try:
+        import _socket
+    except ImportError:
+        pass
+    else:
+        _CAPI = getattr(_socket, "CAPI", None)
+        if _CAPI is not None:
+            _CapsuleType = type(_CAPI)
+
+if _CapsuleType is not None:
+    CapsuleType = _CapsuleType
+    __all__.append("CapsuleType")
 
 
 # Aliases for items that have always been in typing.

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1,3 +1,4 @@
+import _socket
 import abc
 import collections
 import collections.abc
@@ -56,6 +57,7 @@ __all__ = [
 
     # One-off things.
     'Annotated',
+    'CapsuleType',
     'assert_never',
     'assert_type',
     'clear_overloads',
@@ -3409,6 +3411,9 @@ else:
             if not isinstance(other, Doc):
                 return NotImplemented
             return self.documentation == other.documentation
+
+
+CapsuleType = getattr(_types, "CapsuleType", type(_socket.CAPI))
 
 
 # Aliases for items that have always been in typing.


### PR DESCRIPTION
Fixes #374. I'm still not sure how useful this really is, but (as long as this all works with PyPy), it's pretty easy to backport -- so why not.