### PR TITLE
Add missing dunder attributes for TypeAliasType instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   with `@typing_extensions.deprecated`. Patch by Sebastian Rittau.
 - Fix bug where `TypeAliasType` instances could be subscripted even
   where they were not generic. Patch by [Daraan](https://github.com/Daraan).
+- Fix bug where a subscripted `TypeAliasType` instance did not have all
+  attributes of the original `TypeAliasType` instance on older Python versions.
+  Patch by [Daraan](https://github.com/Daraan) and Alex Waygood.
 
 # Release 4.12.2 (June 7, 2024)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7247,6 +7247,32 @@ class TypeAliasTypeTests(BaseTestCase):
         self.assertEqual(get_args(fully_subscripted), (Iterable[float],))
         self.assertIs(get_origin(fully_subscripted), ListOrSetT)
 
+    def test_alias_attributes(self):
+        T = TypeVar('T')
+        T2 = TypeVar('T2')
+        ListOrSetT = TypeAliasType("ListOrSetT", Union[List[T], Set[T]], type_params=(T,))
+        subscripted = ListOrSetT[int]
+        still_generic = ListOrSetT[Iterable[T2]]
+        fully_subscripted = still_generic[float]
+
+        with self.subTest(variable=subscripted):
+            self.assertEqual(subscripted.__module__, ListOrSetT.__module__)
+            self.assertEqual(subscripted.__name__, "ListOrSetT")
+            self.assertEqual(subscripted.__value__, Union[List[T], Set[T]])
+            self.assertEqual(subscripted.__type_params__, (T,))
+        with self.subTest(variable=still_generic):
+            self.assertEqual(still_generic.__module__, ListOrSetT.__module__)
+            self.assertEqual(still_generic.__name__, "ListOrSetT")
+            self.assertEqual(still_generic.__value__, Union[List[T], Set[T]])
+            self.assertEqual(still_generic.__type_params__, (T,))
+        with self.subTest(variable=fully_subscripted):
+            if sys.version_info[:2] == (3, 8):
+                self.skipTest("Cannot further proxy attributes with _GenericAlias")
+            self.assertEqual(fully_subscripted.__module__, ListOrSetT.__module__)
+            self.assertEqual(fully_subscripted.__name__, "ListOrSetT")
+            self.assertEqual(fully_subscripted.__value__, Union[List[T], Set[T]])
+            self.assertEqual(fully_subscripted.__type_params__, (T,))
+
     def test_pickle(self):
         global Alias
         Alias = TypeAliasType("Alias", int)

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7264,7 +7264,7 @@ class TypeAliasTypeTests(BaseTestCase):
         self.assertEqual(still_generic.__value__, Union[List[T], Set[T]])
         self.assertEqual(still_generic.__type_params__, (T,))
         with self.subTest(variable=fully_subscripted):
-            if sys.version_info[:2] < (3, 12):
+            if not TYPING_3_10_0:  # needs to align with GenericAlias usage in __getitem__ else 3.12+
                 self.skipTest("Cannot further proxy attributes with _GenericAlias")
             self.assertEqual(fully_subscripted.__module__, ListOrSetT.__module__)
             self.assertEqual(fully_subscripted.__name__, "ListOrSetT")

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7251,25 +7251,24 @@ class TypeAliasTypeTests(BaseTestCase):
         T = TypeVar('T')
         T2 = TypeVar('T2')
         ListOrSetT = TypeAliasType("ListOrSetT", Union[List[T], Set[T]], type_params=(T,))
-        subscripted = ListOrSetT[int]
-        still_generic = ListOrSetT[Iterable[T2]]
-        fully_subscripted = still_generic[float]
 
+        subscripted = ListOrSetT[int]
         self.assertEqual(subscripted.__module__, ListOrSetT.__module__)
         self.assertEqual(subscripted.__name__, "ListOrSetT")
         self.assertEqual(subscripted.__value__, Union[List[T], Set[T]])
         self.assertEqual(subscripted.__type_params__, (T,))
+
+        still_generic = ListOrSetT[Iterable[T2]]
         self.assertEqual(still_generic.__module__, ListOrSetT.__module__)
         self.assertEqual(still_generic.__name__, "ListOrSetT")
         self.assertEqual(still_generic.__value__, Union[List[T], Set[T]])
         self.assertEqual(still_generic.__type_params__, (T,))
-        with self.subTest(variable=fully_subscripted):
-            if not TYPING_3_10_0:  # needs to align with GenericAlias usage in __getitem__ else 3.12+
-                self.skipTest("Cannot further proxy attributes with _GenericAlias")
-            self.assertEqual(fully_subscripted.__module__, ListOrSetT.__module__)
-            self.assertEqual(fully_subscripted.__name__, "ListOrSetT")
-            self.assertEqual(fully_subscripted.__value__, Union[List[T], Set[T]])
-            self.assertEqual(fully_subscripted.__type_params__, (T,))
+
+        fully_subscripted = still_generic[float]
+        self.assertEqual(fully_subscripted.__module__, ListOrSetT.__module__)
+        self.assertEqual(fully_subscripted.__name__, "ListOrSetT")
+        self.assertEqual(fully_subscripted.__value__, Union[List[T], Set[T]])
+        self.assertEqual(fully_subscripted.__type_params__, (T,))
 
     def test_subscription_without_type_params(self):
         Simple = TypeAliasType("Simple", int)

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7255,18 +7255,16 @@ class TypeAliasTypeTests(BaseTestCase):
         still_generic = ListOrSetT[Iterable[T2]]
         fully_subscripted = still_generic[float]
 
-        with self.subTest(variable=subscripted):
-            self.assertEqual(subscripted.__module__, ListOrSetT.__module__)
-            self.assertEqual(subscripted.__name__, "ListOrSetT")
-            self.assertEqual(subscripted.__value__, Union[List[T], Set[T]])
-            self.assertEqual(subscripted.__type_params__, (T,))
-        with self.subTest(variable=still_generic):
-            self.assertEqual(still_generic.__module__, ListOrSetT.__module__)
-            self.assertEqual(still_generic.__name__, "ListOrSetT")
-            self.assertEqual(still_generic.__value__, Union[List[T], Set[T]])
-            self.assertEqual(still_generic.__type_params__, (T,))
+        self.assertEqual(subscripted.__module__, ListOrSetT.__module__)
+        self.assertEqual(subscripted.__name__, "ListOrSetT")
+        self.assertEqual(subscripted.__value__, Union[List[T], Set[T]])
+        self.assertEqual(subscripted.__type_params__, (T,))
+        self.assertEqual(still_generic.__module__, ListOrSetT.__module__)
+        self.assertEqual(still_generic.__name__, "ListOrSetT")
+        self.assertEqual(still_generic.__value__, Union[List[T], Set[T]])
+        self.assertEqual(still_generic.__type_params__, (T,))
         with self.subTest(variable=fully_subscripted):
-            if sys.version_info[:2] == (3, 8):
+            if sys.version_info[:2] < (3, 12):
                 self.skipTest("Cannot further proxy attributes with _GenericAlias")
             self.assertEqual(fully_subscripted.__module__, ListOrSetT.__module__)
             self.assertEqual(fully_subscripted.__name__, "ListOrSetT")

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3533,6 +3533,8 @@ else:
                 )
                 for item in parameters
             ]
