### PR TITLE
Allow subscription of `Callable[Concatenate[P], Any]` with ellipsis in Python 3.10

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5401,6 +5401,18 @@ class ConcatenateTests(BaseTestCase):
             ):
                 Concatenate[1, P]
 
+    @skipUnless(TYPING_3_10_0, "Missing backported to <=3.9. See issue #48")
+    def test_alias_subscription_with_ellipsis(self):
+        P = ParamSpec('P')
+        X = Callable[Concatenate[int, P], Any]
+
+        C1 = X[...]
+        self.assertEqual(C1.__parameters__, ())
+        with self.subTest("Compare Concatenate[int, ...]"):
+            if sys.version_info[:2] == (3, 10):
+                self.skipTest("Needs Issue #110 | PR # 442: construct Concatenate with ...")
+            self.assertEqual(get_args(C1), (Concatenate[int, ...], Any))
+
     def test_basic_introspection(self):
         P = ParamSpec('P')
         C1 = Concatenate[int, P]

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1798,7 +1798,7 @@ if not hasattr(typing, 'Concatenate'):
 # 3.10+
 else:
     _ConcatenateGenericAlias = typing._ConcatenateGenericAlias
-    
+
     # 3.10
     # Monkey patch to not raise TypeError on python3.10 for ellipsis parameter
     if sys.version_info < (3, 11):


### PR DESCRIPTION
Fixes #48 for python 3.10.3+

The first versions 3.10.0 - 3.10.2 did not enforce restrictions on the last parameter of `_ConcatenateGenericAlias`, 3.10.3-3.10.* only supports `ParamSpec`, i.e. no Ellipsis, hence #48 also holds for these versions.

This PR monkey patches the `copy_with` method of `typing._ConcatenateGenericAlias` with the Python 3.11 equivalent that accepts an ellipsis variant.

---

- This does not solve [110](https://github.com/python/typing_extensions/issues/110) , which requires an earlier check during `Concatenate`
- A backport to `3.8, 3.9` would need a monkey patch of `typing._type_check`