### PR TITLE
Backport PEP-696 specialisation on Python >=3.11.1

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6402,6 +6402,10 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         class A(Generic[Unpack[Ts]]): ...
         Alias = Optional[Unpack[Ts]]
 
+    @skipIf(
+        sys.version_info < (3, 11),
+        "Not yet backported for older versions of Python"
+    )
     def test_typevartuple_specialization(self):
         T = TypeVar("T")
         Ts = TypeVarTuple('Ts', default=Unpack[Tuple[str, int]])
@@ -6411,6 +6415,10 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         self.assertEqual(A[float, range].__args__, (float, range))
         self.assertEqual(A[float, Unpack[tuple[int, ...]]].__args__, (float, Unpack[tuple[int, ...]]))
 
+    @skipIf(
+        sys.version_info < (3, 11),
+        "Not yet backported for older versions of Python"
+    )
     def test_typevar_and_typevartuple_specialization(self):
         T = TypeVar("T")
         U = TypeVar("U", default=float)
@@ -6507,6 +6515,10 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         a4 = Callable[[Unpack[Ts]], T]
         self.assertEqual(a4.__args__, (Unpack[Ts], T))
 
+    @skipIf(
+        sys.version_info < (3, 11),
+        "Not yet backported for older versions of Python"
+    )
     def test_paramspec_specialization(self):
         T = TypeVar("T")
         P = ParamSpec('P', default=[str, int])
@@ -6515,6 +6527,10 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         self.assertEqual(A[float].__args__, (float, (str, int)))
         self.assertEqual(A[float, [range]].__args__, (float, (range,)))
 
+    @skipIf(
+        sys.version_info < (3, 11),
+        "Not yet backported for older versions of Python"
+    )
     def test_typevar_and_paramspec_specialization(self):
         T = TypeVar("T")
         U = TypeVar("U", default=float)
@@ -6525,6 +6541,10 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         self.assertEqual(A[float, int].__args__, (float, int, (str, int)))
         self.assertEqual(A[float, int, [range]].__args__, (float, int, (range,)))
 
+    @skipIf(
+        sys.version_info < (3, 11),
+        "Not yet backported for older versions of Python"
+    )
     def test_paramspec_and_typevar_specialization(self):
         T = TypeVar("T")
         P = ParamSpec('P', default=[str, int])

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6403,7 +6403,7 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         Alias = Optional[Unpack[Ts]]
 
     @skipIf(
-        sys.version_info < (3, 11),
+        sys.version_info < (3, 11, 1),
         "Not yet backported for older versions of Python"
     )
     def test_typevartuple_specialization(self):
@@ -6416,7 +6416,7 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         self.assertEqual(A[float, Unpack[tuple[int, ...]]].__args__, (float, Unpack[tuple[int, ...]]))
 
     @skipIf(
-        sys.version_info < (3, 11),
+        sys.version_info < (3, 11, 1),
         "Not yet backported for older versions of Python"
     )
     def test_typevar_and_typevartuple_specialization(self):
@@ -6516,7 +6516,7 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         self.assertEqual(a4.__args__, (Unpack[Ts], T))
 
     @skipIf(
-        sys.version_info < (3, 11),
+        sys.version_info < (3, 11, 1),
         "Not yet backported for older versions of Python"
     )
     def test_paramspec_specialization(self):
@@ -6528,7 +6528,7 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         self.assertEqual(A[float, [range]].__args__, (float, (range,)))
 
     @skipIf(
-        sys.version_info < (3, 11),
+        sys.version_info < (3, 11, 1),
         "Not yet backported for older versions of Python"
     )
     def test_typevar_and_paramspec_specialization(self):
@@ -6542,7 +6542,7 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         self.assertEqual(A[float, int, [range]].__args__, (float, int, (range,)))
 
     @skipIf(
-        sys.version_info < (3, 11),
+        sys.version_info < (3, 11, 1),
         "Not yet backported for older versions of Python"
     )
     def test_paramspec_and_typevar_specialization(self):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6402,6 +6402,26 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         class A(Generic[Unpack[Ts]]): ...
         Alias = Optional[Unpack[Ts]]
 
