### PR TITLE
Backport bugfixes made to how `inspect.get_annotations()` deals with PEP-695

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-# Release 4.12.2 (June 7, 2024)
+# Unreleased
 
 - Add `typing_extensions.get_annotations`, a backport of
   `inspect.get_annotations` that adds features specified
-  by PEP 649. Patch by Jelle Zijlstra.
+  by PEP 649. Patches by Jelle Zijlstra and Alex Waygood.
+
+# Release 4.12.2 (June 7, 2024)
+
 - Fix regression in v4.12.0 where specialization of certain
   generics with an overridden `__eq__` method would raise errors.
   Patch by Jelle Zijlstra.

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3734,7 +3734,13 @@ else:
         if globals is None:
             globals = obj_globals
         if locals is None:
-            locals = obj_locals
+            locals = obj_locals or {}
+
+        # "Inject" type parameters into the local namespace
+        # (unless they are shadowed by assignments *in* the local namespace),
+        # as a way of emulating annotation scopes when calling `eval()`
+        if type_params := getattr(obj, "__type_params__", ()):
+            locals = {param.__name__: param for param in type_params} | locals
 
         return_value = {key:
             value if not isinstance(value, str) else eval(value, globals, locals)


### PR DESCRIPTION
Backport of https://github.com/python/cpython/pull/120270 and https://github.com/python/cpython/pull/120550