### PR TITLE
Raise TypeError when TypeAliasType is subscripted without having type_params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   by PEP 649. Patches by Jelle Zijlstra and Alex Waygood.
 - Copy the coroutine status of functions and methods wrapped
   with `@typing_extensions.deprecated`. Patch by Sebastian Rittau.
+- Fix bug where `TypeAliasType` instances could be subscripted even
+  where they were not generic. Patch by [Daraan](https://github.com/Daraan).
 
 # Release 4.12.2 (June 7, 2024)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7267,22 +7267,7 @@ class TypeAliasTypeTests(BaseTestCase):
             MissingTypeParamsErr[[]]
         with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
             MissingTypeParamsErr[()]
-            
-        # However, providing type_params=() argument allows subscription
-        MissingTypeParams = TypeAliasType("MissingTypeParams", List[T], type_params=())
-        self.assertEqual(MissingTypeParams.__type_params__, ())
-        self.assertEqual(MissingTypeParams.__parameters__, ())
-        # These do not raise
-        MissingTypeParams[int]
-        MissingTypeParams[()]
-        Simple2 = TypeAliasType("Simple2", int, type_params=())
-        Simple2[int]
-        Simple2[()]
-        with self.subTest():
-            if sys.version_info < (3, 11):
-                self.skipTest("needs change how parameters are checked")
-            MissingTypeParams[[]]
-            Simple2[[]]
+    
 
     def test_pickle(self):
         global Alias

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7251,7 +7251,7 @@ class TypeAliasTypeTests(BaseTestCase):
         Simple = TypeAliasType("Simple", int)
         with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
             Simple[int]
-       
+
         # A TypeVar in the value does not allow subscription
         T = TypeVar('T')
         MissingTypeParamsErr = TypeAliasType("MissingTypeParamsErr", List[T])
@@ -7259,7 +7259,7 @@ class TypeAliasTypeTests(BaseTestCase):
         self.assertEqual(MissingTypeParamsErr.__parameters__, ())
         with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
             MissingTypeParamsErr[int]
-    
+
 
     def test_pickle(self):
         global Alias

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7251,10 +7251,6 @@ class TypeAliasTypeTests(BaseTestCase):
         Simple = TypeAliasType("Simple", int)
         with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
             Simple[int]
-        with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
-            Simple[[]]
-        with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
-            Simple[()]
        
         # A TypeVar in the value does not allow subscription
         T = TypeVar('T')
@@ -7263,10 +7259,6 @@ class TypeAliasTypeTests(BaseTestCase):
         self.assertEqual(MissingTypeParamsErr.__parameters__, ())
         with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
             MissingTypeParamsErr[int]
-        with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
-            MissingTypeParamsErr[[]]
-        with self.assertRaises(TypeError, msg="Only generic type aliases are subscriptable"):
-            MissingTypeParamsErr[()]
     
 
     def test_pickle(self):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3524,21 +3524,8 @@ else:
         def __repr__(self) -> str:
             return self.__name__
 
-        def _is_subscriptable(self):
-            if len(self.__parameters__) > 0:
-                return True
-            if _should_collect_from_parameters(self.__value__):
-                if hasattr(typing, '_collect_type_vars'):
-                    more_parameters = _collect_type_vars((self.__value__,),
-                                                         (TypeVar, ParamSpec))
-                else:
-                    more_parameters = _collect_parameters((self.__value__,))
-                if more_parameters:
-                    return True
-            return False
-
         def __getitem__(self, parameters):
-            if len(self.__parameters__) == 0 and not self._is_subscriptable():
+            if len(self.__parameters__) == 0:
                 raise TypeError("Only generic type aliases are subscriptable")
             if not isinstance(parameters, tuple):
                 parameters = (parameters,)

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3525,7 +3525,7 @@ else:
             return self.__name__
 
         def __getitem__(self, parameters):
-            if len(self.__type_params__) == 0:
+            if not self.__type_params__:
                 raise TypeError("Only generic type aliases are subscriptable")
             if not isinstance(parameters, tuple):
                 parameters = (parameters,)

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3525,7 +3525,7 @@ else:
             return self.__name__
 
         def __getitem__(self, parameters):
-            if len(self.__parameters__) == 0:
+            if len(self.__type_params__) == 0:
                 raise TypeError("Only generic type aliases are subscriptable")
             if not isinstance(parameters, tuple):
                 parameters = (parameters,)

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3524,7 +3524,22 @@ else:
         def __repr__(self) -> str:
             return self.__name__
 
+        def _is_subscriptable(self):
+            if len(self.__parameters__) > 0:
+                return True
+            if _should_collect_from_parameters(self.__value__):
+                if hasattr(typing, '_collect_type_vars'):
+                    more_parameters = _collect_type_vars((self.__value__,),
+                                                         (TypeVar, ParamSpec))
+                else:
+                    more_parameters = _collect_parameters((self.__value__,))
+                if more_parameters:
+                    return True
+            return False
+
         def __getitem__(self, parameters):
+            if len(self.__parameters__) == 0 and not self._is_subscriptable():
+                raise TypeError("Only generic type aliases are subscriptable")
             if not isinstance(parameters, tuple):
                 parameters = (parameters,)
             parameters = [


### PR DESCRIPTION
- Fixes: #468

I was not sure if it should check against `__parameters__` or `__type_params__` the [source](https://github.com/sobolevn/cpython/blob/0b647141d587065c5b82bd658485adca8823a943/Objects/typevarobject.c#L1408) checks against the later.