### PR TITLE
Support ParamSpec for TypeAliasType

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -110,6 +110,7 @@ jobs:
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Install typing_inspect test dependencies
         run: |
+          set -x
           cd typing_inspect
           uv pip install --system -r test-requirements.txt --exclude-newer $(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)
       - name: Install typing_extensions latest
@@ -158,6 +159,7 @@ jobs:
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Install pyanalyze test requirements
         run: |
+          set -x
           cd pyanalyze
           uv pip install --system 'pyanalyze[tests] @ .' --exclude-newer $(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)
       - name: Install typing_extensions latest
@@ -206,6 +208,7 @@ jobs:
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Install typeguard test requirements
         run: |
+          set -x
           cd typeguard
           uv pip install --system "typeguard[test] @ ."  --exclude-newer $(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)
       - name: Install typing_extensions latest
@@ -259,6 +262,7 @@ jobs:
           git config --global user.name "Your Name"
       - name: Install typed-argument-parser test requirements
         run: |
+          set -x
           cd typed-argument-parser
           uv pip install --system "typed-argument-parser @ ."  --exclude-newer $(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)
           uv pip install --system pytest  --exclude-newer $(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)
@@ -308,6 +312,7 @@ jobs:
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Install mypy test requirements
         run: |
+          set -x
           cd mypy
           uv pip install --system -r test-requirements.txt  --exclude-newer $(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)
           uv pip install --system -e .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
   subscripted objects) had wrong parameters if they were directly
   subscripted with an `Unpack` object.
   Patch by [Daraan](https://github.com/Daraan).
+- Fix that lists and ... could not be used for parameter expressions for `TypeAliasType`
+  instances before Python 3.11.
+  Patch by [Daraan](https://github.com/Daraan).
 
 # Release 4.12.2 (June 7, 2024)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7207,7 +7207,7 @@ class TypeAliasTypeTests(BaseTestCase):
         fully_subscripted = still_generic[float]
         self.assertEqual(get_args(fully_subscripted), (Iterable[float],))
         self.assertIs(get_origin(fully_subscripted), ListOrSetT)
-        
+
         # Test ParamSpec and Ellipsis
         P = ParamSpec('P')
         CallableP = TypeAliasType("CallableP", Callable[P, Any], type_params=(P,))

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7285,6 +7285,7 @@ class TypeAliasTypeTests(BaseTestCase):
             # arguments : expected parameters
             int : (),
             ... : (),
+            None : (),
             T2 : (T2,),
             Union[int, List[T2]] : (T2,),
             Tuple[int, str] : (),

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7342,26 +7342,10 @@ class TypeAliasTypeTests(BaseTestCase):
 
         # More complex cases
         Ts = TypeVarTuple("Ts")
-        CallableTs = TypeAliasType("CallableTs", Callable[[Unpack[Ts]], Any], type_params=(Ts, ))
-        unpack_callable = CallableTs[Unpack[Tuple[int, T]]]
-        if TYPING_3_11_0:
-            self.assertEqual(get_args(unpack_callable), (Unpack[Tuple[int, T]],))
-        else:
-            self.assertEqual(get_args(unpack_callable), (Tuple[int, T],))
-        self.assertEqual(unpack_callable.__parameters__, (T,))
-
         Variadic = TypeAliasType("Variadic", Tuple[int, Unpack[Ts]], type_params=(Ts,))
         mixed_subscripedPT = Variadic[Callable[Concatenate[int,  P], T]]
-        self.assertEqual(mixed_subscripedPT.__parameters__, (P, T))
         self.assertEqual(get_args(mixed_subscripedPT), (Callable[Concatenate[int,  P], T],))
 
-        done_subscripted_no_list = mixed_subscripedPT[T, Any] # Expected ParamSpec, ellipsis, or list of types
-        if TYPING_3_10_0:
-            done_subscripted_list = mixed_subscripedPT[[T], Any]
-            self.assertEqual(done_subscripted_list, done_subscripted_no_list)
-        else:
-            with self.assertRaises(TypeError, msg="Parameters to generic types must be types."):
-                mixed_subscripedPT[[T], Any]
 
     @skipUnless(TYPING_3_11_0, "__args__ behaves differently")
     def test_311_substitution(self):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7332,6 +7332,10 @@ class TypeAliasTypeTests(BaseTestCase):
                 subscripted = alias[int, float]
                 self.assertEqual(get_args(subscripted), (int, float))
                 self.assertEqual(subscripted.__parameters__, ())
+            with self.subTest(alias=alias, args=[int, float]):
+                subscripted = alias[[int, float]]
+                self.assertEqual(get_args(subscripted), ([int, float],))
+                self.assertEqual(subscripted.__parameters__, ())
             for expected_args, expected_parameters in test_argument_cases.items():
                 with self.subTest(alias=alias, args=expected_args):
                     self.assertEqual(get_args(alias[expected_args]), (expected_args,))

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7318,10 +7318,6 @@ class TypeAliasTypeTests(BaseTestCase):
 
     def test_getitem(self):
         T = TypeVar('T')
-        ValueWithoutT = TypeAliasType("ValueWithoutT", int, type_params=(T,))
-        still_subscripted = ValueWithoutT[str]
-        self.assertEqual(get_args(still_subscripted), (str,))
-
         ListOrSetT = TypeAliasType("ListOrSetT", Union[List[T], Set[T]], type_params=(T,))
         subscripted = ListOrSetT[int]
         self.assertEqual(get_args(subscripted), (int,))
@@ -7335,6 +7331,10 @@ class TypeAliasTypeTests(BaseTestCase):
         fully_subscripted = still_generic[float]
         self.assertEqual(get_args(fully_subscripted), (Iterable[float],))
         self.assertIs(get_origin(fully_subscripted), ListOrSetT)
+
+        ValueWithoutTypeVar = TypeAliasType("ValueWithoutTypeParam", int, type_params=(T,))
+        still_subscripted = ValueWithoutTypeVar[str]
+        self.assertEqual(get_args(still_subscripted), (str,))
 
     def test_callable_without_concatenate(self):
         P = ParamSpec('P')
@@ -7396,7 +7396,6 @@ class TypeAliasTypeTests(BaseTestCase):
         CallableP = TypeAliasType("CallableP", Callable[P, T], type_params=(P, T))
         callable_concat = CallableP[Concatenate[int, P], Any]
         self.assertEqual(get_args(callable_concat), (Concatenate[int, P], Any))
-        self.assertEqual(callable_concat.__parameters__, (P,))
 
     @skipUnless(TYPING_3_12_0, "__args__ behaves differently")
     def test_substitution_312_plus(self):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7390,8 +7390,8 @@ class TypeAliasTypeTests(BaseTestCase):
         T = TypeVar("T")
         T2 = TypeVar("T2")
         ListOrSetT = TypeAliasType("ListOrSetT", Union[List[T], Set[T]], type_params=(T,))
-        too_many = ListOrSetT[int, bool]
 
+        too_many = ListOrSetT[int, bool]
         self.assertEqual(get_args(too_many), (int, bool))
         self.assertEqual(too_many.__parameters__, ())
 
@@ -7416,55 +7416,33 @@ class TypeAliasTypeTests(BaseTestCase):
         self.assertEqual(callable_too_many.__parameters__, (T2, ))
         self.assertEqual(get_args(callable_too_many), (str, float, T2, int, ))
 
-        # Test with Concatenate
-        callable_concat = CallableP[Concatenate[Any, T2, P], Any]
-        self.assertEqual(callable_concat.__parameters__, (T2, P))
+        # Cases that result in parameterless variable
+
+        # Callable
+        CallableT = CallableP[[T]]
+        self.assertEqual(get_args(CallableT), ([T],))
+        self.assertEqual(CallableT.__parameters__, ())
+        with self.assertRaises(TypeError, msg="is not a generic class"):
+            CallableT[str]
+
+        ImplicitConcatP = CallableP[[int, P]]
+        self.assertEqual(get_args(ImplicitConcatP), ([int, P],))
+        self.assertEqual(ImplicitConcatP.__parameters__, ())
+        with self.assertRaises(TypeError, msg="is not a generic class"):
+            ImplicitConcatP[str]
 
         # TypeVarTuple
         Ts = TypeVarTuple("Ts")
         Variadic = TypeAliasType("Variadic", Tuple[int, Unpack[Ts]], type_params=(Ts,))
-        # No Unpack
-        invalid_tuple_A = Variadic[Tuple[int, T]]
-        self.assertEqual(invalid_tuple_A.__parameters__, (T, ))
-        self.assertEqual(get_args(invalid_tuple_A), (Tuple[int, T], ))
-
-        # To type tuple
-        invalid_tuple_B = Variadic[int, T]
-        self.assertEqual(invalid_tuple_B.__parameters__, (T, ))
 
         # No Tuple, but list
-        invalud_tuple_C = Variadic[[int, T]]
-        self.assertEqual(invalud_tuple_C.__parameters__, ())
-        self.assertEqual(get_args(invalud_tuple_C), ([int, T],))
+        invalid_tupleT = Variadic[[int, T]]
+        self.assertEqual(invalid_tupleT.__parameters__, ())
+        self.assertEqual(get_args(invalid_tupleT), ([int, T],))
 
-        # Callable
-        # NOTE: This these cases seem to be more like a limitation in the typing variant
-        # The final variable is parameterless if using a list here.
-        callable_T = CallableP[[T]]
-        self.assertEqual(get_args(callable_T), ([T],))
-        self.assertEqual(callable_T.__parameters__, ())
         with self.assertRaises(TypeError, msg="is not a generic class"):
-            callable_T[str]
+            invalid_tupleT[str]
 
-        InvalidConcatP = CallableP[[int, P]]
-        self.assertEqual(get_args(InvalidConcatP), ([int, P],))
-        self.assertEqual(InvalidConcatP.__parameters__, ())
-        with self.assertRaises(TypeError, msg="is not a generic class"):
-            InvalidConcatP[str]
-
-        # Callable
-        # NOTE: This these cases seem to be more like a limitation in the typing variant
-        callable_T = CallableP[[T]]
-        self.assertEqual(get_args(callable_T), ([T],))
-        self.assertEqual(callable_T.__parameters__, ())
-        with self.assertRaises(TypeError, msg="is not a generic class"):
-            callable_T[str]
-
-        InvalidConcatP = CallableP[[int, P]]
-        self.assertEqual(get_args(InvalidConcatP), ([int, P],))
-        self.assertEqual(InvalidConcatP.__parameters__, ())
-        with self.assertRaises(TypeError, msg="is not a generic class"):
-            InvalidConcatP[str]
 
     @skipIf(TYPING_3_11_0, "Most cases are allowed in 3.11+")
     def test_invalid_cases_before_3_11(self):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7237,7 +7237,7 @@ class TypeAliasTypeTests(BaseTestCase):
         self.assertEqual(get_args(subscripted), (int,))
         self.assertIs(get_origin(subscripted), ListOrSetT)
         with self.assertRaises(TypeError):
-            subscripted[str]
+            subscripted[int]  # TypeError: ListOrSetT[int] is not a generic class
 
         still_generic = ListOrSetT[Iterable[T]]
         self.assertEqual(get_args(still_generic), (Iterable[T],))
@@ -7273,6 +7273,14 @@ class TypeAliasTypeTests(BaseTestCase):
         self.assertEqual(get_args(callable_generic), ([T],))
         callable_generic_raw = CallableP[T]
         self.assertEqual(get_args(callable_generic_raw), (T,))
+        
+        # test invalid usage
+        if not TYPING_3_11_0:
+            with self.assertRaises(TypeError):
+                ListOrSetT[Generic[T]]
+            with self.assertRaises(TypeError):
+                ListOrSetT[(Generic[T], )]
+        
 
     def test_pickle(self):
         global Alias

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7203,11 +7203,9 @@ class TypeAliasTypeTests(BaseTestCase):
             Unpack[Ts] : (Ts,),
             Unpack[Tuple[int, T2]] : (T2,),
             Concatenate[int,  P] : (P,),
+            # Not tested usage of bare TypeVarTuple, would need 3.11+
+            # Ts : (Ts,),  # invalid case
         }
-        test_argument_cases_311_plus = {
-            Ts : (Ts,),  # invalid case
-        }
-        test_argument_cases.update(test_argument_cases_311_plus)
 
         test_alias_cases = [
             # Simple cases
@@ -7241,8 +7239,6 @@ class TypeAliasTypeTests(BaseTestCase):
                 self.assertEqual(subscripted.__parameters__, ())
             for expected_args, expected_parameters in test_argument_cases.items():
                 with self.subTest(alias=alias, args=expected_args):
-                    if expected_args in test_argument_cases_311_plus and sys.version_info < (3, 11):
-                        self.skipTest("Case is not valid before 3.11")
                     self.assertEqual(get_args(alias[expected_args]), (expected_args,))
                     self.assertEqual(alias[expected_args].__parameters__, expected_parameters)
 
@@ -7419,9 +7415,9 @@ class TypeAliasTypeTests(BaseTestCase):
                 self.assertEqual(get_args(alias), expected_args)
                 self.assertEqual(alias.__parameters__, expected_params)
 
-    # The condition should align with the version of GeneriAlias usage in __getitem__
+    # The condition should align with the version of GeneriAlias usage in __getitem__ or be 3.11+
     @skipIf(TYPING_3_10_0, "Most arguments are allowed in 3.11+ or with GenericAlias")
-    def test_invalid_cases_before_3_11(self):
+    def test_invalid_cases_before_3_10(self):
         T = TypeVar('T')
         ListOrSetT = TypeAliasType("ListOrSetT", Union[List[T], Set[T]], type_params=(T,))
         with self.assertRaises(TypeError):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7200,10 +7200,6 @@ class TypeAliasTypeTests(BaseTestCase):
             Callable[P, T2] : (P, T2),
             Callable[Concatenate[T2,  P], T_default] : (T2, P, T_default),
             TypeAliasType("NestedAlias", List[T], type_params=(T,))[T2] : (T2,),
-        }
-        # currently a limitation, these args are no longer unpacked in 3.11
-        # OK if GenericAlias in __getitem__ is used
-        test_argument_cases_310_plus = {
             Unpack[Ts] : (Ts,),
             Unpack[Tuple[int, T2]] : (T2,),
             Concatenate[int,  P] : (P,),
@@ -7211,7 +7207,6 @@ class TypeAliasTypeTests(BaseTestCase):
         test_argument_cases_311_plus = {
             Ts : (Ts,),  # invalid case
         }
-        test_argument_cases.update(test_argument_cases_310_plus)
         test_argument_cases.update(test_argument_cases_311_plus)
 
         test_alias_cases = [
@@ -7249,8 +7244,6 @@ class TypeAliasTypeTests(BaseTestCase):
                 self.assertEqual(subscripted.__parameters__, ())
             for expected_args, expected_parameters in test_argument_cases.items():
                 with self.subTest(alias=alias, args=expected_args):
-                    if expected_args in test_argument_cases_310_plus and sys.version_info < (3, 10):
-                        self.skipTest("args are unpacked before 3.11 or need GenericAlias")
                     if expected_args in test_argument_cases_311_plus and sys.version_info < (3, 11):
                         self.skipTest("Case is not valid before 3.11")
                     self.assertEqual(get_args(alias[expected_args]), (expected_args,))

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7372,8 +7372,6 @@ class TypeAliasTypeTests(BaseTestCase):
             self.assertEqual(concat_usage, callable_concat[[str]])
 
     def test_substitution(self):
-        # To pass these tests alias.__args__ in TypeAliasType.__getitem__ needs adjustment
-        # Unpack and Concatenate are unpacked in versions before
         T = TypeVar('T')
         Ts = TypeVarTuple("Ts")
 
@@ -7418,7 +7416,7 @@ class TypeAliasTypeTests(BaseTestCase):
                 self.assertEqual(alias.__parameters__, expected_params)
 
     # The condition should align with the version of GeneriAlias usage in __getitem__
-    @skipIf(TYPING_3_10_0, "Most cases are allowed in 3.11+ or with GenericAlias")
+    @skipIf(TYPING_3_10_0, "Most arguments are allowed in 3.11+ or with GenericAlias")
     def test_invalid_cases_before_3_11(self):
         T = TypeVar('T')
         ListOrSetT = TypeAliasType("ListOrSetT", Union[List[T], Set[T]], type_params=(T,))

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7339,9 +7339,7 @@ class TypeAliasTypeTests(BaseTestCase):
 
         # Test with Concatenate
         callable_concat = CallableP[Concatenate[Any, T2, P], Any]
-        reveal_type(callable_concat)
         self.assertEqual(callable_concat.__parameters__, (T2, P))
-        self.assertEqual(get_args(callable_concat), (Concatenate[Any, T2, P], Any))
 
         # TypeVarTuple
         Ts = TypeVarTuple("Ts")
@@ -7359,6 +7357,15 @@ class TypeAliasTypeTests(BaseTestCase):
         invalud_tuple_C = Variadic[[int, T]]
         self.assertEqual(invalud_tuple_C.__parameters__, ())
         self.assertEqual(get_args(invalud_tuple_C), ([int, T],))
+        
+    @skipUnless(TYPING_3_11_0, "Concatenate not unpacked anymore")
+    def test_further_invalid_cases(self):
+        P = ParamSpec('P')
+        T = TypeVar("T")
+        T2 = TypeVar("T2")
+        CallableP = TypeAliasType("CallableP", Callable[P, T], type_params=(P,))
+        callable_concat = CallableP[Concatenate[Any, T2, P], Any]
+        self.assertEqual(get_args(callable_concat), (Concatenate[Any, T2, P], Any))
 
     def test_pickle(self):
         global Alias

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7457,6 +7457,24 @@ class TypeAliasTypeTests(BaseTestCase):
         with self.assertRaises(TypeError):
             ListOrSetT[(Generic[T], )]
 
+    def test_subscription_without_type_params(self):
+        Simple = TypeAliasType("Simple", int)
+        with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
+            Simple[int]
+        with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
+            Simple[[]]
+        with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
+            Simple[()]
+
+        # no TypeVar in type_params, however in value still allows subscription
+        T = TypeVar("T")
+        MissingTypeParams = TypeAliasType("MissingTypeParams", List[T], type_params=())
+        self.assertEqual(MissingTypeParams.__type_params__, ())
+        self.assertEqual(MissingTypeParams.__parameters__, ())
+        # These should not raise:
+        MissingTypeParams[int]
+        MissingTypeParams[[]]
+        MissingTypeParams[()]
 
     def test_pickle(self):
         global Alias

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7273,14 +7273,14 @@ class TypeAliasTypeTests(BaseTestCase):
         self.assertEqual(get_args(callable_generic), ([T],))
         callable_generic_raw = CallableP[T]
         self.assertEqual(get_args(callable_generic_raw), (T,))
-        
+
         # test invalid usage
         if not TYPING_3_11_0:
             with self.assertRaises(TypeError):
                 ListOrSetT[Generic[T]]
             with self.assertRaises(TypeError):
                 ListOrSetT[(Generic[T], )]
-        
+
 
     def test_pickle(self):
         global Alias

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7357,12 +7357,16 @@ class TypeAliasTypeTests(BaseTestCase):
 
     def test_callable_with_concatenate(self):
         P = ParamSpec('P')
+        P2 = ParamSpec('P2')
         CallableP = TypeAliasType("CallableP", Callable[P, Any], type_params=(P,))
 
-        callable_concat = CallableP[Concatenate[int, P]]
-        self.assertEqual(callable_concat.__parameters__, (P,))
+        callable_concat = CallableP[Concatenate[int, P2]]
+        self.assertEqual(callable_concat.__parameters__, (P2,))
         concat_usage = callable_concat[str]
         with self.subTest("get_args of Concatenate in TypeAliasType"):
+            if not TYPING_3_9_0:
+                # args are: ([<class 'int'>, ~P2],)
+                self.skipTest("Nested ParamSpec is not substituted")
             if sys.version_info < (3, 10, 2):
                 self.skipTest("GenericAlias keeps Concatenate in __args__ prior to 3.10.2")
             self.assertEqual(get_args(concat_usage), ((int, str),))

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7515,40 +7515,6 @@ class TypeAliasTypeTests(BaseTestCase):
         with self.assertRaises(TypeError):
             ListOrSetT[(Generic[T], )]
 
-    def test_subscription_without_type_params(self):
-        Simple = TypeAliasType("Simple", int)
-        with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
-            Simple[int]
-        with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
-            Simple[[]]
-        with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
-            Simple[()]
-       
-        # A TypeVar in the value does not allow subscription
-        T = TypeVar('T')
-        MissingTypeParamsErr = TypeAliasType("MissingTypeParamsErr", List[T])
-        self.assertEqual(MissingTypeParamsErr.__type_params__, ())
-        self.assertEqual(MissingTypeParamsErr.__parameters__, ())
-        with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
-            MissingTypeParamsErr[int]
-        with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
-            MissingTypeParamsErr[[]]
-        with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
-            MissingTypeParamsErr[()]
-            
-        # However, providing type_params=() argument allows subscription
-        MissingTypeParams = TypeAliasType("MissingTypeParams", List[T], type_params=())
-        self.assertEqual(MissingTypeParams.__type_params__, ())
-        self.assertEqual(MissingTypeParams.__parameters__, ())
-        # These do not raise
-        MissingTypeParams[int]
-        MissingTypeParams[[]]
-        MissingTypeParams[()]
-        # These do not raise
-        Simple2 = TypeAliasType("Simple2", int, type_params=())
-        Simple2[int]
-        Simple2[[]]
-        Simple2[()]
 
     def test_pickle(self):
         global Alias

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7439,34 +7439,6 @@ class TypeAliasTypeTests(BaseTestCase):
                 self.assertEqual(get_args(alias), expected_args)
                 self.assertEqual(alias.__parameters__, expected_params)
 
-    def test_list_argument(self):
-        # NOTE: These cases could be seen as valid but result in a parameterless
-        # variable. If these tests fail the specificiation might have changed
-
-        # Callable
-        P = ParamSpec('P')
-        CallableP = TypeAliasType("CallableP", Callable[P, Any], type_params=(P,))
-        CallableT_list = CallableP[[T]]
-        self.assertEqual(get_args(CallableT_list), ([T],))
-        self.assertEqual(CallableT_list.__parameters__, ())
-        with self.assertRaises(TypeError, msg="is not a generic class"):
-            CallableT_list[str]
-
-        ImplicitConcatP = CallableP[[int, P]]
-        self.assertEqual(get_args(ImplicitConcatP), ([int, P],))
-        self.assertEqual(ImplicitConcatP.__parameters__, ())
-        with self.assertRaises(TypeError, msg="is not a generic class"):
-            ImplicitConcatP[str]
-
-        # TypeVarTuple
-        Ts = TypeVarTuple("Ts")
-        Variadic = TypeAliasType("Variadic", Tuple[int, Unpack[Ts]], type_params=(Ts,))
-        invalid_tupleT = Variadic[[int, T]]
-        self.assertEqual(get_args(invalid_tupleT), ([int, T],))
-        self.assertEqual(invalid_tupleT.__parameters__, ())
-        with self.assertRaises(TypeError, msg="is not a generic class"):
-            invalid_tupleT[str]
-
     # The condition should align with the version of GeneriAlias usage in __getitem__
     @skipIf(TYPING_3_10_0, "Most cases are allowed in 3.11+ or with GenericAlias")
     def test_invalid_cases_before_3_11(self):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3572,13 +3572,13 @@ class ProtocolTests(BaseTestCase):
         self.assertEqual(Alias, Alias2)
 
     def test_protocols_pickleable(self):
-        global GlobalProto, CP  # pickle wants to reference the class by name
+        global P, CP  # pickle wants to reference the class by name
         T = TypeVar('T')
 
         @runtime_checkable
-        class GlobalProto(Protocol[T]):
+        class P(Protocol[T]):
             x = 1
-        class CP(GlobalProto[int]):
+        class CP(P[int]):
             pass
 
         c = CP()
@@ -3591,7 +3591,7 @@ class ProtocolTests(BaseTestCase):
             self.assertEqual(x.bar, 'abc')
             self.assertEqual(x.x, 1)
             self.assertEqual(x.__dict__, {'foo': 42, 'bar': 'abc'})
-            s = pickle.dumps(GlobalProto)
+            s = pickle.dumps(P)
             D = pickle.loads(s)
             class E:
                 x = 1

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7456,40 +7456,27 @@ class TypeAliasTypeTests(BaseTestCase):
         CallablePT = TypeAliasType("CallablePT", Callable[P, T], type_params=(P, T))
 
         # Not enough parameters
-        not_enough = TwoT[int]
-        self.assertEqual(get_args(not_enough), (int,))
-        self.assertEqual(not_enough.__parameters__, ())
+        test_cases = [
+            # not_enough
+            (TwoT[int],                              [(int,), ()]),
+            (TwoT[T],                                [(T,), (T,)]),
+            # callable and not enough
+            (CallablePT[int],                        [(int,), ()]),
+            # too many
+            (ListOrSetT[int, bool],                  [(int, bool), ()]),
+            # callable and too many
+            (CallablePT[str, float, int],            [(str, float, int), ()]),
+            # Check if TypeVar is still present even if over substituted
+            (ListOrSetT[int, T],                     [(int, T), (T,)]),
+            # With and without list for ParamSpec
+            (CallablePT[str, float, T],              [(str, float, T), (T,)]),
+            (CallablePT[[str], float, int, T2],      [([str], float, int, T2), (T2,)]),
+        ]
 
-        not_enough2 = TwoT[T]
-        self.assertEqual(get_args(not_enough2), (T,))
-        self.assertEqual(not_enough2.__parameters__, (T,))
-
-        callable_not_enough = CallablePT[int]
-        self.assertEqual(get_args(callable_not_enough), (int, ))
-        self.assertEqual(callable_not_enough.__parameters__, ())
-
-        # Too many
-        too_many = ListOrSetT[int, bool]
-        self.assertEqual(get_args(too_many), (int, bool))
-        self.assertEqual(too_many.__parameters__, ())
-
-        callable_too_many = CallablePT[str, float, int]
-        self.assertEqual(get_args(callable_too_many), (str, float, int))
-        self.assertEqual(callable_too_many.__parameters__, ())
-
-        # Check if TypeVar is still present even if over substituted
-        too_manyT = ListOrSetT[int, T]
-        self.assertEqual(get_args(too_manyT), (int, T))
-        self.assertEqual(too_manyT.__parameters__, (T, ))
-
-        # With and without list for ParamSpec
-        callable_too_manyT = CallablePT[str, float, T]
-        self.assertEqual(get_args(callable_too_manyT), (str, float, T))
-        self.assertEqual(callable_too_manyT.__parameters__, (T, ))
-
-        callable_too_manyT2 = CallablePT[[str], float, int, T2]
-        self.assertEqual(get_args(callable_too_manyT2), ([str], float, int, T2))
-        self.assertEqual(callable_too_manyT2.__parameters__, (T2, ))
+        for index, (alias, [expected_args, expected_params]) in enumerate(test_cases):
+            with self.subTest(index=index, alias=alias):
+                self.assertEqual(get_args(alias), expected_args)
+                self.assertEqual(alias.__parameters__, expected_params)
 
     def test_list_argument(self):
         # NOTE: These cases could be seen as valid but result in a parameterless

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7224,9 +7224,6 @@ class TypeAliasTypeTests(BaseTestCase):
             # TypeVar with default
             TypeAliasType("TupleT_default", Tuple[T_default, T], type_params=(T, T_default)),
             TypeAliasType("CallableT_default", Callable[[T], T_default], type_params=(T, T_default)),
-            # default order reversed
-            TypeAliasType("TupleT_default_reversed", Tuple[T_default, T], type_params=(T_default, T)),
-            TypeAliasType("CallableT_default_reversed", Callable[[T], T_default], type_params=(T_default, T)),
         ]
 
         for alias in test_alias_cases:

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7180,40 +7180,6 @@ class TypeAliasTypeTests(BaseTestCase):
         self.assertEqual(CallableP.__type_params__, (P,))
         self.assertEqual(CallableP.__parameters__, (P,))
 
-    def test_attributes_from_origin(self):
-        T = TypeVar('T')
-        ListOrSetT = TypeAliasType("ListOrSetT", Union[List[T], Set[T]], type_params=(T,))
-        subscripted = ListOrSetT[int]
-        self.assertIs(get_origin(subscripted), ListOrSetT)
-        self.assertEqual(subscripted.__name__, "ListOrSetT")
-        self.assertEqual(subscripted.__value__, Union[List[T], Set[T]],)
-        self.assertEqual(subscripted.__type_params__, (T, ))
-
-        still_generic = ListOrSetT[Iterable[T]]
-        self.assertIs(get_origin(still_generic), ListOrSetT)
-        fully_subscripted = still_generic[float]
-        self.assertIs(get_origin(fully_subscripted), ListOrSetT)
-        # __name__ needs Python 3.10+
-        # __value__ and __type_params__ need Python 3.12+
-        # Further tests are below
-
-    @skipUnless(TYPING_3_10_0, "__name__ not added to GenericAlias")
-    def test_attributes_from_origin_3_10_plus(self):
-        T = TypeVar('T')
-        ListOrSetT = TypeAliasType("ListOrSetT", Union[List[T], Set[T]], type_params=(T,))
-        fully_subscripted = ListOrSetT[Iterable[T]][float]
-        self.assertEqual(fully_subscripted.__name__, "ListOrSetT")
-        # __value__ and __type_params__ need Python 3.12+
-
-    @skipUnless(TYPING_3_12_0, "attributes not added to GenericAlias")
-    def test_attributes_from_origin_3_12_plus(self):
-        T = TypeVar('T')
-        ListOrSetT = TypeAliasType("ListOrSetT", Union[List[T], Set[T]], type_params=(T,))
-        fully_subscripted = ListOrSetT[Iterable[T]][float]
-        self.assertEqual(fully_subscripted.__name__, "ListOrSetT")
-        self.assertEqual(fully_subscripted.__value__, Union[List[T], Set[T]],)
-        self.assertEqual(fully_subscripted.__type_params__, (T, ))
-
     def test_alias_types_and_substitutions(self):
         T = TypeVar('T')
         T2 = TypeVar('T2')
@@ -7359,13 +7325,16 @@ class TypeAliasTypeTests(BaseTestCase):
         ListOrSetT = TypeAliasType("ListOrSetT", Union[List[T], Set[T]], type_params=(T,))
         subscripted = ListOrSetT[int]
         self.assertEqual(get_args(subscripted), (int,))
+        self.assertIs(get_origin(subscripted), ListOrSetT)
         with self.assertRaises(TypeError, msg="not a generic class"):
             subscripted[int]
 
         still_generic = ListOrSetT[Iterable[T]]
         self.assertEqual(get_args(still_generic), (Iterable[T],))
+        self.assertIs(get_origin(still_generic), ListOrSetT)
         fully_subscripted = still_generic[float]
         self.assertEqual(get_args(fully_subscripted), (Iterable[float],))
+        self.assertIs(get_origin(fully_subscripted), ListOrSetT)
 
     def test_callable_without_concatenate(self):
         P = ParamSpec('P')

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7389,25 +7389,6 @@ class TypeAliasTypeTests(BaseTestCase):
         callable_concat = CallableP[Concatenate[int, P], Any]
         self.assertEqual(get_args(callable_concat), (Concatenate[int, P], Any))
 
-    @skipUnless(TYPING_3_12_0, "__args__ behaves differently")
-    def test_substitution_312_plus(self):
-        # To pass these tests alias.__args__ in TypeAliasType.__getitem__ needs adjustment
-        # Would raise: TypeError: Substitution of bare TypeVarTuple is not supported
-        T = TypeVar('T')
-        Ts = TypeVarTuple("Ts")
-        Variadic = TypeAliasType("Variadic", Tuple[int, Unpack[Ts]], type_params=(Ts,))
-
-        subcriped_callable_tvt = Variadic[Callable[[Unpack[Ts]], T]]
-        variadic_tvt_callableA = subcriped_callable_tvt[str, object]
-        variadic_tvt_callableA2 = subcriped_callable_tvt[Unpack[Tuple[str]], object]
-        self.assertEqual(variadic_tvt_callableA, variadic_tvt_callableA2)
-
-        variadic_tvt_callableB = subcriped_callable_tvt[[str, int], object]
-        variadic_tvt_callableB2 = subcriped_callable_tvt[Unpack[Tuple[str, int]], object]
-        variadic_tvt_callableB3 = subcriped_callable_tvt[str, int, object]
-        self.assertNotEqual(variadic_tvt_callableB, variadic_tvt_callableB2)
-        self.assertEqual(variadic_tvt_callableB2, variadic_tvt_callableB3)
-
     def test_wrong_amount_of_parameters(self):
         T = TypeVar('T')
         T2 = TypeVar("T2")

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7185,15 +7185,21 @@ class TypeAliasTypeTests(BaseTestCase):
         self.assertEqual(Variadic.__type_params__, (Ts,))
         self.assertEqual(Variadic.__parameters__, tuple(iter(Ts)))
 
-        subscripted_tuple = Variadic[Unpack[Tuple[int, float]]]
+        # Test bare
+        subscripted_tuple = Variadic[int, float]
         self.assertEqual(subscripted_tuple.__name__, "Variadic")
         self.assertEqual(subscripted_tuple.__value__, Tuple[int, Unpack[Ts]])
         self.assertEqual(subscripted_tuple.__type_params__, (Ts,))
         self.assertEqual(subscripted_tuple.__parameters__, ())
 
+        # Test with Unpack
         subscripted_tupleT = Variadic[Unpack[Tuple[int, T]]]
         self.assertEqual(subscripted_tupleT.__name__, "Variadic")
         self.assertEqual(subscripted_tupleT.__parameters__, (T, ))
+
+        # Test with Unpack and TypeVarTuple
+        subscripted_Ts = Variadic[Unpack[Ts]]
+        self.assertEqual(subscripted_Ts.__parameters__, (Ts, ))
 
         # Use with Callable
         # Use with Callable+Concatenate

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7523,16 +7523,32 @@ class TypeAliasTypeTests(BaseTestCase):
             Simple[[]]
         with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
             Simple[()]
-
-        # no TypeVar in type_params, however in value still allows subscription
+       
+        # A TypeVar in the value does not allow subscription
         T = TypeVar('T')
+        MissingTypeParamsErr = TypeAliasType("MissingTypeParamsErr", List[T])
+        self.assertEqual(MissingTypeParamsErr.__type_params__, ())
+        self.assertEqual(MissingTypeParamsErr.__parameters__, ())
+        with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
+            MissingTypeParamsErr[int]
+        with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
+            MissingTypeParamsErr[[]]
+        with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
+            MissingTypeParamsErr[()]
+            
+        # However, providing type_params=() argument allows subscription
         MissingTypeParams = TypeAliasType("MissingTypeParams", List[T], type_params=())
         self.assertEqual(MissingTypeParams.__type_params__, ())
         self.assertEqual(MissingTypeParams.__parameters__, ())
-        # These should not raise:
+        # These do not raise
         MissingTypeParams[int]
         MissingTypeParams[[]]
         MissingTypeParams[()]
+        # These do not raise
+        Simple2 = TypeAliasType("Simple2", int, type_params=())
+        Simple2[int]
+        Simple2[[]]
+        Simple2[()]
 
     def test_pickle(self):
         global Alias

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7218,9 +7218,8 @@ class TypeAliasTypeTests(BaseTestCase):
             # Simple cases
             TypeAliasType("ListT", List[T], type_params=(T,)),
             TypeAliasType("UnionT", Union[int, List[T]], type_params=(T,)),
-            # Either value or type_params contain generic
+            # Value has no parameter but in type_param
             TypeAliasType("ValueWithoutT", int, type_params=(T,)),
-            TypeAliasType("ValueTNoParams", List[T], type_params=()),
             # Callable
             TypeAliasType("CallableP", Callable[P, Any], type_params=(P, )),
             TypeAliasType("CallableT", Callable[..., T], type_params=(T, )),

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7329,18 +7329,15 @@ class TypeAliasTypeTests(BaseTestCase):
         callable_concat = CallableP[Concatenate[int, P]]
         self.assertEqual(callable_concat.__parameters__, (P,))
         if TYPING_3_11_0:
-            self.assertEqual(get_args(callable_concat), (Concatenate[int, P],))
             concat_usage = callable_concat[str]
             self.assertEqual(get_args(concat_usage), ((int, str),))
             self.assertEqual(concat_usage, callable_concat[[str]])
         elif TYPING_3_10_0:
-            self.assertEqual(get_args(callable_concat), (int, P,))
             with self.assertRaises(TypeError, msg="Parameters to generic types must be types"):
                 callable_concat[str]
             concat_usage = callable_concat[[str]]
             self.assertEqual(get_args(concat_usage), (int, [str]))
         else:
-            self.assertEqual(get_args(callable_concat), (int, P,))
             with self.assertRaises(TypeError, msg="Parameters to generic types must be types"):
                 callable_concat[[str]]
             concat_usage = callable_concat[str]

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -3572,13 +3572,13 @@ class ProtocolTests(BaseTestCase):
         self.assertEqual(Alias, Alias2)
 
     def test_protocols_pickleable(self):
-        global P, CP  # pickle wants to reference the class by name
+        global GlobalProto, CP  # pickle wants to reference the class by name
         T = TypeVar('T')
 
         @runtime_checkable
-        class P(Protocol[T]):
+        class GlobalProto(Protocol[T]):
             x = 1
-        class CP(P[int]):
+        class CP(GlobalProto[int]):
             pass
 
         c = CP()
@@ -3591,7 +3591,7 @@ class ProtocolTests(BaseTestCase):
             self.assertEqual(x.bar, 'abc')
             self.assertEqual(x.x, 1)
             self.assertEqual(x.__dict__, {'foo': 42, 'bar': 'abc'})
-            s = pickle.dumps(P)
+            s = pickle.dumps(GlobalProto)
             D = pickle.loads(s)
             class E:
                 x = 1
@@ -7232,6 +7232,7 @@ class TypeAliasTypeTests(BaseTestCase):
             Alias | "Ref"
 
     def test_getitem(self):
+        T = TypeVar("T")
         ListOrSetT = TypeAliasType("ListOrSetT", Union[List[T], Set[T]], type_params=(T,))
         subscripted = ListOrSetT[int]
         self.assertEqual(get_args(subscripted), (int,))

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7484,6 +7484,22 @@ class TypeAliasTypeTests(BaseTestCase):
         with self.assertRaises(TypeError):
             ListOrSetT[(Generic[T], )]
 
+    def test_unpack_parameter_collection(self):
+        Ts = TypeVarTuple("Ts")
+
+        class Foo(Generic[Unpack[Ts]]):
+            bar: Tuple[Unpack[Ts]]
+
+        FooAlias = TypeAliasType("FooAlias", Foo[Unpack[Ts]], type_params=(Ts,))
+        self.assertEqual(FooAlias[Unpack[Tuple[str]]].__parameters__, ())
+        self.assertEqual(FooAlias[Unpack[Tuple[T]]].__parameters__, (T,))
+
+        P = ParamSpec("P")
+        CallableP = TypeAliasType("CallableP", Callable[P, Any], type_params=(P,))
+        call_int_T = CallableP[Unpack[Tuple[int, T]]]
+        self.assertEqual(call_int_T.__parameters__, (T,))
+
+
     def test_alias_attributes(self):
         T = TypeVar('T')
         T2 = TypeVar('T2')

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7207,6 +7207,34 @@ class TypeAliasTypeTests(BaseTestCase):
         fully_subscripted = still_generic[float]
         self.assertEqual(get_args(fully_subscripted), (Iterable[float],))
         self.assertIs(get_origin(fully_subscripted), ListOrSetT)
+        
+        # Test ParamSpec and Ellipsis
+        P = ParamSpec('P')
+        CallableP = TypeAliasType("CallableP", Callable[P, Any], type_params=(P,))
+        # () -> Any
+        callable_no_arg = CallableP[[]]
+        self.assertEqual(get_args(callable_no_arg), ([],))
+        # (int) -> Any
+        callable_arg_raw = CallableP[int]
+        self.assertEqual(get_args(callable_arg_raw), (int,))
+        callable_arg = CallableP[[int]]
+        self.assertEqual(get_args(callable_arg), ([int],))
+        # (int, int) -> Any
+        callable_arg2 = CallableP[[int, int]]
+        self.assertEqual(get_args(callable_arg2), ([int, int],))
+        # (...) -> Any
+        callable_ellipsis = CallableP[...]
+        self.assertEqual(get_args(callable_ellipsis), (...,))
+        callable_ellipsis2 = CallableP[(...,)]
+        self.assertEqual(callable_ellipsis, callable_ellipsis2)
+        # (int, ...) -> Any
+        callable_arg_more = CallableP[[int, ...]]
+        self.assertEqual(get_args(callable_arg_more), ([int, ...],))
+        # (T) -> Any
+        callable_generic = CallableP[[T]]
+        self.assertEqual(get_args(callable_generic), ([T],))
+        callable_generic_raw = CallableP[T]
+        self.assertEqual(get_args(callable_generic_raw), (T,))
 
     def test_pickle(self):
         global Alias

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7307,8 +7307,14 @@ class TypeAliasTypeTests(BaseTestCase):
         subscripted = ListOrSetT[int]
         self.assertEqual(get_args(subscripted), (int,))
         self.assertIs(get_origin(subscripted), ListOrSetT)
-        with self.assertRaises(TypeError, msg="not a generic class"):
+        with self.assertRaisesRegex(TypeError,
+                                    "not a generic class"
+                                    # types.GenericAlias raises a different error in 3.10
+                                    if sys.version_info[:2] != (3, 10)
+                                    else "There are no type variables left in ListOrSetT"
+        ):
             subscripted[int]
+
 
         still_generic = ListOrSetT[Iterable[T]]
         self.assertEqual(get_args(still_generic), (Iterable[T],))

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3531,7 +3531,7 @@ else:
             def __getitem__(self, parameters):
                 if not isinstance(parameters, tuple):
                     parameters = (parameters,)
-                    parameters = [
+                parameters = [
                         typing._type_check(
                             item, f'Subscripting {self.__name__} requires a type.'
                         )
@@ -3560,7 +3560,7 @@ else:
             def __getitem__(self, parameters):
                 if not isinstance(parameters, tuple):
                     parameters = (parameters,)
-                    parameters = [
+                parameters = [
                         self._check_parameter(item, typ)
                         for item, typ in zip(parameters, self.__type_params__)
                 ]

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3577,7 +3577,7 @@ else:
                 # Allow [], [int], [int, str], [int, ...], [int, T]
                 if param is ...:
                     yield ...
-                # Note in < 3.9 _ConcatenateGenericAlias inherits from list
+                # Note in <= 3.9 _ConcatenateGenericAlias inherits from list
                 elif isinstance(param, list) and recursion == 0:
                     yield [checked
                            for arg in param
@@ -3611,9 +3611,10 @@ else:
             type_vars = _collect_type_vars(parameters)
             parameters = self._check_parameters(parameters)
             alias = _TypeAliasGenericAlias(self, parameters)
-            # If Concatenate is present its parameters were not collected
-            if len(alias.__parameters__) < len(type_vars):
-                alias.__parameters__ = tuple(type_vars)
+            # alias.__parameters__ is not complete if Concatenate is present
+            # as it is converted to a list from which no parameters are extracted.
+            if alias.__parameters__ != type_vars:
+                alias.__parameters__ = type_vars
             return alias
 
         def __reduce__(self):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3528,14 +3528,16 @@ else:
 
         if sys.version_info >= (3, 11):
             def __getitem__(self, parameters):
+                if len(self.__type_params__) == 0:
+                    raise TypeError("Only generic type aliases are subscriptable")
                 if not isinstance(parameters, tuple):
                     parameters = (parameters,)
                 parameters = [
-                        typing._type_check(
-                            item, f'Subscripting {self.__name__} requires a type.'
-                        )
-                        for item in parameters
-                    ]
+                    typing._type_check(
+                        item, f'Subscripting {self.__name__} requires a type.'
+                    )
+                    for item in parameters
+                ]
                 alias = typing._GenericAlias(self, tuple(parameters))
                 alias.__value__ = self.__value__
                 alias.__type_params__ = self.__type_params__
@@ -3560,12 +3562,14 @@ else:
                     )
 
             def __getitem__(self, parameters):
+                if len(self.__type_params__) == 0:
+                    raise TypeError("Only generic type aliases are subscriptable")
                 if not isinstance(parameters, tuple):
                     parameters = (parameters,)
                 parameters = [
-                        checked
-                        for item in parameters
-                        for checked in self._check_parameter(item)
+                    checked
+                    for item in parameters
+                    for checked in self._check_parameter(item)
                 ]
                 if sys.version_info[:2] == (3, 10):
                     alias = typing._GenericAlias(self, tuple(parameters),

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3488,6 +3488,8 @@ else:
             self.__type_params__ = type_params
 
             parameters = []
+            if not isinstance(type_params, tuple):
+                raise TypeError("type_params must be a tuple")
             for type_param in type_params:
                 if isinstance(type_param, TypeVarTuple):
                     parameters.extend(type_param)

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3068,7 +3068,10 @@ if hasattr(typing, '_collect_type_vars'):
         for t in types:
             if _is_unpacked_typevartuple(t):
                 type_var_tuple_encountered = True
-            elif isinstance(t, typevar_types) and t not in tvars:
+            elif (
+                isinstance(t, typevar_types) and not isinstance(t, _UnpackAlias)
+                and t not in tvars
+            ):
                 if enforce_default_ordering:
                     has_default = getattr(t, '__default__', NoDefault) is not NoDefault
                     if has_default:

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3526,9 +3526,22 @@ else:
         def __repr__(self) -> str:
             return self.__name__
 
+        def _is_subscriptable(self):
+            if len(self.__parameters__) > 0:
+                return True
+            if _should_collect_from_parameters(self.__value__):
+                if hasattr(typing, '_collect_type_vars'):
+                    more_parameters = _collect_type_vars((self.__value__,),
+                                                         (TypeVar, ParamSpec))
+                else:
+                    more_parameters = _collect_parameters((self.__value__,))
+                if more_parameters:
+                    return True
+            return False
+
         if sys.version_info >= (3, 11):
             def __getitem__(self, parameters):
-                if len(self.__type_params__) == 0:
+                if len(self.__parameters__) == 0 and not self._is_subscriptable():
                     raise TypeError("Only generic type aliases are subscriptable")
                 if not isinstance(parameters, tuple):
                     parameters = (parameters,)
@@ -3562,7 +3575,7 @@ else:
                     )
 
             def __getitem__(self, parameters):
-                if len(self.__type_params__) == 0:
+                if len(self.__parameters__) == 0 and not self._is_subscriptable():
                     raise TypeError("Only generic type aliases are subscriptable")
                 if not isinstance(parameters, tuple):
                     parameters = (parameters,)

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3526,19 +3526,6 @@ else:
         def __repr__(self) -> str:
             return self.__name__
 
-        def _is_subscriptable(self):
-            if len(self.__parameters__) > 0:
-                return True
-            if _should_collect_from_parameters(self.__value__):
-                if hasattr(typing, '_collect_type_vars'):
-                    more_parameters = _collect_type_vars((self.__value__,),
-                                                         (TypeVar, ParamSpec))
-                else:
-                    more_parameters = _collect_parameters((self.__value__,))
-                if more_parameters:
-                    return True
-            return False
-
         if sys.version_info < (3, 11):
             def _check_single_param(self, param, recursion=0):
                 # Allow [], [int], [int, str], [int, ...], [int, T]
@@ -3572,8 +3559,6 @@ else:
                     ]
 
         def __getitem__(self, parameters):
-            if len(self.__parameters__) == 0 and not self._is_subscriptable():
-                raise TypeError("Only generic type aliases are subscriptable")
             if not isinstance(parameters, tuple):
                 parameters = (parameters,)
             parameters = self._check_parameters(parameters)

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3561,17 +3561,13 @@ else:
         def __getitem__(self, parameters):
             if not isinstance(parameters, tuple):
                 parameters = (parameters,)
+            if sys.version_info >= (3, 10):
+                return _types.GenericAlias(self, tuple(parameters))
             parameters = self._check_parameters(parameters)
-            if sys.version_info[:2] == (3, 10):
-                alias = typing._GenericAlias(self, tuple(parameters),
-                                                _typevar_types=(TypeVar, ParamSpec)
-                                                )
-            else:
-                alias = typing._GenericAlias(self, tuple(parameters))
+            alias = typing._GenericAlias(self, tuple(parameters))
             alias.__value__ = self.__value__
             alias.__type_params__ = self.__type_params__
-            if not hasattr(alias, '__name__'):  # < 3.11
-                alias.__name__ = self.__name__
+            alias.__name__ = self.__name__
             return alias
 
         def __reduce__(self):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1,4 +1,3 @@
-# pyright: reportShadowedImports=false
 import abc
 import collections
 import collections.abc

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3564,9 +3564,6 @@ else:
             alias = typing._GenericAlias(self, tuple(parameters))
             if len(alias.__parameters__) < len(type_vars):
                 alias.__parameters__ = tuple(type_vars)
-            alias.__value__ = self.__value__
-            alias.__type_params__ = self.__type_params__
-            alias.__name__ = self.__name__
             return alias
 
         def __reduce__(self):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3564,6 +3564,7 @@ else:
                         for item, typ in zip(parameters, self.__type_params__)
                 ]
                 alias = typing._GenericAlias(self, tuple(parameters))
+                alias.__name__ = self.__name__
                 alias.__value__ = self.__value__
                 alias.__type_params__ = self.__type_params__
                 return alias

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3647,23 +3647,20 @@ else:
             def _check_single_param(self, param, recursion=0):
                 # Allow [], [int], [int, str], [int, ...], [int, T]
                 if param is ...:
-                    yield ...
+                    return ...
                 # Note in <= 3.9 _ConcatenateGenericAlias inherits from list
-                elif isinstance(param, list) and recursion == 0:
-                    yield [checked
-                           for arg in param
-                           for checked in self._check_single_param(arg, recursion+1)]
-                else:
-                    yield typing._type_check(
+                if isinstance(param, list) and recursion == 0:
+                    return [self._check_single_param(arg, recursion+1)
+                            for arg in param]
+                return typing._type_check(
                         param, f'Subscripting {self.__name__} requires a type.'
                     )
 
         def _check_parameters(self, parameters):
             if sys.version_info < (3, 11):
                 return tuple(
-                    checked
+                    self._check_single_param(item)
                     for item in parameters
-                    for checked in self._check_single_param(item)
                 )
             return tuple(typing._type_check(
                         item, f'Subscripting {self.__name__} requires a type.'

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3537,7 +3537,10 @@ else:
                         )
                         for item in parameters
                     ]
-                return typing._GenericAlias(self, tuple(parameters))
+                alias = typing._GenericAlias(self, tuple(parameters))
+                alias.__value__ = self.__value__
+                alias.__type_params__ = self.__type_params__
+                return alias
         else:
             def _check_parameter(self, item, typ=_marker):
                 # Allow [], [int], [int, str], [int, ...], [int, T]
@@ -3561,7 +3564,10 @@ else:
                         self._check_parameter(item, typ)
                         for item, typ in zip(parameters, self.__type_params__)
                 ]
-                return typing._GenericAlias(self, tuple(parameters))
+                alias = typing._GenericAlias(self, tuple(parameters))
+                alias.__value__ = self.__value__
+                alias.__type_params__ = self.__type_params__
+                return alias
 
         def __reduce__(self):
             return self.__name__

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3535,8 +3535,6 @@ else:
             self.__type_params__ = type_params
 
             parameters = []
-            if not isinstance(type_params, tuple):
-                raise TypeError("type_params must be a tuple")
             for type_param in type_params:
                 if isinstance(type_param, TypeVarTuple):
                     parameters.extend(type_param)

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3593,9 +3593,10 @@ else:
             # Using 3.9 here will create problems with Concatenate
             if sys.version_info >= (3, 10):
                 return _types.GenericAlias(self, parameters)
-            parameters = tuple(self._check_parameters(parameters))
-            return typing._GenericAlias(self, tuple(parameters))
             type_vars = _collect_type_vars(parameters)
+            parameters = self._check_parameters(parameters)
+            alias = _TypeAliasGenericAlias(self, parameters)
+            # If Concatenate is present its parameters were not collected
             if len(alias.__parameters__) < len(type_vars):
                 alias.__parameters__ = tuple(type_vars)
             return alias

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1,3 +1,4 @@
+# pyright: reportShadowedImports=false
 import abc
 import collections
 import collections.abc
@@ -3541,7 +3542,7 @@ else:
                 else:
                     return typing._type_check(
                         item, f'Subscripting {self.__name__} requires a type.'
-                    ) 
+                    )
 
             def __getitem__(self, parameters):
                 if not isinstance(parameters, tuple):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3667,6 +3667,8 @@ else:
                 # Allow [], [int], [int, str], [int, ...], [int, T]
                 if param is ...:
                     return ...
+                if param is None:
+                    return None
                 # Note in <= 3.9 _ConcatenateGenericAlias inherits from list
                 if isinstance(param, list) and recursion == 0:
                     return [self._check_single_param(arg, recursion+1)


### PR DESCRIPTION
Fixes #448 that usage of ParamSpec with TypeAliasType was limited for < Python 3.11

This PR enables `TypeAliasType` to use Ellipsis and list arguments for `ParamSpec` type params.