### PR TITLE
Support subscription of `Callable[Concatenate[P], Any]` with `...` in Python 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@
   subscripted objects) had wrong parameters if they were directly
   subscripted with an `Unpack` object.
   Patch by [Daraan](https://github.com/Daraan).
-- Backport to Python 3.10 to support substitution with `...` on `Callable`
-  aliases that have a `Concatenate` argument. Patch by [Daraan](https://github.com/Daraan).
+- Backport to Python 3.10 the ability to substitute `...` in generic `Callable`
+aliases that have a `Concatenate` special form as their argument.
+  Patch by [Daraan](https://github.com/Daraan).
 - Fix error in subscription of `Unpack` aliases causing nested Unpacks 
   to not be resolved correctly. Patch by [Daraan](https://github.com/Daraan).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   subscripted objects) had wrong parameters if they were directly
   subscripted with an `Unpack` object.
   Patch by [Daraan](https://github.com/Daraan).
+- Backport to Python 3.10 to support substitution with `...` on Callable
+  aliases that have a Concatenate argument. Patch by [Daraan](https://github.com/Daraan).
 
 # Release 4.12.2 (June 7, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@
   subscripted objects) had wrong parameters if they were directly
   subscripted with an `Unpack` object.
   Patch by [Daraan](https://github.com/Daraan).
-- Backport to Python 3.10 to support substitution with `...` on Callable
-  aliases that have a Concatenate argument. Patch by [Daraan](https://github.com/Daraan).
+- Backport to Python 3.10 to support substitution with `...` on `Callable`
+  aliases that have a `Concatenate` argument. Patch by [Daraan](https://github.com/Daraan).
 
 # Release 4.12.2 (June 7, 2024)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5401,6 +5401,18 @@ class ConcatenateTests(BaseTestCase):
             ):
                 Concatenate[1, P]
 
+    @skipUnless(TYPING_3_10_0, "Missing backported to <=3.9. See issue #48")
+    def test_alias_subscription_with_ellipsis(self):
+        P = ParamSpec('P')
+        X = Callable[Concatenate[int, P], Any]
+
+        C1 = X[...]
+        self.assertEqual(C1.__parameters__, ())
+        with self.subTest("Compare Concatenate[int, ...]"):
+            if sys.version_info[:2] == (3, 10):
+                self.skipTest("Needs Issue #110 | PR # 442: construct Concatenate with ...")
+            self.assertEqual(get_args(C1), (Concatenate[int, ...], Any))
+
     def test_basic_introspection(self):
         P = ParamSpec('P')
         C1 = Concatenate[int, P]
@@ -6089,7 +6101,7 @@ class AllTests(BaseTestCase):
         if sys.version_info < (3, 10, 1):
             exclude |= {"Literal"}
         if sys.version_info < (3, 11):
-            exclude |= {'final', 'Any', 'NewType', 'overload'}
+            exclude |= {'final', 'Any', 'NewType', 'overload', 'Concatenate'}
         if sys.version_info < (3, 12):
             exclude |= {
                 'SupportsAbs', 'SupportsBytes',

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5401,7 +5401,7 @@ class ConcatenateTests(BaseTestCase):
             ):
                 Concatenate[1, P]
 
-    @skipUnless(TYPING_3_10_0, "Missing backported to <=3.9. See issue #48")
+    @skipUnless(TYPING_3_10_0, "Missing backport to <=3.9. See issue #48")
     def test_alias_subscription_with_ellipsis(self):
         P = ParamSpec('P')
         X = Callable[Concatenate[int, P], Any]

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5410,7 +5410,7 @@ class ConcatenateTests(BaseTestCase):
         self.assertEqual(C1.__parameters__, ())
         with self.subTest("Compare Concatenate[int, ...]"):
             if sys.version_info[:2] == (3, 10):
-                self.skipTest("Needs Issue #110 | PR # 442: construct Concatenate with ...")
+                self.skipTest("Needs Issue #110 | PR #481: construct Concatenate with ...")
             self.assertEqual(get_args(C1), (Concatenate[int, ...], Any))
 
     def test_basic_introspection(self):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1818,7 +1818,7 @@ else:
                 return super(_typing_ConcatenateGenericAlias, self).copy_with(params)
 
 
-# 3.8-3.9
+# 3.8-3.10
 @typing._tp_cache
 def _concatenate_getitem(self, parameters):
     if parameters == ():
@@ -1838,7 +1838,7 @@ def _concatenate_getitem(self, parameters):
 
 
 # 3.11+
-if hasattr(typing, 'Concatenate') and sys.version_info[:2] != (3, 10):
+if sys.version_info >= (3, 11):
     Concatenate = typing.Concatenate
 # 3.9-3.10
 elif sys.version_info[:2] >= (3, 9):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1830,7 +1830,7 @@ def _concatenate_getitem(self, parameters):
                         "ParamSpec variable or ellipsis.")
     msg = "Concatenate[arg, ...]: each arg must be a type."
     parameters = tuple(typing._type_check(p, msg) for p in parameters)
-    if (3, 10, 2) < sys.version_info < (3,11):
+    if (3, 10, 2) < sys.version_info < (3, 11):
         return _ConcatenateGenericAlias(self, parameters,
                                  _typevar_types=(TypeVar, ParamSpec),
                                  _paramspec_tvars=True)


### PR DESCRIPTION
Fixes https://github.com/python/typing_extensions/issues/48 for python 3.10.3+

The first versions 3.10.0 - 3.10.2 did not enforce restrictions on the last parameter of _ConcatenateGenericAlias. 3.10.3-3.10.* only support ParamSpec, i.e. no Ellipsis, hence https://github.com/python/typing_extensions/issues/48 also holds for these versions.

This PR adds a backport of `_ConcatenateGenericAlias` which overrrides the problematic `copy_with` method.

---

- This partialy addresses #110 on 3.10, which requires an earlier check during `Concatenate` but does not fix it fully (see the skipped test)
