### PR TITLE
Change issue text on third party failure

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -412,5 +412,5 @@ jobs:
               owner: "python",
               repo: "typing_extensions",
               title: `Third-party tests failed on ${new Date().toDateString()}`,
-              body: "Runs listed here: https://github.com/python/typing_extensions/actions/workflows/third_party.yml",
+              body: "Full history of runs listed here: https://github.com/python/typing_extensions/actions/workflows/third_party.yml",
             })


### PR DESCRIPTION
It can be confusing to click on an old issue, click the first red thing you see and you're seeing some new failure, not the old one. This has tripped me up before and it looks like it briefly tripped up Daraan yesterday