### PR TITLE
Don't turn list defaults for ParamSpecs into tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 - It is now disallowed to use a `TypeVar` with a default value after a
   `TypeVarTuple` in a type parameter list. This matches the CPython
   implementation of PEP 696 on Python 3.13+.
+- Fix bug in PEP-696 implementation where default values for `ParamSpec`s
+  would be cast to tuples if a list was provided as the default value.
+  Patch by Alex Waygood.
 - Fix `Protocol` tests on Python 3.13.0a6 and newer. 3.13.0a6 adds a new
   `__static_attributes__` attribute to all classes in Python,
   which broke some assumptions made by the implementation of

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -4997,7 +4997,7 @@ class ParamSpecTests(BaseTestCase):
         P = ParamSpec('P')
         P_co = ParamSpec('P_co', covariant=True)
         P_contra = ParamSpec('P_contra', contravariant=True)
-        P_default = ParamSpec('P_default', default=int)
+        P_default = ParamSpec('P_default', default=[int])
         for proto in range(pickle.HIGHEST_PROTOCOL):
             with self.subTest(f'Pickle protocol {proto}'):
                 for paramspec in (P, P_co, P_contra, P_default):
@@ -6456,6 +6456,17 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
                 self.assertEqual(z.__contravariant__, typevar.__contravariant__)
                 self.assertEqual(z.__bound__, typevar.__bound__)
                 self.assertEqual(z.__default__, typevar.__default__)
+
+    def test_strange_defaults_are_allowed(self):
+        # Leave it to type checkers to check whether strange default values
+        # should be allowed or disallowed
+        def not_a_type(): ...
+
+        for typevarlike_cls in TypeVar, ParamSpec, TypeVarTuple:
+            for default in not_a_type, 42, bytearray(), (int, not_a_type, 42):
+                with self.subTest(typevarlike_cls=typevarlike_cls, default=default):
+                    T = typevarlike_cls("T", default=default)
+                    self.assertEqual(T.__default__, default)
 
     @skip_if_py313_beta_1
     def test_allow_default_after_non_default_in_alias(self):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6363,8 +6363,8 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         self.assertTrue(U_None.has_default())
 
     def test_paramspec(self):
-        P = ParamSpec('P', default=(str, int))
-        self.assertEqual(P.__default__, (str, int))
+        P = ParamSpec('P', default=[str, int])
+        self.assertEqual(P.__default__, [str, int])
         self.assertTrue(P.has_default())
         self.assertIsInstance(P, ParamSpec)
         if hasattr(typing, "ParamSpec"):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1467,17 +1467,7 @@ else:
 
 def _set_default(type_param, default):
     type_param.has_default = lambda: default is not NoDefault
-    if isinstance(default, (tuple, list)):
-        type_param.__default__ = type(default)(
-            typing._type_check(d, "Default must be a type") for d in default
-        )
-    elif default in (None, NoDefault):
-        type_param.__default__ = default
-    else:
-        if isinstance(type_param, ParamSpec) and default is ...:  # ... not valid <3.11
-            type_param.__default__ = default
-        else:
-            type_param.__default__ = typing._type_check(default, "Default must be a type")
+    type_param.__default__ = default
 
 
 def _set_module(typevarlike):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1468,8 +1468,9 @@ else:
 def _set_default(type_param, default):
     type_param.has_default = lambda: default is not NoDefault
     if isinstance(default, (tuple, list)):
-        type_param.__default__ = tuple((typing._type_check(d, "Default must be a type")
-                                        for d in default))
+        type_param.__default__ = type(default)(
+            typing._type_check(d, "Default must be a type") for d in default
+        )
     elif default in (None, NoDefault):
         type_param.__default__ = default
     else:


### PR DESCRIPTION
PEP 696 specifies that default values for ParamSpecs must be lists, and CPython on 3.13 keeps them as a list for the `__default__` attribute:

```pycon
Python 3.14.0a0 (heads/cleanup-typing:2e98d5dbf9, May 11 2024, 12:20:48) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> def foo[**P = [str, int]](): pass
... 
>>> foo.__type_params__[0].__default__
[<class 'str'>, <class 'int'>]
>>> 
```

Currently in the `typing_extensions` version, however, we turn any list into a tuple, which seems wrong:

```pycon
(main) % python                                                                                                          ~/dev/typing_extensions/src
Python 3.12.3 (main, Apr 30 2024, 10:12:02) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from typing_extensions import ParamSpec
>>> ParamSpec("P", default=[int, str]).__default__
(<class 'int'>, <class 'str'>)
```

This PR fixes that.