### PR TITLE
Concatenate to support Ellipsis argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Fix bug where a subscripted `TypeAliasType` instance did not have all
   attributes of the original `TypeAliasType` instance on older Python versions.
   Patch by [Daraan](https://github.com/Daraan) and Alex Waygood.
+- Extended the Concatenate backport for Python 3.9 and 3.10 to now accept
+  ellipsis as an argument. Patch by [Daraan](https://github.com/Daraan).
 
 # Release 4.12.2 (June 7, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Fix bug where a subscripted `TypeAliasType` instance did not have all
   attributes of the original `TypeAliasType` instance on older Python versions.
   Patch by [Daraan](https://github.com/Daraan) and Alex Waygood.
-- Extended the Concatenate backport for Python 3.9 and 3.10 to now accept
+- Extended the Concatenate backport for Python 3.8-3.10 to now accept
   ellipsis as an argument. Patch by [Daraan](https://github.com/Daraan).
 
 # Release 4.12.2 (June 7, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,10 @@
 - Backport to Python 3.10 the ability to substitute `...` in generic `Callable`
 aliases that have a `Concatenate` special form as their argument.
   Patch by [Daraan](https://github.com/Daraan).
-- Fix error in subscription of `Unpack` aliases causing nested Unpacks 
-  to not be resolved correctly. Patch by [Daraan](https://github.com/Daraan).
 - Extended the `Concatenate` backport for Python 3.8-3.10 to now accept
   `Ellipsis` as an argument. Patch by [Daraan](https://github.com/Daraan).
+- Fix error in subscription of `Unpack` aliases causing nested Unpacks 
+  to not be resolved correctly. Patch by [Daraan](https://github.com/Daraan).
 
 # Release 4.12.2 (June 7, 2024)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -178,7 +178,7 @@ Special typing primitives
    See :py:data:`typing.Concatenate` and :pep:`612`. In ``typing`` since 3.10.
 
    The backport does not support certain operations involving ``...`` as
-   a parameter; see :pr:`442`, :issue:`48` and :issue:`110` for details.
+   a parameter; see :issue:`48` and :pr:`442` for details.
 
 .. data:: Final
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -178,7 +178,7 @@ Special typing primitives
    See :py:data:`typing.Concatenate` and :pep:`612`. In ``typing`` since 3.10.
 
    The backport does not support certain operations involving ``...`` as
-   a parameter; see :issue:`48` and :pr:`442` for details.
+   a parameter; see :issue:`48` and :pr:`481` for details.
 
 .. data:: Final
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -178,7 +178,7 @@ Special typing primitives
    See :py:data:`typing.Concatenate` and :pep:`612`. In ``typing`` since 3.10.
 
    The backport does not support certain operations involving ``...`` as
-   a parameter; see :issue:`48` and :issue:`110` for details.
+   a parameter; see :pr:`442`, :issue:`48` and :issue:`110` for details.
 
 .. data:: Final
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5426,20 +5426,14 @@ class ConcatenateTests(BaseTestCase):
         ):
             Callable[Concatenate[int, ...], Any][Any]
 
-    @skipIf(TYPING_3_11_0, "Args can be non-types in 3.11+")
-    def test_invalid_uses_before_3_11(self):
+    def test_invalid_use(self):
+        # Assure that `_type_check` is called.
         P = ParamSpec('P')
         with self.assertRaisesRegex(
             TypeError,
-            'each arg must be a type',
+            "each arg must be a type",
         ):
-            Concatenate[1, P]
-
-        with self.assertRaisesRegex(
-            TypeError,
-            'each arg must be a type.',
-        ):
-            Concatenate[1, ..., P]
+            Concatenate[(str,), P]
 
     @skipUnless(TYPING_3_11_0 or (3, 10, 0) <= sys.version_info < (3, 10, 2),
                 "Cannot be backported to <=3.9. See issue #48"

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5384,17 +5384,18 @@ class ConcatenateTests(BaseTestCase):
         self.assertEqual(C1.__origin__, C2.__origin__)
         self.assertNotEqual(C1, C2)
 
-        # Test collections.abc.Callable too.
-        if sys.version_info[:2] >= (3, 9):
-            C3 = collections.abc.Callable[Concatenate[int, P], int]
-            C4 = collections.abc.Callable[Concatenate[int, T, P], T]
-            self.assertEqual(C3.__origin__, C4.__origin__)
-            self.assertNotEqual(C3, C4)
+    @skipUnless(TYPING_3_9_0, "Needs PEP 585")
+    def test_collections_abc_callable(self):
+        P = ParamSpec('P')
+        T = TypeVar('T')
+        C3 = collections.abc.Callable[Concatenate[int, P], int]
+        C4 = collections.abc.Callable[Concatenate[int, T, P], T]
+        self.assertEqual(C3.__origin__, C4.__origin__)
+        self.assertNotEqual(C3, C4)
 
-        # Callable with Ellipsis cannot be constructed in 3.8 and below 3.9.2
-        if sys.version_info[:2] <= (3, 9, 2):
-            return
-
+    @skipUnless(sys.version_info >= (3, 9, 3), "Callable with Ellipsis cannot be constructed below 3.9.2")
+    def test_valid_uses_py39_plus(self):
+        T = TypeVar('T')
         C5 = Callable[Concatenate[int, ...], int]
         C6 = Callable[Concatenate[int, T, ...], T]
         self.assertEqual(C5.__origin__, C6.__origin__)

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5384,7 +5384,7 @@ class ConcatenateTests(BaseTestCase):
             Concatenate[P, T]
 
         # Cannot construct a Callable with Ellipsis in 3.8 as args must be types
-        if sys.version_info[:2] >= (3, 9, 2):
+        if sys.version_info >= (3, 9, 2):
             with self.assertRaisesRegex(
                 TypeError,
                 'is not a generic class',
@@ -5404,16 +5404,16 @@ class ConcatenateTests(BaseTestCase):
             ):
                 Concatenate[1, ..., P]
 
-    @skipUnless(TYPING_3_11_0, "Cannot be backported to <=3.9"
-                               "Cannot use ... with 3.10 typing._ConcatenateGenericAlias")
+    @skipUnless(TYPING_3_11_0 or (3, 10, 0) <= sys.version_info < (3, 10, 2),
+                "Cannot be backported to <=3.9"
+                "Cannot use ... with 3.10.2+ typing._ConcatenateGenericAlias")
     def test_alias(self):
-        P = ParamSpec("P")
-        C1 = Callable[Concatenate[int, P], Any]
-        # Python <= 3.9 fails because parameters to generic types must be types.
-        # For Python 3.10 & typing._ConcatenateGenericAlias will
-        # as Ellipsis is not supported for ParamSpec
-        # Fallback to 3.10 & typing_extensions._ConcatenateGenericAlias not implemented
-        C1[...]
+        P = ParamSpec('P')
+        X = Callable[Concatenate[int, P], Any]
+
+        C1 = X[...]
+        self.assertEqual(C1.__parameters__, ())
+        self.assertEqual(C1.__args__, (Concatenate[int, ...], Any))
 
     def test_basic_introspection(self):
         P = ParamSpec('P')

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5407,13 +5407,19 @@ class ConcatenateTests(BaseTestCase):
         ):
             Concatenate[P, T]
 
+        # Test with tuple argument
+        with self.assertRaisesRegex(
+            TypeError,
+            "The last parameter to Concatenate should be a ParamSpec variable or ellipsis.",
+        ):
+            Concatenate[(P, T)]
+
         with self.assertRaisesRegex(
             TypeError,
             'is not a generic class',
         ):
             Callable[Concatenate[int, ...], Any][Any]
 
-    def test_invalid_use(self):
         # Assure that `_type_check` is called.
         P = ParamSpec('P')
         with self.assertRaisesRegex(

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5446,8 +5446,8 @@ class ConcatenateTests(BaseTestCase):
 
     @skipUnless(TYPING_3_11_0 or (3, 10, 0) <= sys.version_info < (3, 10, 2),
                 "Cannot be backported to <=3.9"
-                "Cannot use ... with 3.10.2+ typing._ConcatenateGenericAlias")
-    def test_alias(self):
+                "Cannot use ... with typing._ConcatenateGenericAlias after 3.10.2")
+    def test_alias_subscription_with_ellipsis(self):
         P = ParamSpec('P')
         X = Callable[Concatenate[int, P], Any]
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5380,7 +5380,7 @@ class ConcatenateTests(BaseTestCase):
             with self.subTest(callable_variant=callable_variant):
                 if not TYPING_3_9_0 and callable_variant is collections.abc.Callable:
                     self.skipTest("Needs PEP 585")
-                
+
                 C1 = callable_variant[Concatenate[int, P], int]
                 C2 = callable_variant[Concatenate[int, T, P], T]
                 self.assertEqual(C1.__origin__, C2.__origin__)

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1799,30 +1799,30 @@ if not hasattr(typing, 'Concatenate'):
 else:
     _ConcatenateGenericAlias = typing._ConcatenateGenericAlias
 
-# 3.8-3.9,2
-class _EllipsisDummyType: ...
+# 3.8-3.9.2
+class _EllipsisDummy: ...
 
 # 3.8-3.10
 def _create_concatenate_alias(origin, parameters):
     if parameters[-1] is ... and sys.version_info < (3, 9, 2):
-        # Arguments must be types
-        parameters = parameters[:-1] + (_EllipsisDummyType,)
+        # Hack: Arguments must be types, replace it with one.
+        parameters = parameters[:-1] + (_EllipsisDummy,)
     if sys.version_info >= (3, 10, 2):
         concatenate = _ConcatenateGenericAlias(origin, parameters,
                                         _typevar_types=(TypeVar, ParamSpec),
                                         _paramspec_tvars=True)
     else:
         concatenate = _ConcatenateGenericAlias(origin, parameters)
-    if parameters[-1] is not _EllipsisDummyType:
+    if parameters[-1] is not _EllipsisDummy:
         return concatenate
     # Remove dummy again
-    concatenate.__args__ = tuple(p if p is not _EllipsisDummyType else ...
+    concatenate.__args__ = tuple(p if p is not _EllipsisDummy else ...
                                     for p in concatenate.__args__)
     if sys.version_info < (3, 10):
         # backport needs __args__ adjustment only
         return concatenate
     concatenate.__parameters__ = tuple(p for p in concatenate.__parameters__
-                                        if p is not _EllipsisDummyType)
+                                        if p is not _EllipsisDummy)
     return concatenate
 
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1803,7 +1803,6 @@ else:
     if sys.version_info < (3, 11):
         _typing_ConcatenateGenericAlias = _ConcatenateGenericAlias
 
-
         class _ConcatenateGenericAlias(_typing_ConcatenateGenericAlias, _root=True):
             # needed for checks in collections.abc.Callable to accept this class
             __module__ = "typing"
@@ -1822,11 +1821,12 @@ else:
 # 3.8-3.9.2
 class _EllipsisDummy: ...
 
+
 # 3.8-3.10
 def _create_concatenate_alias(origin, parameters):
     if parameters[-1] is ... and sys.version_info < (3, 9, 2):
         # Hack: Arguments must be types, replace it with one.
-        parameters = parameters[:-1] + (_EllipsisDummy,)
+        parameters = (*parameters[:-1], _EllipsisDummy)
     if sys.version_info >= (3, 10, 2):
         concatenate = _ConcatenateGenericAlias(origin, parameters,
                                         _typevar_types=(TypeVar, ParamSpec),
@@ -1860,6 +1860,7 @@ def _concatenate_getitem(self, parameters):
     parameters = (*(typing._type_check(p, msg) for p in parameters[:-1]),
                     parameters[-1])
     return _create_concatenate_alias(self, parameters)
+
 
 # 3.11+; Concatenate does not accept ellipsis in 3.10
 if sys.version_info >= (3, 11):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1800,7 +1800,7 @@ else:
     _ConcatenateGenericAlias = typing._ConcatenateGenericAlias
 
 # 3.10.2+
-if sys.version_info[:3] >= (3, 10, 2):
+if sys.version_info >= (3, 10, 2):
     _ellipsis_dummy = ParamSpec('_ellipsis_dummy')
 
     @typing._tp_cache
@@ -1848,7 +1848,7 @@ else:
         return _ConcatenateGenericAlias(self, parameters)
 
 # 3.11+; Concatenate does not accept ellipsis in 3.10
-if hasattr(typing, 'Concatenate') and sys.version_info[:2] >= (3, 11):
+if hasattr(typing, 'Concatenate') and sys.version_info >= (3, 11):
     Concatenate = typing.Concatenate
 # 3.9-3.10
 elif sys.version_info[:2] >= (3, 9):


### PR DESCRIPTION
Fixes https://github.com/python/typing_extensions/issues/110.

This PR adds support for Ellipsis in Concatenate for the Python 3.8-3.10 backports.

Does not fix:
   - https://github.com/python/typing_extensions/issues/48 : Using Ellipsis as argument for Callable with a generic..
      -  <= 3.9: because of typing.Callable limitations
      -  For 3.10 needs modification of `_ConcatenateGenericAlias`

Changes:
    - Changed _concatenate_getitem to reflect the Python3.11 typing module that allows the Ellipsis parameter.
    - For Python 3.10 uses typing._ConcatenateGenericAlias and _concatenate_getitem
    - For <=Python 3.9 the typing_extensions._ConcatenateGenericAlias and _concatenate_getitem like before
    - For <3.9.2 uses a Dummy class that is temporarily swapped with an Ellipsis input
    - added tests and updated tests