+            if sys.version_info >= (3, 10):
+                return typing.GenericAlias(self, tuple(parameters))
             alias = typing._GenericAlias(self, tuple(parameters))
             alias.__value__ = self.__value__
             alias.__type_params__ = self.__type_params__

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3534,7 +3534,7 @@ else:
                 for item in parameters
             ]
             if sys.version_info >= (3, 10):
-                return typing.GenericAlias(self, tuple(parameters))
+                return _types.GenericAlias(self, tuple(parameters))
             alias = typing._GenericAlias(self, tuple(parameters))
             alias.__value__ = self.__value__
             alias.__type_params__ = self.__type_params__

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3459,6 +3459,12 @@ else:
                     return getattr(self.__origin__, attr)
                 return super().__getattr__(attr)
 
+            if sys.version_info < (3, 9):
+                def __getitem__(self, item):
+                    result = super().__getitem__(item)
+                    result.__class__ = type(self)
+                    return result
+
     class TypeAliasType:
         """Create named, parameterized type aliases.
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3533,14 +3533,11 @@ else:
                 )
                 for item in parameters
             ]
-            if sys.version_info >= (3, 9):
-                # Using GenericAlias solves the attribute presence issue
-                # however creates a chain of other issues.
-                return typing.GenericAlias(self, parameters)
             alias = typing._GenericAlias(self, tuple(parameters))
             alias.__value__ = self.__value__
             alias.__type_params__ = self.__type_params__
-            alias.__name__ = self.__name__  # this is present on 3.11
+            if sys.version_info <= (3, 11):
+                alias.__name__ = self.__name__
             return alias
 
         def __reduce__(self):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3527,6 +3527,7 @@ else:
         def __getitem__(self, parameters):
             if not isinstance(parameters, tuple):
                 parameters = (parameters,)
+            # Using 3.9 here will create problems with Concatenate
             parameters = [
                 typing._type_check(
                     item, f'Subscripting {self.__name__} requires a type.'
@@ -3538,8 +3539,7 @@ else:
             alias = typing._GenericAlias(self, tuple(parameters))
             alias.__value__ = self.__value__
             alias.__type_params__ = self.__type_params__
-            if sys.version_info <= (3, 11):
-                alias.__name__ = self.__name__
+            alias.__name__ = self.__name__
             return alias
 
         def __reduce__(self):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3453,7 +3453,7 @@ else:
         ))
 
     if sys.version_info < (3, 10):
-        class _TypeAliasGenericAlias(_typing_GenericAlias):
+        class _TypeAliasGenericAlias(typing._GenericAlias, _root=True):
             def __getattr__(self, attr):
                 if attr in {"__value__", "__type_params__", "__name__"}:
                     return getattr(self.__origin__, attr)

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3544,7 +3544,7 @@ else:
                 parameters = (parameters,)
             # Using 3.9 here will create problems with Concatenate
             if sys.version_info >= (3, 10):
-                return _types.GenericAlias(self, tuple(parameters))
+                return _types.GenericAlias(self, parameters)
             parameters = tuple(
                 typing._type_check(
                     item, f'Subscripting {self.__name__} requires a type.'

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3533,7 +3533,15 @@ else:
                 )
                 for item in parameters
             ]
-            return typing._GenericAlias(self, tuple(parameters))
+            if sys.version_info >= (3, 9):
+                # Using GenericAlias solves the attribute presence issue
+                # however creates a chain of other issues.
+                return typing.GenericAlias(self, parameters)
+            alias = typing._GenericAlias(self, tuple(parameters))
+            alias.__value__ = self.__value__
+            alias.__type_params__ = self.__type_params__
+            alias.__name__ = self.__name__  # this is present on 3.11
+            return alias
 
         def __reduce__(self):
             return self.__name__

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3454,7 +3454,8 @@ else:
 
     if sys.version_info < (3, 10):
         # Copied and pasted from https://github.com/python/cpython/blob/986a4e1b6fcae7fe7a1d0a26aea446107dd58dd2/Objects/genericaliasobject.c#L568-L582,
-        # so that we emulate the behaviour of `types.GenericAlias` on the latest versions of CPython
+        # so that we emulate the behaviour of `types.GenericAlias`
+        # on the latest versions of CPython
         _ATTRIBUTE_DELEGATION_EXCLUSIONS = frozenset({
             "__class__",
             "__bases__",

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3453,11 +3453,28 @@ else:
         ))
 
     if sys.version_info < (3, 10):
+        # Copied and pasted from https://github.com/python/cpython/blob/986a4e1b6fcae7fe7a1d0a26aea446107dd58dd2/Objects/genericaliasobject.c#L568-L582,
+        # so that we emulate the behaviour of `types.GenericAlias` on the latest versions of CPython
+        _ATTRIBUTE_DELEGATION_EXCLUSIONS = frozenset({
+            "__class__",
+            "__bases__",
+            "__origin__",
+            "__args__",
+            "__unpacked__",
+            "__parameters__",
+            "__typing_unpacked_tuple_args__",
+            "__mro_entries__",
+            "__reduce_ex__",
+            "__reduce__",
+            "__copy__",
+            "__deepcopy__",
+        })
+
         class _TypeAliasGenericAlias(typing._GenericAlias, _root=True):
             def __getattr__(self, attr):
-                if attr in {"__value__", "__type_params__", "__name__"}:
-                    return getattr(self.__origin__, attr)
-                return super().__getattr__(attr)
+                if attr in _ATTRIBUTE_DELEGATION_EXCLUSIONS:
+                    return object.__getattr__(self, attr)
+                return getattr(self.__origin__, attr)
 
             if sys.version_info < (3, 9):
                 def __getitem__(self, item):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3528,14 +3528,14 @@ else:
             if not isinstance(parameters, tuple):
                 parameters = (parameters,)
             # Using 3.9 here will create problems with Concatenate
+            if sys.version_info >= (3, 10):
+                return _types.GenericAlias(self, tuple(parameters))
             parameters = [
                 typing._type_check(
                     item, f'Subscripting {self.__name__} requires a type.'
                 )
                 for item in parameters
             ]
-            if sys.version_info >= (3, 10):
-                return _types.GenericAlias(self, tuple(parameters))
             alias = typing._GenericAlias(self, tuple(parameters))
             alias.__value__ = self.__value__
             alias.__type_params__ = self.__type_params__


### PR DESCRIPTION
Adresses: #449
- https://github.com/python/typing_extensions/issues/469

As @JelleZijlstra [mentioned](https://github.com/python/typing_extensions/pull/449#discussion_r1773747048) that GenericAlias can be used to address #469. `GenericAlias` seems promising, however I am not sure what greater underlying changes this swap could maybe cause.

Currently I am still tracing some errors and I want to make sure I am not regressing some cases that currently are not covered by tests. This is also a reason this is currently only used for 3.10+.
See below I think using it in 3.9 will cause more harm than benefits.