### PR TITLE
match Buffer inheritance to cpython Buffer

### DIFF
--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3404,7 +3404,7 @@ else:
 if hasattr(collections.abc, "Buffer"):
     Buffer = collections.abc.Buffer
 else:
-    class Buffer(abc.ABC):  # noqa: B024
+    class Buffer(metaclass=abc.ABCMeta):  # noqa: B024
         """Base class for classes that implement the buffer protocol.
 
         The buffer protocol allows Python objects to expose a low-level


### PR DESCRIPTION
On 3.12+, `collections.abc.Buffer` uses `metaclass=ABCMeta` instead of inheriting from `ABC`. Is there a reason why `typing_extensions.Buffer` doesn't do the same?

In typeshed, `typing_extensions.Buffer` is Protocol, which means the stubs do have `metaclass=ABCMeta` but they don't inherit from `abc.ABC`, so this MR improves alignment with both `typing.Buffer` and the stubs. 