### PR TITLE
Make sure `isinstance(typing_extensions.ParamSpec("P"), typing.TypeVar)` is unaffected by `sys.setprofile()`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,9 @@ jobs:
           export path_to_file=$(find dist -type f -name "typing_extensions-*.tar.gz")
           echo "::notice::Unpacking source distribution: $path_to_file"
           tar xzf $path_to_file -C dist/
+          ls -a
           cd ${path_to_file%.tar.gz}
+          ls -a
           python src/test_typing_extensions.py
 
   test-sdist-installed:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,8 +92,8 @@ jobs:
           export path_to_file=$(find dist -type f -name "typing_extensions-*.tar.gz")
           echo "::notice::Unpacking source distribution: $path_to_file"
           tar xzf $path_to_file -C dist/
-          cd ${path_to_file%.tar.gz}
-          python src/test_typing_extensions.py
+          cd ${path_to_file%.tar.gz}/src
+          python test_typing_extensions.py
 
   test-sdist-installed:
     name: Test installed source distribution

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,8 +92,8 @@ jobs:
           export path_to_file=$(find dist -type f -name "typing_extensions-*.tar.gz")
           echo "::notice::Unpacking source distribution: $path_to_file"
           tar xzf $path_to_file -C dist/
-          cd ${path_to_file%.tar.gz}/src
-          python test_typing_extensions.py
+          cd ${path_to_file%.tar.gz}
+          python src/test_typing_extensions.py
 
   test-sdist-installed:
     name: Test installed source distribution

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,9 +92,7 @@ jobs:
           export path_to_file=$(find dist -type f -name "typing_extensions-*.tar.gz")
           echo "::notice::Unpacking source distribution: $path_to_file"
           tar xzf $path_to_file -C dist/
-          ls -a
           cd ${path_to_file%.tar.gz}
-          ls -a
           python src/test_typing_extensions.py
 
   test-sdist-installed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+- Fix incorrect behaviour of `typing_extensions.ParamSpec` on Python 3.8 and