+    def test_typevartuple_specialization(self):
+        T = TypeVar("T")
+        Ts = TypeVarTuple('Ts', default=Unpack[Tuple[str, int]])
+        self.assertEqual(Ts.__default__, Unpack[Tuple[str, int]])
+        class A(Generic[T, Unpack[Ts]]): ...
+        self.assertEqual(A[float].__args__, (float, str, int))
+        self.assertEqual(A[float, range].__args__, (float, range))
+        self.assertEqual(A[float, *tuple[int, ...]].__args__, (float, *tuple[int, ...]))
+
+    def test_typevar_and_typevartuple_specialization(self):
+        T = TypeVar("T")
+        U = TypeVar("U", default=float)
+        Ts = TypeVarTuple('Ts', default=Unpack[Tuple[str, int]])
+        self.assertEqual(Ts.__default__, Unpack[Tuple[str, int]])
+        class A(Generic[T, U, Unpack[Ts]]): ...
+        self.assertEqual(A[int].__args__, (int, float, str, int))
+        self.assertEqual(A[int, str].__args__, (int, str, str, int))
+        self.assertEqual(A[int, str, range].__args__, (int, str, range))
+        self.assertEqual(A[int, str, *tuple[int, ...]].__args__, (int, str, *tuple[int, ...]))
+
     def test_no_default_after_typevar_tuple(self):
         T = TypeVar("T", default=int)
         Ts = TypeVarTuple("Ts")
@@ -6486,6 +6506,34 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
 
         a4 = Callable[[Unpack[Ts]], T]
         self.assertEqual(a4.__args__, (Unpack[Ts], T))
+
+    def test_paramspec_specialization(self):
+        T = TypeVar("T")
+        P = ParamSpec('P', default=[str, int])
+        self.assertEqual(P.__default__, [str, int])
+        class A(Generic[T, P]): ...
+        self.assertEqual(A[float].__args__, (float, (str, int)))
+        self.assertEqual(A[float, [range]].__args__, (float, (range,)))
+
+    def test_typevar_and_paramspec_specialization(self):
+        T = TypeVar("T")
+        U = TypeVar("U", default=float)
+        P = ParamSpec('P', default=[str, int])
+        self.assertEqual(P.__default__, [str, int])
+        class A(Generic[T, U, P]): ...
+        self.assertEqual(A[float].__args__, (float, float, (str, int)))
+        self.assertEqual(A[float, int].__args__, (float, int, (str, int)))
+        self.assertEqual(A[float, int, [range]].__args__, (float, int, (range,)))
+
+    def test_paramspec_and_typevar_specialization(self):
+        T = TypeVar("T")
+        P = ParamSpec('P', default=[str, int])
+        U = TypeVar("U", default=float)
+        self.assertEqual(P.__default__, [str, int])
+        class A(Generic[T, P, U]): ...
+        self.assertEqual(A[float].__args__, (float, (str, int), float))
+        self.assertEqual(A[float, [range]].__args__, (float, (range,), float))
+        self.assertEqual(A[float, [range], int].__args__, (float, (range,), int))
 
 
 class NoDefaultTests(BaseTestCase):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6409,7 +6409,7 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         class A(Generic[T, Unpack[Ts]]): ...
         self.assertEqual(A[float].__args__, (float, str, int))
         self.assertEqual(A[float, range].__args__, (float, range))
-        self.assertEqual(A[float, *tuple[int, ...]].__args__, (float, *tuple[int, ...]))
+        self.assertEqual(A[float, Unpack[tuple[int, ...]]].__args__, (float, Unpack[tuple[int, ...]]))
 
     def test_typevar_and_typevartuple_specialization(self):
         T = TypeVar("T")
@@ -6420,7 +6420,7 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         self.assertEqual(A[int].__args__, (int, float, str, int))
         self.assertEqual(A[int, str].__args__, (int, str, str, int))
         self.assertEqual(A[int, str, range].__args__, (int, str, range))
-        self.assertEqual(A[int, str, *tuple[int, ...]].__args__, (int, str, *tuple[int, ...]))
+        self.assertEqual(A[int, str, Unpack[tuple[int, ...]]].__args__, (int, str, Unpack[tuple[int, ...]]))
 
     def test_no_default_after_typevar_tuple(self):
         T = TypeVar("T", default=int)

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1515,6 +1515,13 @@ else:
                 typevar.__infer_variance__ = infer_variance
             _set_default(typevar, default)
             _set_module(typevar)
+
+            def _tvar_prepare_subst(alias, args):
+                if alias.__parameters__.index(typevar) == len(args) and typevar.has_default():
+                    args += (typevar.__default__,)
+                return args
+
+            typevar.__typing_prepare_subst__ = _tvar_prepare_subst
             return typevar
 
         def __init_subclass__(cls) -> None:
@@ -1589,7 +1596,6 @@ if _PEP_696_IMPLEMENTED:
 
 # 3.10+
 elif hasattr(typing, 'ParamSpec'):
-
     # Add default parameter - PEP 696
     class ParamSpec(metaclass=_TypeVarLikeMeta):
         """Parameter specification."""
@@ -1613,6 +1619,24 @@ elif hasattr(typing, 'ParamSpec'):
 
             _set_default(paramspec, default)
             _set_module(paramspec)
