### PR TITLE
Change license identifier in project metadata to text

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 readme = "README.md"
 requires-python = ">=3.8"
-license = { file = "LICENSE" }
+license = { text = "Python-2.0" }
 keywords = [
     "annotations",
     "backport",


### PR DESCRIPTION
I'd like to propose changing the license metadata to text with the license identifier "Python-2.0" reflecting the content of the `LICENSE` file.

License scanning tools such as the one GitLab uses rely on the `license` field returned by the PyPI API which returns `license: null` for this package ([JSON](https://pypi.org/pypi/typing-extensions/json)).

Related to #62