### PR TITLE
Migrate pydantic tests to uv

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -60,19 +60,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: typing-extensions-latest
-      - name: Setup pdm for pydantic tests
-        uses: pdm-project/setup-pdm@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          allow-python-prereleases: true
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
       - name: Add local version of typing_extensions as a dependency
-        run: pdm add ./typing-extensions-latest
+        run: uv add --editable ./typing-extensions-latest
       - name: Install pydantic test dependencies
-        run: pdm install -G testing -G email
+        run: uv sync --group testing --group dev
       - name: List installed dependencies
-        run: pdm list -vv  # pdm equivalent to `pip list`
+        run: uv pip list
       - name: Run pydantic tests
-        run: pdm run pytest
+        run: uv run pytest
 
   typing_inspect:
     name: typing_inspect tests


### PR DESCRIPTION
Fixes #499

Pydantic switched from pdm to uv in https://github.com/pydantic/pydantic/pull/10727, which broke the pydantic daily tests. This PR updates the pydantic tests to use the new uv-based setup.

Example of the updated CI running green: https://github.com/brianschubert/typing_extensions/actions/runs/11767214620