### PR TITLE
Allow type parameters without default values to follow those with default values in some situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   at runtime rather than `types.NoneType`.
 - Fix most tests for `TypeVar`, `ParamSpec` and `TypeVarTuple` on Python
   3.13.0b1 and newer.
+- Backport CPython PR [#118774](https://github.com/python/cpython/pull/118774),
+  allowing type parameters without default values to follow those with
+  default values in some type parameter lists. Patch by Alex Waygood,
+  backporting a CPython PR by Jelle Zijlstra.
 - Fix `Protocol` tests on Python 3.13.0a6 and newer. 3.13.0a6 adds a new
   `__static_attributes__` attribute to all classes in Python,
   which broke some assumptions made by the implementation of

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6430,6 +6430,24 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
                 self.assertEqual(z.__bound__, typevar.__bound__)
                 self.assertEqual(z.__default__, typevar.__default__)
 
+    def test_allow_default_after_non_default_in_alias(self):
+        T_default = TypeVar('T_default', default=int)
+        T = TypeVar('T')
+        Ts = TypeVarTuple('Ts')
+
+        a1 = Callable[[T_default], T]
+        self.assertEqual(a1.__args__, (T_default, T))
+
+        if sys.version_info >= (3, 9):
+            a2 = dict[T_default, T]
+            self.assertEqual(a2.__args__, (T_default, T))
+
+        a3 = typing.Dict[T_default, T]
+        self.assertEqual(a3.__args__, (T_default, T))
+
+        a4 = Callable[[Unpack[Ts]], T]
+        self.assertEqual(a4.__args__, (Unpack[Ts], T))
+
 
 class NoDefaultTests(BaseTestCase):
     @skip_if_py313_beta_1

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6430,6 +6430,7 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
                 self.assertEqual(z.__bound__, typevar.__bound__)
                 self.assertEqual(z.__default__, typevar.__default__)
 
+    @skip_if_py313_beta_1
     def test_allow_default_after_non_default_in_alias(self):
         T_default = TypeVar('T_default', default=int)
         T = TypeVar('T')

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2934,8 +2934,8 @@ else:
         parameters = []
 
         # required TypeVarLike cannot appear after TypeVarLike with default
-        # if it was a direct call to `Generic[]` or `Protocol[]`
         default_encountered = False
+        # if it was a direct call to `Generic[]` or `Protocol[]`
         enforce_default_ordering = _has_generic_or_protocol_as_origin()
 
         # or after TypeVarTuple

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2896,10 +2896,10 @@ if hasattr(typing, '_collect_type_vars'):
         tvars = []
 
         # required TypeVarLike cannot appear after TypeVarLike with default
-        # if it was a direct call to `Generic[]` or `Protocol[]`
         default_encountered = False
         # or after TypeVarTuple
         type_var_tuple_encountered = False
+        # if it was a direct call to `Generic[]` or `Protocol[]`
         enforce_default_ordering = _has_generic_or_protocol_as_origin()
         for t in types:
             if _is_unpacked_typevartuple(t):
@@ -2954,7 +2954,9 @@ else:
             elif hasattr(t, '__typing_subst__'):
                 if t not in parameters:
                     if enforce_default_ordering:
-                        has_default = getattr(t, '__default__', NoDefault) is not NoDefault
+                        has_default = (
+                            getattr(t, '__default__', NoDefault) is not NoDefault
+                        )
 
                         if type_var_tuple_encountered and has_default:
                             raise TypeError('Type parameter with a default'

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2895,12 +2895,12 @@ if hasattr(typing, '_collect_type_vars'):
             typevar_types = typing.TypeVar
         tvars = []
 
-        # A required TypeVarLike cannot appear after TypeVarLike with default
+        # A required TypeVarLike cannot appear after a TypeVarLike with a default
         # if it was a direct call to `Generic[]` or `Protocol[]`
         enforce_default_ordering = _has_generic_or_protocol_as_origin()
         default_encountered = False
 
-        # A TypeVarLike with a default also cannot appear after a TypeVarTuple
+        # Also, a TypeVarLike with a default cannot appear after a TypeVarTuple
         type_var_tuple_encountered = False
 
         for t in types:
@@ -2935,11 +2935,12 @@ else:
         """
         parameters = []
 
-        # required TypeVarLike cannot appear after TypeVarLike with default
+        # A required TypeVarLike cannot appear after a TypeVarLike with default
         # if it was a direct call to `Generic[]` or `Protocol[]`
+        enforce_default_ordering = _has_generic_or_protocol_as_origin()
         default_encountered = False
 
-        # Also, a TypeVarLike with a default cannot appear after TypeVarTuple
+        # Also, a TypeVarLike with a default cannot appear after a TypeVarTuple
         type_var_tuple_encountered = False
 
         for t in args:

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2895,12 +2895,14 @@ if hasattr(typing, '_collect_type_vars'):
             typevar_types = typing.TypeVar
         tvars = []
 
-        # required TypeVarLike cannot appear after TypeVarLike with default
-        default_encountered = False
-        # or after TypeVarTuple
-        type_var_tuple_encountered = False
+        # A required TypeVarLike cannot appear after TypeVarLike with default
         # if it was a direct call to `Generic[]` or `Protocol[]`
         enforce_default_ordering = _has_generic_or_protocol_as_origin()
+        default_encountered = False
+
+        # A TypeVarLike with a default also cannot appear after a TypeVarTuple
+        type_var_tuple_encountered = False
+
         for t in types:
             if _is_unpacked_typevartuple(t):
                 type_var_tuple_encountered = True
@@ -2934,12 +2936,12 @@ else:
         parameters = []
 
         # required TypeVarLike cannot appear after TypeVarLike with default
-        default_encountered = False
         # if it was a direct call to `Generic[]` or `Protocol[]`
-        enforce_default_ordering = _has_generic_or_protocol_as_origin()
+        default_encountered = False
 
-        # or after TypeVarTuple
+        # Also, a TypeVarLike with a default cannot appear after TypeVarTuple
         type_var_tuple_encountered = False
+
         for t in args:
             if isinstance(t, type):
                 # We don't want __parameters__ descriptor of a bare Python class.


### PR DESCRIPTION
This is a backport of https://github.com/python/cpython/pull/118774. The implementation feels unbelievably hacky (we're looking up the value of a local variable in frame two levels up the call stack), but I can't see another way of doing it. I initially tried an approach where we monkeypatched `_GenericAlias.__init__`, but this didn't work: see https://github.com/python/cpython/pull/118774#issuecomment-2108631342.