+
+            def _paramspec_prepare_subst(alias, args):
+                params = alias.__parameters__
+                i = params.index(paramspec)
+                if i == len(args) and paramspec.has_default():
+                    args = [*args, paramspec.__default__]
+                if i >= len(args):
+                    raise TypeError(f"Too few arguments for {alias}")
+                # Special case where Z[[int, str, bool]] == Z[int, str, bool] in PEP 612.
+                if len(params) == 1 and not _is_param_expr(args[0]):
+                    assert i == 0
+                    args = (args,)
+                # Convert lists to tuples to help other libraries cache the results.
+                elif isinstance(args[i], list):
+                    args = (*args[:i], tuple(args[i]), *args[i+1:])
+                return args
+
+            paramspec.__typing_prepare_subst__ = _paramspec_prepare_subst
             return paramspec
 
         def __init_subclass__(cls) -> None:
@@ -2311,6 +2335,17 @@ elif sys.version_info[:2] >= (3, 9):  # 3.9+
     class _UnpackAlias(typing._GenericAlias, _root=True):
         __class__ = typing.TypeVar
 
+        @property
+        def __typing_unpacked_tuple_args__(self):
+            assert self.__origin__ is Unpack
+            assert len(self.__args__) == 1
+            arg, = self.__args__
+            if isinstance(arg, (typing._GenericAlias, _types.GenericAlias)):
+                if arg.__origin__ is not tuple:
+                    raise TypeError("Unpack[...] must be used with a tuple type")
+                return arg.__args__
+            return None
+
     @_UnpackSpecialForm
     def Unpack(self, parameters):
         item = typing._type_check(parameters, f'{self._name} accepts only a single type.')
@@ -2339,6 +2374,15 @@ if _PEP_696_IMPLEMENTED:
     from typing import TypeVarTuple
 
 elif hasattr(typing, "TypeVarTuple"):  # 3.11+
+    def _unpack_args(*args):
+        newargs = []
+        for arg in args:
+            subargs = getattr(arg, '__typing_unpacked_tuple_args__', None)
+            if subargs is not None and not (subargs and subargs[-1] is ...):
+                newargs.extend(subargs)
+            else:
+                newargs.append(arg)
+        return newargs
 
     # Add default parameter - PEP 696
     class TypeVarTuple(metaclass=_TypeVarLikeMeta):
@@ -2350,6 +2394,48 @@ elif hasattr(typing, "TypeVarTuple"):  # 3.11+
             tvt = typing.TypeVarTuple(name)
             _set_default(tvt, default)
             _set_module(tvt)
+
+            def _typevartuple_prepare_subst(alias, args):
+                params = alias.__parameters__
+                typevartuple_index = params.index(tvt)
+                for param in params[typevartuple_index + 1:]:
+                    if isinstance(param, TypeVarTuple):
+                        raise TypeError(f"More than one TypeVarTuple parameter in {alias}")
+
+                alen = len(args)
+                plen = len(params)
+                left = typevartuple_index
+                right = plen - typevartuple_index - 1
+                var_tuple_index = None
+                fillarg = None
+                for k, arg in enumerate(args):
+                    if not isinstance(arg, type):
+                        subargs = getattr(arg, '__typing_unpacked_tuple_args__', None)
+                        if subargs and len(subargs) == 2 and subargs[-1] is ...:
+                            if var_tuple_index is not None:
+                                raise TypeError("More than one unpacked arbitrary-length tuple argument")
+                            var_tuple_index = k
+                            fillarg = subargs[0]
+                if var_tuple_index is not None:
+                    left = min(left, var_tuple_index)
+                    right = min(right, alen - var_tuple_index - 1)
+                elif left + right > alen:
+                    raise TypeError(f"Too few arguments for {alias};"
+                                    f" actual {alen}, expected at least {plen-1}")
+                if left == alen - right and tvt.has_default():
+                    replacement = _unpack_args(tvt.__default__)
+                else:
+                    replacement = args[left: alen - right]
+
+                return (
+                    *args[:left],
+                    *([fillarg]*(typevartuple_index - left)),
+                    replacement,
+                    *([fillarg]*(plen - right - left - typevartuple_index - 1)),
+                    *args[alen - right:],
+                )
+
+            tvt.__typing_prepare_subst__ = _typevartuple_prepare_subst
             return tvt
 
         def __init_subclass__(self, *args, **kwds):


### PR DESCRIPTION
This is a fix for #396 on Python 3.11 and Python 3.12. Unfortunately, the `__typing_prepare_subst__` hook doesn't exist on Python 3.10 and lower, so I'm not sure it's possible to backport it on older versions of Python without monkeypatching `typing._GenericAlias.__getitem__`, which seems like a bad idea. So maybe we should just document that not all features of PEP-696 are guaranteed to work on Python <=3.10?