### PR TITLE
Fix subscription of Unpack causing nested Unpacks to not be resolved correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   subscripted objects) had wrong parameters if they were directly
   subscripted with an `Unpack` object.
   Patch by [Daraan](https://github.com/Daraan).
+- Fix error in subscription of Unpack aliases causing nested Unpacks 
+  to not be resolved correctly. Patch by [Daraan](https://github.com/Daraan).
 
 # Release 4.12.2 (June 7, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   subscripted objects) had wrong parameters if they were directly
   subscripted with an `Unpack` object.
   Patch by [Daraan](https://github.com/Daraan).
-- Fix error in subscription of Unpack aliases causing nested Unpacks 
+- Fix error in subscription of `Unpack` aliases causing nested Unpacks 
   to not be resolved correctly. Patch by [Daraan](https://github.com/Daraan).
 
 # Release 4.12.2 (June 7, 2024)

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5805,9 +5805,6 @@ class UnpackTests(BaseTestCase):
             nested_tuple_A_unpack = TupleAliasTsT[Unpack[Tuple[str]], object]
             self.assertEqual(nested_tuple_A, nested_tuple_A_unpack)
 
-        with self.subTest("Test invalid args", args=([str, int], object)):
-            # TypeError on some versions as types should be passed
-            invalid_nested_tuple = TupleAliasTsT[[str, int], object]  # invalid form
         with self.subTest("With Callable Ts"):
             # Tuple[int, (str, int) -> object]
             CallableAliasTsT = Variadic[Callable[[Unpack[Ts]], T]]

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5782,7 +5782,7 @@ class UnpackTests(BaseTestCase):
     def test_substitution(self):
         Ts = TypeVarTuple("Ts")
         unpacked_str = Unpack[Ts][str]
-        with self.subTest("Check full unpack"):
+        with self.subTest("Check substitution result"):
             self.assertIs(unpacked_str, str)
 
     @skipUnless(TYPING_3_11_0, "Needs Issue #103 first")
@@ -5805,10 +5805,11 @@ class UnpackTests(BaseTestCase):
             nested_tuple_A_unpack = TupleAliasTsT[Unpack[Tuple[str]], object]
             self.assertEqual(nested_tuple_A, nested_tuple_A_unpack)
 
-        with self.subTest("With Callable Ts"):
+        with self.subTest("With Callable and Unpack"):
             # Tuple[int, (str, int) -> object]
             CallableAliasTsT = Variadic[Callable[[Unpack[Ts]], T]]
-            CallableAliasTsT[[str, int], object]  # valid nested tuple
+            callable_fully_subscripted = CallableAliasTsT[Unpack[Tuple[str, int]], object]
+            self.assertEqual(get_args(callable_fully_subscripted), (Callable[[str, int], object],))
 
         # Equivalent Forms
         with self.subTest("Equivalence of variadic arguments"):
@@ -5817,7 +5818,7 @@ class UnpackTests(BaseTestCase):
             nested_tuple_B_2xUnpack = TupleAliasTsT[Unpack[Tuple[str]], Unpack[Tuple[int]], object]
             self.assertEqual(nested_tuple_B_1xUnpack, nested_tuple_bare)
             self.assertEqual(nested_tuple_B_1xUnpack, nested_tuple_B_2xUnpack)
-            self.assertNotEqual(invalid_nested_tuple, nested_tuple_B_1xUnpack)
+            self.assertEqual(get_args(nested_tuple_B_2xUnpack), (Tuple[str, int, object], ))
 
 
 class TypeVarTupleTests(BaseTestCase):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2424,6 +2424,17 @@ elif sys.version_info[:2] >= (3, 9):  # 3.9+
                 return arg.__args__
             return None
 
+        @property
+        def __typing_is_unpacked_typevartuple__(self):
+            assert self.__origin__ is Unpack
+            assert len(self.__args__) == 1
+            return isinstance(self.__args__[0], TypeVarTuple)
+
+        def __getitem__(self, args):
+            if self.__typing_is_unpacked_typevartuple__:
+                return args
+            return super().__getitem__(args)
+
     @_UnpackSpecialForm
     def Unpack(self, parameters):
         item = typing._type_check(parameters, f'{self._name} accepts only a single type.')
@@ -2435,6 +2446,17 @@ elif sys.version_info[:2] >= (3, 9):  # 3.9+
 else:  # 3.8
     class _UnpackAlias(typing._GenericAlias, _root=True):
         __class__ = typing.TypeVar
+
+        @property
+        def __typing_is_unpacked_typevartuple__(self):
+            assert self.__origin__ is Unpack
+            assert len(self.__args__) == 1
+            return isinstance(self.__args__[0], TypeVarTuple)
+
+        def __getitem__(self, args):
+            if self.__typing_is_unpacked_typevartuple__:
+                return args
+            return super().__getitem__(args)
 
     class _UnpackForm(_ExtensionsSpecialForm, _root=True):
         def __getitem__(self, parameters):


### PR DESCRIPTION
The current Unpack alias backport had an issue that it did not resolve correctly during substition.
This PR fixes that the following should hold, or rather that the subscription does not raise a `TypeError`.

```python
from typing_extensions import TypeVarTuple, Unpack
Ts = TypeVarTuple("Ts")
assert Unpack[Ts][str] is str
```

This fixes #474 and was solved by simply adding the [Python 3.12+](https://github.com/python/cpython/blob/3.13/Lib/typing.py) code to the alias classes.

Sitenote: This is only slightly related to #103, the code sample there also did not work in 3.11 after the backport was used. However, the error is not related and still persists for <=3.10.