### PR TITLE
Just use git for checkout

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -49,9 +49,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout pydantic
-        uses: actions/checkout@v4
-        with:
-          repository: pydantic/pydantic
+        run: git clone https://github.com/pydantic/pydantic.git
       - name: Checkout typing_extensions
         uses: actions/checkout@v4
         with:
@@ -89,10 +87,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout typing_inspect
-        uses: actions/checkout@v4
-        with:
-          repository: ilevkivskyi/typing_inspect
-          path: typing_inspect
+        run: git clone https://github.com/ilevkivskyi/typing_inspect.git
       - name: Checkout typing_extensions
         uses: actions/checkout@v4
         with:
@@ -137,10 +132,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check out pyanalyze
-        uses: actions/checkout@v4
-        with:
-          repository: quora/pyanalyze
-          path: pyanalyze
+        run: git clone https://github.com/quora/pyanalyze.git
       - name: Checkout typing_extensions
         uses: actions/checkout@v4
         with:
@@ -186,10 +178,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check out typeguard
-        uses: actions/checkout@v4
-        with:
-          repository: agronholm/typeguard
-          path: typeguard
+        run: git clone https://github.com/agronholm/typeguard.git
       - name: Checkout typing_extensions
         uses: actions/checkout@v4
         with:
@@ -236,10 +225,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check out typed-argument-parser
-        uses: actions/checkout@v4
-        with:
-          repository: swansonk14/typed-argument-parser
-          path: typed-argument-parser
+        run: git clone https://github.com/swansonk14/typed-argument-parser.git
       - name: Checkout typing_extensions
         uses: actions/checkout@v4
         with:
@@ -291,10 +277,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout mypy for stubtest and mypyc tests
-        uses: actions/checkout@v4
-        with:
-          repository: python/mypy
-          path: mypy
+        run: git clone https://github.com/python/mypy.git
       - name: Checkout typing_extensions
         uses: actions/checkout@v4
         with:
@@ -342,9 +325,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout cattrs
-        uses: actions/checkout@v4
-        with:
-          repository: python-attrs/cattrs
+        run: git clone https://github.com/python-attrs/cattrs.git
       - name: Checkout typing_extensions
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -48,24 +48,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Checkout pydantic
         run: git clone https://github.com/pydantic/pydantic.git
       - name: Checkout typing_extensions
         uses: actions/checkout@v4
         with:
           path: typing-extensions-latest
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
       - name: Add local version of typing_extensions as a dependency
-        run: uv add --editable ./typing-extensions-latest
+        run: cd pydantic; uv add --editable ../typing-extensions-latest
       - name: Install pydantic test dependencies
-        run: uv sync --group dev
+        run: cd pydantic; uv sync --group dev
       - name: List installed dependencies
-        run: uv pip list
+        run: cd pydantic; uv pip list
       - name: Run pydantic tests
-        run: uv run pytest
+        run: cd pydantic; uv run pytest
 
   typing_inspect:
     name: typing_inspect tests
@@ -86,18 +89,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - name: Checkout typing_inspect
-        run: git clone https://github.com/ilevkivskyi/typing_inspect.git
-      - name: Checkout typing_extensions
-        uses: actions/checkout@v4
-        with:
-          path: typing-extensions-latest
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Checkout typing_inspect
+        run: git clone https://github.com/ilevkivskyi/typing_inspect.git
+      - name: Checkout typing_extensions
+        uses: actions/checkout@v4
+        with:
+          path: typing-extensions-latest
       - name: Install typing_inspect test dependencies
         run: |
           set -x
@@ -131,12 +134,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - name: Check out pyanalyze
-        run: git clone https://github.com/quora/pyanalyze.git
-      - name: Checkout typing_extensions
-        uses: actions/checkout@v4
-        with:
-          path: typing-extensions-latest
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -144,6 +141,12 @@ jobs:
           allow-prereleases: true
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Check out pyanalyze
+        run: git clone https://github.com/quora/pyanalyze.git
+      - name: Checkout typing_extensions
+        uses: actions/checkout@v4
+        with:
+          path: typing-extensions-latest
       - name: Install pyanalyze test requirements
         run: |
           set -x
@@ -177,12 +180,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - name: Check out typeguard
-        run: git clone https://github.com/agronholm/typeguard.git
-      - name: Checkout typing_extensions
-        uses: actions/checkout@v4
-        with:
-          path: typing-extensions-latest
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -190,6 +187,12 @@ jobs:
           allow-prereleases: true
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Check out typeguard
+        run: git clone https://github.com/agronholm/typeguard.git
+      - name: Checkout typing_extensions
+        uses: actions/checkout@v4
+        with:
+          path: typing-extensions-latest
       - name: Install typeguard test requirements
         run: |
           set -x
@@ -224,18 +227,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - name: Check out typed-argument-parser
-        run: git clone https://github.com/swansonk14/typed-argument-parser.git
-      - name: Checkout typing_extensions
-        uses: actions/checkout@v4
-        with:
-          path: typing-extensions-latest
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Check out typed-argument-parser
+        run: git clone https://github.com/swansonk14/typed-argument-parser.git
+      - name: Checkout typing_extensions
+        uses: actions/checkout@v4
+        with:
+          path: typing-extensions-latest
       - name: Configure git for typed-argument-parser tests
         # typed-argument parser does this in their CI,
         # and the tests fail unless we do this
@@ -276,12 +279,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - name: Checkout mypy for stubtest and mypyc tests
-        run: git clone https://github.com/python/mypy.git
-      - name: Checkout typing_extensions
-        uses: actions/checkout@v4
-        with:
-          path: typing-extensions-latest
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -289,6 +286,12 @@ jobs:
           allow-prereleases: true
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Checkout mypy for stubtest and mypyc tests
+        run: git clone https://github.com/python/mypy.git
+      - name: Checkout typing_extensions
+        uses: actions/checkout@v4
+        with:
+          path: typing-extensions-latest
       - name: Install mypy test requirements
         run: |
           set -x
@@ -324,28 +327,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Checkout cattrs
         run: git clone https://github.com/python-attrs/cattrs.git
       - name: Checkout typing_extensions
         uses: actions/checkout@v4
         with:
           path: typing-extensions-latest
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install pdm for cattrs
         run: pip install pdm
       - name: Add latest typing-extensions as a dependency
         run: |
+          cd cattrs
           pdm remove typing-extensions
-          pdm add --dev ./typing-extensions-latest
+          pdm add --dev ../typing-extensions-latest
       - name: Install cattrs test dependencies
-        run: pdm install --dev -G :all
+        run: cd cattrs; pdm install --dev -G :all
       - name: List all installed dependencies
-        run: pdm list -vv
+        run: cd cattrs; pdm list -vv
       - name: Run cattrs tests
-        run: pdm run pytest tests
+        run: cd cattrs; pdm run pytest tests
 
   create-issue-on-failure:
     name: Create an issue if daily tests failed


### PR DESCRIPTION
actions/checkout is repeatedly flaky. See also https://github.com/actions/checkout/issues/1951

On the other hand, plain git clone seems to work just fine and never has connection issues checking out the default branch or whatever. If we do still see issues, it'll also be much easier to add retries 

Funnily enough, the YAML is shorter this way too