+  3.9 that meant that
+  `isinstance(typing_extensions.ParamSpec("P"), typing.TypeVar)` would have a
+  different result in some situations depending on whether or not a profiling
+  function had been set using `sys.setprofile`. Patch by Alex Waygood.
+
 # Release 4.12.0rc1 (May 16, 2024)
 
 This release focuses on compatibility with the upcoming release of

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5027,9 +5027,6 @@ class ParamSpecTests(BaseTestCase):
         code = textwrap.dedent(
             """\
             import sys, typing
-            import os
-            print(f'{os.getcwd()=}')
-            print(f'{os.environ["PYTHONPATH"]=}')
 
             def trace_call(*args):
                 return trace_call

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -10,6 +10,7 @@ import copy
 from functools import lru_cache
 import importlib
 import inspect
+import os
 import pickle
 import re
 import subprocess
@@ -5050,7 +5051,7 @@ class ParamSpecTests(BaseTestCase):
                 check=True,
                 capture_output=True,
                 text=True,
-                cwd=".",
+                env={**os.environ, "PYTHONPATH": "."},
             )
         except subprocess.CalledProcessError as exc:
             print("stdout", exc.stdout, sep="\n")

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5046,7 +5046,11 @@ class ParamSpecTests(BaseTestCase):
         # and makes other tests fail:
         try:
             proc = subprocess.run(
-                [sys.executable, "-c", code], check=True, capture_output=True, text=True,
+                [sys.executable, "-c", code],
+                check=True,
+                capture_output=True,
+                text=True,
+                shell=True,
             )
         except subprocess.CalledProcessError as exc:
             print("stdout", exc.stdout, sep="\n")

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -10,7 +10,6 @@ import copy
 from functools import lru_cache
 import importlib
 import inspect
-import os
 import pickle
 import re
 import subprocess
@@ -5051,7 +5050,7 @@ class ParamSpecTests(BaseTestCase):
                 check=True,
                 capture_output=True,
                 text=True,
-                env={**os.environ, "PYTHONPATH": "."},
+                cwd=".",
             )
         except subprocess.CalledProcessError as exc:
             print("stdout", exc.stdout, sep="\n")

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5046,11 +5046,7 @@ class ParamSpecTests(BaseTestCase):
         # and makes other tests fail:
         try:
             proc = subprocess.run(
-                [sys.executable, "-c", code],
-                check=True,
-                capture_output=True,
-                text=True,
-                shell=True,
+                [sys.executable, "-c", code], check=True, capture_output=True, text=True,
             )
         except subprocess.CalledProcessError as exc:
             print("stdout", exc.stdout, sep="\n")

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -11,6 +11,7 @@ from functools import lru_cache
 import importlib
 import inspect
 import pickle
+import os
 import re
 import subprocess
 import tempfile
@@ -5046,7 +5047,11 @@ class ParamSpecTests(BaseTestCase):
         # and makes other tests fail:
         try:
             proc = subprocess.run(
-                [sys.executable, "-c", code], check=True, capture_output=True, text=True,
+                [sys.executable, "-c", code],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=os.environ
             )
         except subprocess.CalledProcessError as exc:
             print("stdout", exc.stdout, sep="\n")

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5027,6 +5027,9 @@ class ParamSpecTests(BaseTestCase):
         code = textwrap.dedent(
             """\
             import sys, typing
+            import os
+            print(f'{os.getcwd()=}')
+            print(f'{os.environ["PYTHONPATH"]=}')
 
             def trace_call(*args):
                 return trace_call

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5046,7 +5046,11 @@ class ParamSpecTests(BaseTestCase):
         # and makes other tests fail:
         try:
             proc = subprocess.run(
-                [sys.executable, "-c", code], check=True, capture_output=True, text=True,
+                [sys.executable, "-c", code],
+                check=True,
+                capture_output=True,
+                text=True,
+                cwd=".",
             )
         except subprocess.CalledProcessError as exc:
             print("stdout", exc.stdout, sep="\n")

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5046,11 +5046,7 @@ class ParamSpecTests(BaseTestCase):
         # and makes other tests fail:
         try:
             proc = subprocess.run(
-                [sys.executable, "-c", code],
-                check=True,
-                capture_output=True,
-                text=True,
-                cwd=".",
+                [sys.executable, "-c", code], check=True, capture_output=True, text=True,
             )
         except subprocess.CalledProcessError as exc:
             print("stdout", exc.stdout, sep="\n")

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -11,7 +11,6 @@ from functools import lru_cache
 import importlib
 import inspect
 import pickle
-import os
 import re
 import subprocess
 import tempfile
@@ -5047,11 +5046,7 @@ class ParamSpecTests(BaseTestCase):
         # and makes other tests fail:
         try:
             proc = subprocess.run(
-                [sys.executable, "-c", code],
-                check=True,
-                capture_output=True,
-                text=True,
-                env=os.environ
+                [sys.executable, "-c", code], check=True, capture_output=True, text=True,
             )
         except subprocess.CalledProcessError as exc:
             print("stdout", exc.stdout, sep="\n")

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5044,9 +5044,14 @@ class ParamSpecTests(BaseTestCase):
 
         # Run this in an isolated process or it pollutes the environment
         # and makes other tests fail:
-        proc = subprocess.run(
-            [sys.executable, "-c", code], check=True, capture_output=True, text=True,
-        )
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-c", code], check=True, capture_output=True, text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            print("stdout", exc.stdout, sep="\n")
+            print("stderr", exc.stderr, sep="\n")
+            raise
 
         # Sanity checks that assert the test is working as expected
         self.assertIsInstance(proc.stdout, str)

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1711,7 +1711,7 @@ else:
 
         def __init__(self, name, *, bound=None, covariant=False, contravariant=False,
                      infer_variance=False, default=NoDefault):
-            super().__init__([self])
+            list.__init__(self, [self])
             self.__name__ = name
             self.__covariant__ = bool(covariant)
             self.__contravariant__ = bool(contravariant)


### PR DESCRIPTION
Fixes #318. The workaround here is to avoid the `super()` call -- the `super()` call accesses the `__class__` variable from the `__init__` method, which due to a CPython bug on Python <=3.10 means that `__class__` is removed from `ParamSpec.__dict__` if a profiling function has been set.