### PR TITLE
_collect_type_vars should not collect Unpack objects itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@
 - Fix bug where a subscripted `TypeAliasType` instance did not have all
   attributes of the original `TypeAliasType` instance on older Python versions.
   Patch by [Daraan](https://github.com/Daraan) and Alex Waygood.
-- Fix bug where among others `TypeAliasType` instances did have wrong parameters
-  if they were directly subscripted with an Unpack object.
+- Fix bug where subscripted `TypeAliasType` instances (and some other
+  subscripted objects) had wrong parameters if they were directly
+  subscripted with an `Unpack` object.
   Patch by [Daraan](https://github.com/Daraan).
-
 
 # Release 4.12.2 (June 7, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Fix bug where a subscripted `TypeAliasType` instance did not have all
   attributes of the original `TypeAliasType` instance on older Python versions.
   Patch by [Daraan](https://github.com/Daraan) and Alex Waygood.
+- Fix bug where among others `TypeAliasType` instances did have wrong parameters
+  if they were directly subscripted with an Unpack object.
+  Patch by [Daraan](https://github.com/Daraan).
+
 
 # Release 4.12.2 (June 7, 2024)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5779,6 +5779,33 @@ class UnpackTests(BaseTestCase):
                     with self.assertRaises(TypeError):
                         klass[int]
 
+    def test_with_non_typevartuple(self):
+        # This is more a test for the two subfunctions used by GenericAlias
+        T = TypeVar('T')
+        class MyTypedDict(TypedDict):
+            foo: int
+            bar: str
+        class MyTypedDictT(Generic[T], TypedDict):
+            foo: T
+            bar: str
+
+        with self.subTest("_collect_type_vars"):
+            if not hasattr(typing_extensions, "_collect_type_vars"):
+                self.skipTest("No _collect_type_vars")
+            self.assertEqual(typing_extensions._collect_type_vars((Unpack[MyTypedDict], )), ())
+            self.assertEqual(typing_extensions._collect_type_vars((Unpack[MyTypedDictT], )), ())
+            self.assertEqual(typing_extensions._collect_type_vars((Unpack[MyTypedDictT[T]], )), (T,))
+            self.assertEqual(typing_extensions._collect_type_vars((Unpack[Tuple[int]], )), ())
+            self.assertEqual(typing_extensions._collect_type_vars((Unpack[Tuple[int, T]], )), (T,))
+        with self.subTest("_collect_parameters"):
+            if not hasattr(typing_extensions, "_collect_parameters"):
+                self.skipTest("No _collect_parameters")
+            self.assertEqual(typing_extensions._collect_parameters((Unpack[MyTypedDict], )), ())
+            self.assertEqual(typing_extensions._collect_parameters((Unpack[MyTypedDictT], )), ())
+            self.assertEqual(typing_extensions._collect_parameters((Unpack[MyTypedDictT[T]], )), (T,))
+            self.assertEqual(typing_extensions._collect_parameters((Unpack[Tuple[int]], )), ())
+            self.assertEqual(typing_extensions._collect_parameters((Unpack[Tuple[int, T]], )), (T,))
+
 
 class TypeVarTupleTests(BaseTestCase):
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5779,39 +5779,6 @@ class UnpackTests(BaseTestCase):
                     with self.assertRaises(TypeError):
                         klass[int]
 
-    def test_with_non_typevartuple(self):
-        # These functions are, among others, used to determine typing._GenericAlias.__parameters__
-        # and are monkey patched.
-        T = TypeVar('T')
-        class MyTypedDict(TypedDict):
-            foo: int
-            bar: str
-        class MyTypedDictT(Generic[T], TypedDict):
-            foo: T
-            bar: str
-
-        with self.subTest("_collect_type_vars"):
-            if not hasattr(typing_extensions, "_collect_type_vars"):
-                self.skipTest("No _collect_type_vars")
-            self.assertEqual(typing_extensions._collect_type_vars((Unpack[MyTypedDict], )), ())
-            self.assertEqual(typing_extensions._collect_type_vars((Unpack[MyTypedDictT], )), ())
-            self.assertEqual(typing_extensions._collect_type_vars((Unpack[MyTypedDictT[T]], )), (T,))
-            self.assertEqual(typing_extensions._collect_type_vars((Unpack[Tuple[int]], )), ())
-            self.assertEqual(typing_extensions._collect_type_vars((Unpack[Tuple[int, T]], )), (T,))
-        with self.subTest("_collect_parameters"):
-            if not hasattr(typing_extensions, "_collect_parameters"):
-                self.skipTest("No _collect_parameters")
-            self.assertEqual(typing_extensions._collect_parameters((Unpack[MyTypedDict], )), ())
-            self.assertEqual(typing_extensions._collect_parameters((Unpack[MyTypedDictT], )), ())
-            self.assertEqual(typing_extensions._collect_parameters((Unpack[MyTypedDictT[T]], )), (T,))
-            self.assertEqual(typing_extensions._collect_parameters((Unpack[Tuple[int]], )), ())
-            self.assertEqual(typing_extensions._collect_parameters((Unpack[Tuple[int, T]], )), (T,))
-        self.assertEqual(typing._GenericAlias(Any, Unpack[MyTypedDict]).__parameters__, ())
-        self.assertEqual(typing._GenericAlias(Any, Unpack[MyTypedDictT]).__parameters__, ())
-        self.assertEqual(typing._GenericAlias(Any, Unpack[MyTypedDictT[T]]).__parameters__, (T,))
-        self.assertEqual(typing._GenericAlias(Any, Unpack[Tuple[int]]).__parameters__, ())
-        self.assertEqual(typing._GenericAlias(Any, Unpack[Tuple[int, T]]).__parameters__, (T,))
-
 
 class TypeVarTupleTests(BaseTestCase):
 
@@ -7280,7 +7247,7 @@ class TypeAliasTypeTests(BaseTestCase):
         self.assertEqual(get_args(fully_subscripted), (Iterable[float],))
         self.assertIs(get_origin(fully_subscripted), ListOrSetT)
 
-    def tset_unpack_parameter_collection(self):
+    def test_unpack_parameter_collection(self):
         class Foo(Generic[T], TypedDict):
             bar: Tuple[T]
 
@@ -7288,7 +7255,6 @@ class TypeAliasTypeTests(BaseTestCase):
         self.assertEqual(FooAlias[Unpack[Tuple[str]]].__parameters__, ())
         self.assertEqual(FooAlias[Unpack[Tuple[T]]].__parameters__, (T,))
         self.assertEqual(FooAlias[Unpack[Foo[T]]].__parameters__, (T,))
-
         P = ParamSpec("P")
         CallableP = TypeAliasType("CallableP", Callable[P, Any], type_params=(P,))
         call_int_T = CallableP[Unpack[Tuple[int, T]]]

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7248,13 +7248,15 @@ class TypeAliasTypeTests(BaseTestCase):
         self.assertIs(get_origin(fully_subscripted), ListOrSetT)
 
     def test_unpack_parameter_collection(self):
-        class Foo(Generic[T], TypedDict):
-            bar: Tuple[T]
+        Ts = TypeVarTuple("Ts")
 
-        FooAlias = TypeAliasType("FooAlias", Foo[T], type_params=(T,))
+        class Foo(Generic[Unpack[Ts]]):
+            bar: Tuple[Unpack[Ts]]
+
+        FooAlias = TypeAliasType("FooAlias", Foo[Unpack[Ts]], type_params=(Ts,))
         self.assertEqual(FooAlias[Unpack[Tuple[str]]].__parameters__, ())
         self.assertEqual(FooAlias[Unpack[Tuple[T]]].__parameters__, (T,))
-        self.assertEqual(FooAlias[Unpack[Foo[T]]].__parameters__, (T,))
+
         P = ParamSpec("P")
         CallableP = TypeAliasType("CallableP", Callable[P, Any], type_params=(P,))
         call_int_T = CallableP[Unpack[Tuple[int, T]]]

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5780,7 +5780,7 @@ class UnpackTests(BaseTestCase):
                         klass[int]
 
     def test_with_non_typevartuple(self):
-        # This is more a test for the two subfunctions used by GenericAlias
+        # The two functions below are used by typing._GenericAlias and typing.Generic via monkey patching.
         T = TypeVar('T')
         class MyTypedDict(TypedDict):
             foo: int

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3068,7 +3068,10 @@ if hasattr(typing, '_collect_type_vars'):
         for t in types:
             if _is_unpacked_typevartuple(t):
                 type_var_tuple_encountered = True
-            elif isinstance(t, typevar_types) and t not in tvars:
+            elif (
+                isinstance(t, typevar_types) and not isinstance(t, _UnpackAlias)
+                and t not in tvars
+            ):
                 if enforce_default_ordering:
                     has_default = getattr(t, '__default__', NoDefault) is not NoDefault
                     if has_default:


### PR DESCRIPTION
Fixes:  #471

- #471

This PR fixes that these two cases should only yield `T` and not the unpack variable itself:

```py
print(_collect_type_vars([Unpack[Movie[T]]]))
# (typing_extensions.Unpack[typing_extensions.Movie[~T]], ~T)

print(_collect_type_vars([Unpack[Tuple[T]]]))
# (typing_extensions.Unpack[typing.Tuple[~T]], ~T)
```