### PR TITLE
[3.14] Address invalid inputs of TypeAliasType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   subscripted objects) had wrong parameters if they were directly
   subscripted with an `Unpack` object.
   Patch by [Daraan](https://github.com/Daraan).
-  - Backport of CPython PR [#124795](https://github.com/python/cpython/pull/124795)
+- Backport of CPython PR [#124795](https://github.com/python/cpython/pull/124795)
   and fix that `TypeAliasType` not raising an error on non-tupple inputs for `type_params`.
   Patch by [Daraan](https://github.com/Daraan).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
   subscripted objects) had wrong parameters if they were directly
   subscripted with an `Unpack` object.
   Patch by [Daraan](https://github.com/Daraan).
+  - Backport of CPython PR [#124795](https://github.com/python/cpython/pull/124795)
+  and fix that `TypeAliasType` not raising an error on non-tupple inputs for `type_params`.
+  Patch by [Daraan](https://github.com/Daraan).
 
 # Release 4.12.2 (June 7, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Add `typing_extensions.TypeExpr` from PEP 747. Patch by
+- Add `typing_extensions.TypeForm` from PEP 747. Patch by
   Jelle Zijlstra.
 - Add `typing_extensions.get_annotations`, a backport of
   `inspect.get_annotations` that adds features specified

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -367,9 +367,9 @@ Special typing primitives
 
    .. versionadded:: 4.6.0
 
-.. data:: TypeExpr
+.. data:: TypeForm
 
-   See :pep:`747`. A type hint representing a type expression.
+   See :pep:`747`. A special form representing the value of a type expression.
 
    .. versionadded:: 4.13.0
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7312,18 +7312,38 @@ class TypeAliasTypeTests(BaseTestCase):
             class MyAlias(TypeAliasType):
                 pass
 
-    def test_type_params_compatibility(self):
+    def test_type_var_compatibility(self):
         # Regression test to assure compatibility with typing variants
-        with self.subTest(type_params="typing.TypeVar"):
-            TypeAliasType("TypingTypeParams", ..., type_params=(typing.TypeVar('T'),))
-        with self.subTest(type_params="typing.TypeAliasType"):
-            if not hasattr(typing, "TypeAliasType"):
-                self.skipTest("typing.TypeAliasType is not available before 3.12")
-            TypeAliasType("TypingTypeParams", ..., type_params=(typing.TypeVarTuple("Ts"),))
-        with self.subTest(type_params="typing.TypeAliasType"):
-            if not hasattr(typing, "ParamSpec"):
-                self.skipTest("typing.ParamSpec is not available before 3.10")
-            TypeAliasType("TypingTypeParams", ..., type_params=(typing.ParamSpec("P"),))
+        typingT = typing.TypeVar('typingT')
+        T1 = TypeAliasType("TypingTypeVar", ..., type_params=(typingT,))
+        self.assertEqual(T1.__type_params__, (typingT,))
+
+        # Test typing_extensions backports
+        textT = TypeVar('textT')
+        T2 = TypeAliasType("TypingExtTypeVar", ..., type_params=(textT,))
+        self.assertEqual(T2.__type_params__, (textT,))
+
+        textP = ParamSpec("textP")
+        T3 = TypeAliasType("TypingExtParamSpec", ..., type_params=(textP,))
+        self.assertEqual(T3.__type_params__, (textP,))
+
+        textTs = TypeVarTuple("textTs")
+        T4 = TypeAliasType("TypingExtTypeVarTuple", ..., type_params=(textTs,))
+        self.assertEqual(T4.__type_params__, (textTs,))
+
+    @skipUnless(TYPING_3_10_0, "typing.ParamSpec is not available before 3.10")
+    def test_param_spec_compatibility(self):
+        # Regression test to assure compatibility with typing variant
+        typingP = typing.ParamSpec("typingP")
+        T5 = TypeAliasType("TypingParamSpec", ..., type_params=(typingP,))
+        self.assertEqual(T5.__type_params__, (typingP,))
+
+    @skipUnless(TYPING_3_12_0, "typing.TypeVarTuple is not available before 3.12")
+    def test_type_var_tuple_compatibility(self):
+        # Regression test to assure compatibility with typing variant
+        typingTs = typing.TypeVarTuple("typingTs")
+        T6 = TypeAliasType("TypingTypeVarTuple", ..., type_params=(typingTs,))
+        self.assertEqual(T6.__type_params__, (typingTs,))
 
     def test_type_params_possibilities(self):
         T = TypeVar('T')

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7312,6 +7312,11 @@ class TypeAliasTypeTests(BaseTestCase):
             class MyAlias(TypeAliasType):
                 pass
 
+    def test_type_params_possibilities(self):
+        T = TypeVar('T')
+        # Test not a tuple
+        with self.assertRaisesRegex(TypeError, "type_params must be a tuple"):
+            TypeAliasType("InvalidTypeParams", List[T], type_params=[T])
 
 class DocTests(BaseTestCase):
     def test_annotation(self):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7364,8 +7364,8 @@ class TypeAliasTypeTests(BaseTestCase):
                 TypeAliasType("OkCase", List[T], type_params=case)
         for case, msg in invalid_cases:
             with self.subTest(type_params=case):
-                if TYPING_3_12_0 and sys.version_info < (3, 12, 7) or sys.version_info[:3] < (3, 13, 1):
-                    self.skipTest("No backport for <3.12.7 and 3.13.0, requires PR #124795")
+                if TYPING_3_12_0 and sys.version_info < (3, 12, 8) or sys.version_info[:3] < (3, 13, 1):
+                    self.skipTest("No backport for <3.12.8 and 3.13.0, requires PR #124795")
                 with self.assertRaisesRegex(TypeError, msg):
                     TypeAliasType("InvalidCase", List[T], type_params=case)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7466,11 +7466,11 @@ class TypeAliasTypeTests(BaseTestCase):
             ((T_default, T), f"non-default type parameter {T!r} follows default"),
             ((P_default, P), f"non-default type parameter {P!r} follows default"),
             ((Ts_default, T), f"non-default type parameter {T!r} follows default"),
-
-            # Potentially add invalid inputs, e.g. literals or classes
-            # depends on upstream
+            # Only type params are accepted
             ((1,), "Expected a type param, got 1"),
             ((str,), f"Expected a type param, got {str!r}"),
+            # Unpack backport behaves like TypeVar in some cases
+            ((Unpack[Ts],), f"Expected a type param, got {re.escape(repr(Unpack[Ts]))}"),
         ]
 
         for case in valid_cases:

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7329,19 +7329,16 @@ class TypeAliasTypeTests(BaseTestCase):
         Ts_default = TypeVarTuple('Ts_default', default=Unpack[Tuple[str, int]])
         P = ParamSpec('P')
         P_default = ParamSpec('P_default', default=[str, int])
-        P_default2 = ParamSpec('P_default2', default=P_default)
 
-        ok_cases = [
-            (T, T_default),
-            (T, Ts_default),
+        # NOTE: "TypeVars with defaults cannot immediately follow TypeVarTuples"
+        # from PEP 696 is currently not enfored for the type statement and are not tested.
+        # PEP 695: Double usage of the same name is also not enforced and not tested.
+        valid_cases = [
             (T, P, Ts),
+            (T, Ts_default),
+            (P_default, T_default)
             (P, T_default, Ts_default),
-            (Ts, P, Ts_default),
-            (T, P_default),
-            (T, P_default, T_default),
-            (T, P_default, Ts_default),
-            (T, Ts_default, P_default),
-            (T, P_default, P_default2),
+            (T_default, P_default, Ts_default),
         ]
         invalid_cases = [
             ((T_default, T),    f"non-default type parameter {T!r} follows default"),
@@ -7352,19 +7349,9 @@ class TypeAliasTypeTests(BaseTestCase):
             # depends on upstream
             ((1,),  "Expected a type param, got 1"),
             ((str,), f"Expected a type param, got {str!r}"),
-
-            # "TypeVars with defaults cannot immediately follow TypeVarTuples"
-            # is currently not enfored for the type statement, only for Generics
-            # (T, Ts, T_default),
-            # (T, Ts_default, T_default),
-
-            # Double use; however T2 = T; (T, T2) would likely be fine for a type checker
-            # (T, T)
-            # (Ts, *Ts)
-            # (P, **P)
         ]
 
-        for case in ok_cases:
+        for case in valid_cases:
             with self.subTest(type_params=case):
                 TypeAliasType("OkCase", List[T], type_params=case)
         for case, msg in invalid_cases:

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7364,8 +7364,8 @@ class TypeAliasTypeTests(BaseTestCase):
                 TypeAliasType("OkCase", List[T], type_params=case)
         for case, msg in invalid_cases:
             with self.subTest(type_params=case):
-                if TYPING_3_12_0 and sys.version_info < (3, 12, 8) or sys.version_info[:3] < (3, 13, 1):
-                    self.skipTest("No backport for <3.12.8 and 3.13.0, requires PR #124795")
+                if TYPING_3_12_0 and sys.version_info < (3, 14):
+                    self.skipTest("No backport for 3.12 and 3.13 requires cpython PR #124795")
                 with self.assertRaisesRegex(TypeError, msg):
                     TypeAliasType("InvalidCase", List[T], type_params=case)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -70,7 +70,7 @@ from typing_extensions import (
     TypeAlias,
     TypeAliasType,
     TypedDict,
-    TypeExpr,
+    TypeForm,
     TypeGuard,
     TypeIs,
     TypeVar,
@@ -5508,33 +5508,33 @@ class TypeIsTests(BaseTestCase):
             issubclass(int, TypeIs)
 
 
-class TypeExprTests(BaseTestCase):
+class TypeFormTests(BaseTestCase):
     def test_basics(self):
-        TypeExpr[int]  # OK
-        self.assertEqual(TypeExpr[int], TypeExpr[int])
+        TypeForm[int]  # OK
+        self.assertEqual(TypeForm[int], TypeForm[int])
 
-        def foo(arg) -> TypeExpr[int]: ...
-        self.assertEqual(gth(foo), {'return': TypeExpr[int]})
+        def foo(arg) -> TypeForm[int]: ...
+        self.assertEqual(gth(foo), {'return': TypeForm[int]})
 
     def test_repr(self):
-        if hasattr(typing, 'TypeExpr'):
+        if hasattr(typing, 'TypeForm'):
             mod_name = 'typing'
         else:
             mod_name = 'typing_extensions'
-        self.assertEqual(repr(TypeExpr), f'{mod_name}.TypeExpr')
-        cv = TypeExpr[int]
-        self.assertEqual(repr(cv), f'{mod_name}.TypeExpr[int]')
-        cv = TypeExpr[Employee]
-        self.assertEqual(repr(cv), f'{mod_name}.TypeExpr[{__name__}.Employee]')
-        cv = TypeExpr[Tuple[int]]
-        self.assertEqual(repr(cv), f'{mod_name}.TypeExpr[typing.Tuple[int]]')
+        self.assertEqual(repr(TypeForm), f'{mod_name}.TypeForm')
+        cv = TypeForm[int]
+        self.assertEqual(repr(cv), f'{mod_name}.TypeForm[int]')
+        cv = TypeForm[Employee]
+        self.assertEqual(repr(cv), f'{mod_name}.TypeForm[{__name__}.Employee]')
+        cv = TypeForm[Tuple[int]]
+        self.assertEqual(repr(cv), f'{mod_name}.TypeForm[typing.Tuple[int]]')
 
     def test_cannot_subclass(self):
         with self.assertRaises(TypeError):
-            class C(type(TypeExpr)):
+            class C(type(TypeForm)):
                 pass
         with self.assertRaises(TypeError):
-            class D(type(TypeExpr[int])):
+            class D(type(TypeForm[int])):
                 pass
 
     def test_call(self):
@@ -5546,24 +5546,24 @@ class TypeExprTests(BaseTestCase):
         ]
         for obj in objs:
             with self.subTest(obj=obj):
-                self.assertIs(TypeExpr(obj), obj)
+                self.assertIs(TypeForm(obj), obj)
 
         with self.assertRaises(TypeError):
-            TypeExpr()
+            TypeForm()
         with self.assertRaises(TypeError):
-            TypeExpr("too", "many")
+            TypeForm("too", "many")
 
     def test_cannot_init_type(self):
         with self.assertRaises(TypeError):
-            type(TypeExpr)()
+            type(TypeForm)()
         with self.assertRaises(TypeError):
-            type(TypeExpr[Optional[int]])()
+            type(TypeForm[Optional[int]])()
 
     def test_no_isinstance(self):
         with self.assertRaises(TypeError):
-            isinstance(1, TypeExpr[int])
+            isinstance(1, TypeForm[int])
         with self.assertRaises(TypeError):
-            issubclass(int, TypeExpr)
+            issubclass(int, TypeForm)
 
 
 class LiteralStringTests(BaseTestCase):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7452,8 +7452,8 @@ class TypeAliasTypeTests(BaseTestCase):
         P = ParamSpec('P')
         P_default = ParamSpec('P_default', default=[str, int])
 
-        # NOTE: "TypeVars with defaults cannot immediately follow TypeVarTuples"
-        # from PEP 696 is currently not enfored for the type statement and are not tested.
+        # NOTE: PEP 696 states: "TypeVars with defaults cannot immediately follow TypeVarTuples"
+        # this is currently not enforced for the type statement and is not tested.
         # PEP 695: Double usage of the same name is also not enforced and not tested.
         valid_cases = [
             (T, P, Ts),
@@ -7463,13 +7463,13 @@ class TypeAliasTypeTests(BaseTestCase):
             (T_default, P_default, Ts_default),
         ]
         invalid_cases = [
-            ((T_default, T),    f"non-default type parameter {T!r} follows default"),
-            ((P_default, P),    f"non-default type parameter {P!r} follows default"),
-            ((Ts_default, T),   f"non-default type parameter {T!r} follows default"),
+            ((T_default, T), f"non-default type parameter {T!r} follows default"),
+            ((P_default, P), f"non-default type parameter {P!r} follows default"),
+            ((Ts_default, T), f"non-default type parameter {T!r} follows default"),
 
             # Potentially add invalid inputs, e.g. literals or classes
             # depends on upstream
-            ((1,),  "Expected a type param, got 1"),
+            ((1,), "Expected a type param, got 1"),
             ((str,), f"Expected a type param, got {str!r}"),
         ]
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6192,6 +6192,10 @@ class AllTests(BaseTestCase):
                 'AsyncGenerator', 'ContextManager', 'AsyncContextManager',
                 'ParamSpec', 'TypeVar', 'TypeVarTuple', 'get_type_hints',
             }
+        if sys.version_info < (3, 14):
+            exclude |= {
+                'TypeAliasType'
+            }
         if not typing_extensions._PEP_728_IMPLEMENTED:
             exclude |= {'TypedDict', 'is_typeddict'}
         for item in typing_extensions.__all__:
@@ -7460,7 +7464,7 @@ class TypeAliasTypeTests(BaseTestCase):
         ]
         invalid_cases = [
             ((T_default, T),    f"non-default type parameter {T!r} follows default"),
-            ((P_default, P),   f"non-default type parameter {P!r} follows default"),
+            ((P_default, P),    f"non-default type parameter {P!r} follows default"),
             ((Ts_default, T),   f"non-default type parameter {T!r} follows default"),
 
             # Potentially add invalid inputs, e.g. literals or classes
@@ -7474,8 +7478,6 @@ class TypeAliasTypeTests(BaseTestCase):
                 TypeAliasType("OkCase", List[T], type_params=case)
         for case, msg in invalid_cases:
             with self.subTest(type_params=case):
-                if TYPING_3_12_0 and sys.version_info < (3, 14):
-                    self.skipTest("No backport for 3.12 and 3.13 requires cpython PR #124795")
                 with self.assertRaisesRegex(TypeError, msg):
                     TypeAliasType("InvalidCase", List[T], type_params=case)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7469,7 +7469,7 @@ class TypeAliasTypeTests(BaseTestCase):
             # Only type params are accepted
             ((1,), "Expected a type param, got 1"),
             ((str,), f"Expected a type param, got {str!r}"),
-            # Unpack backport behaves like TypeVar in some cases
+            # Unpack is not a TypeVar but isinstance(Unpack[Ts], TypeVar) is True in Python < 3.12
             ((Unpack[Ts],), f"Expected a type param, got {re.escape(repr(Unpack[Ts]))}"),
         ]
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7318,6 +7318,65 @@ class TypeAliasTypeTests(BaseTestCase):
         with self.assertRaisesRegex(TypeError, "type_params must be a tuple"):
             TypeAliasType("InvalidTypeParams", List[T], type_params=[T])
 
+        # Regression test assure compatibility with typing.TypeVar
+        typing_T = typing.TypeVar('T')
+        with self.subTest(type_params="typing.TypeVar"):
+            TypeAliasType("TypingTypeParams", List[typing_T], type_params=(typing_T,))
+
+        # Test default order
+        T_default = TypeVar('T_default', default=int)
+        Ts = TypeVarTuple('Ts')
+        Ts_default = TypeVarTuple('Ts_default', default=Unpack[Tuple[str, int]])
+        P = ParamSpec('P')
+        P_default = ParamSpec('P_default', default=[str, int])
+        P_default2 = ParamSpec('P_default2', default=...)
+
+        ok_cases = [
+            (T, T_default),
+            (T, Ts_default),
+            (T, T_default, Ts_default),
+            (T, P, Ts),
+            (T, P, Ts_default),
+            (T, P_default),
+            (T, P_default, T_default),
+            (T, P_default, Ts_default),
+            (T, Ts_default, P_default),
+            (T, P_default, P_default2),
+        ]
+        invalid_cases = [
+            (T_default, T),
+            (Ts_default, T),
+           
+            # TypeVar after TypeVarTuple
+            # "TypeVars with defaults cannot immediately follow TypeVarTuples"
+            # (T, Ts, T_default),
+            # (T, Ts_default, T_default),
+            
+            # Two TypeVarTuples in a row, should the reverse be also invalid?
+            (T, Ts_default, Ts),
+
+            (P_default, T),
+            (P_default, Ts),
+            
+            # Double defintion
+            # (T, T)
+            # (Ts, *Ts)
+            # (P, **P)
+            
+            # Potentially add invalid inputs, e.g. literals or classes
+            # depends on upstream
+            # (1,)
+            # (str,)
+        ]
+
+        for case in ok_cases:
+            with self.subTest(type_params=case):
+                TypeAliasType("OkCase", List[T], type_params=case)
+        for case in invalid_cases:
+            with self.subTest(type_params=case):
+                with self.assertRaises(TypeError):
+                    TypeAliasType("InvalidCase", List[T], type_params=case)
+
 class DocTests(BaseTestCase):
     def test_annotation(self):
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3541,10 +3541,12 @@ else:
             for type_param in type_params:
                 if not isinstance(type_param, (TypeVar, TypeVarTuple, ParamSpec)):
                     raise TypeError(f"Expected a type param, got {type_param!r}")
-                has_default = getattr(type_param, '__default__', NoDefault) is not NoDefault
+                has_default = (
+                    getattr(type_param, '__default__', NoDefault) is not NoDefault
+                )
                 if default_value_encountered and not has_default:
-                    raise TypeError(f'Type parameter {type_param!r} without a default'
-                                    ' follows type parameter with a default')
+                    raise TypeError(f'non-default type parameter {type_param!r}'
+                                    ' follows default type parameter')
                 if has_default:
                     default_value_encountered = True
                 if isinstance(type_param, TypeVarTuple):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -86,7 +86,7 @@ __all__ = [
     'Text',
     'TypeAlias',
     'TypeAliasType',
-    'TypeExpr',
+    'TypeForm',
     'TypeGuard',
     'TypeIs',
     'TYPE_CHECKING',
@@ -2047,23 +2047,30 @@ else:
         """)
 
 # 3.14+?
-if hasattr(typing, 'TypeExpr'):
-    TypeExpr = typing.TypeExpr
+if hasattr(typing, 'TypeForm'):
+    TypeForm = typing.TypeForm
 # 3.9
 elif sys.version_info[:2] >= (3, 9):
-    class _TypeExprForm(_ExtensionsSpecialForm, _root=True):
-        # TypeExpr(X) is equivalent to X but indicates to the type checker
-        # that the object is a TypeExpr.
+    class _TypeFormForm(_ExtensionsSpecialForm, _root=True):
+        # TypeForm(X) is equivalent to X but indicates to the type checker
+        # that the object is a TypeForm.
         def __call__(self, obj, /):
             return obj
 
-    @_TypeExprForm
-    def TypeExpr(self, parameters):
-        """Special typing form used to represent a type expression.
+    @_TypeFormForm
+    def TypeForm(self, parameters):
+        """A special form representing the value that results from the evaluation
+        of a type expression. This value encodes the information supplied in the
+        type expression, and it represents the type described by that type expression.
+
+        When used in a type expression, TypeForm describes a set of type form objects.
+        It accepts a single type argument, which must be a valid type expression.
+        ``TypeForm[T]`` describes the set of all type form objects that represent
+        the type T or types that are assignable to T.
 
         Usage:
 
-            def cast[T](typ: TypeExpr[T], value: Any) -> T: ...
+            def cast[T](typ: TypeForm[T], value: Any) -> T: ...
 
             reveal_type(cast(int, "x"))  # int
 
@@ -2073,7 +2080,7 @@ elif sys.version_info[:2] >= (3, 9):
         return typing._GenericAlias(self, (item,))
 # 3.8
 else:
-    class _TypeExprForm(_ExtensionsSpecialForm, _root=True):
+    class _TypeFormForm(_ExtensionsSpecialForm, _root=True):
         def __getitem__(self, parameters):
             item = typing._type_check(parameters,
                                       f'{self._name} accepts only a single type')
@@ -2082,13 +2089,20 @@ else:
         def __call__(self, obj, /):
             return obj
 
-    TypeExpr = _TypeExprForm(
-        'TypeExpr',
-        doc="""Special typing form used to represent a type expression.
+    TypeForm = _TypeFormForm(
+        'TypeForm',
+        doc="""A special form representing the value that results from the evaluation
+        of a type expression. This value encodes the information supplied in the
+        type expression, and it represents the type described by that type expression.
+
+        When used in a type expression, TypeForm describes a set of type form objects.
+        It accepts a single type argument, which must be a valid type expression.
+        ``TypeForm[T]`` describes the set of all type form objects that represent
+        the type T or types that are assignable to T.
 
         Usage:
 
-            def cast[T](typ: TypeExpr[T], value: Any) -> T: ...
+            def cast[T](typ: TypeForm[T], value: Any) -> T: ...
 
             reveal_type(cast(int, "x"))  # int
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3536,8 +3536,15 @@ else:
             self.__value__ = value
             self.__type_params__ = type_params
 
+            default_value_encountered = False
             parameters = []
             for type_param in type_params:
+                has_default = getattr(type_param, '__default__', NoDefault) is not NoDefault
+                if default_value_encountered and not has_default:
+                    raise TypeError(f'Type parameter {type_param!r} without a default'
+                                    ' follows type parameter with a default')
+                if has_default:
+                    default_value_encountered = True
                 if isinstance(type_param, TypeVarTuple):
                     parameters.extend(type_param)
                 else:

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3539,6 +3539,8 @@ else:
             default_value_encountered = False
             parameters = []
             for type_param in type_params:
+                if not isinstance(type_param, (TypeVar, TypeVarTuple, ParamSpec)):
+                    raise TypeError(f"Expected a type param, got {type_param!r}")
                 has_default = getattr(type_param, '__default__', NoDefault) is not NoDefault
                 if default_value_encountered and not has_default:
                     raise TypeError(f'Type parameter {type_param!r} without a default'

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3611,8 +3611,10 @@ else:
             default_value_encountered = False
             parameters = []
             for type_param in type_params:
-                if (not isinstance(type_param, (TypeVar, TypeVarTuple, ParamSpec))
-                    # The Unpack backport passes aboves check
+                if (
+                    not isinstance(type_param, (TypeVar, TypeVarTuple, ParamSpec))
+                    # 3.8-3.11
+                    # Unpack Backport passes isinstance(type_param, TypeVar)
                     or _is_unpack(type_param)
                 ):
                     raise TypeError(f"Expected a type param, got {type_param!r}")

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3528,36 +3528,9 @@ else:
                 return typing.Union[other, self]
 
 
-if hasattr(typing, "TypeAliasType") and sys.version_info >= (3, 14):
+if sys.version_info >= (3, 14):
     TypeAliasType = typing.TypeAliasType
-# 3.12-3.13
-elif hasattr(typing, "TypeAliasType"):
-
-    class TypeAliasType:
-
-        def __new__(self, name: str, value, *, type_params=()):
-            default_value_encountered = False
-            for type_param in type_params:
-                if not isinstance(type_param,
-                                  (typing.TypeVar, typing.TypeVarTuple, typing.ParamSpec)
-                ):
-                    raise TypeError(f"Expected a type param, got {type_param!r}")
-                has_default = (
-                        getattr(type_param, '__default__', NoDefault) is not NoDefault
-                    )
-                if default_value_encountered and not has_default:
-                    raise TypeError(f'non-default type parameter {type_param!r}'
-                                    ' follows default type parameter')
-                if has_default:
-                    default_value_encountered = True
-
-            return typing.TypeAliasType(name, value, type_params=type_params)
-
-        def __init_subclass__(cls, *args, **kwargs):
-            raise TypeError(
-                "type 'typing_extensions.TypeAliasType' is not an acceptable base type"
-            )
-
+# 3.8-3.13
 else:
     def _is_unionable(obj):
         """Corresponds to is_unionable() in unionobject.c in CPython."""

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3611,7 +3611,10 @@ else:
             default_value_encountered = False
             parameters = []
             for type_param in type_params:
-                if not isinstance(type_param, (TypeVar, TypeVarTuple, ParamSpec)):
+                if (not isinstance(type_param, (TypeVar, TypeVarTuple, ParamSpec))
+                    # The Unpack backport passes aboves check
+                    or _is_unpack(type_param)
+                ):
                     raise TypeError(f"Expected a type param, got {type_param!r}")
                 has_default = (
                     getattr(type_param, '__default__', NoDefault) is not NoDefault

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3531,6 +3531,8 @@ else:
         def __init__(self, name: str, value, *, type_params=()):
             if not isinstance(name, str):
                 raise TypeError("TypeAliasType name must be a string")
+            if not isinstance(type_params, tuple):
+                raise TypeError("type_params must be a tuple")
             self.__value__ = value
             self.__type_params__ = type_params
 


### PR DESCRIPTION
I've prepared this draft  which contains two changes:
- `typing_extensions.TypeAliasType` not raising TypeError if a non-tuple is passed compared to the `typing` variant.
- backport of 
https://github.com/python/cpython/pull/124795 for <=3.11 **(needs to be accepted first)**

- [x] Await merge and change if necessary
- [x] Afterwards fix correct python versions. I currently assume the backport is valid in 3.14. 
- [x] Should backport for 3.12-13 be made? Yes.

It should maybe noted that for 3.12.0-3.12.7 the `typing.TypeAliasType` variant does not contain this stricter backport.
I do not think that there is a necessity to do a backport for 3.12 and it will likely do more harm (I did not test it).