### PR TITLE
Use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 readme = "README.md"
 requires-python = ">=3.8"
-license = { file = "LICENSE" }
+license = { text = "PSF-2.0" }
 keywords = [
     "annotations",
     "backport",


### PR DESCRIPTION
Use the SPDX license identifier as recommended by [PEP 639](https://peps.python.org/pep-0639/).
https://spdx.org/licenses/PSF-2.0.html

At the moment the license key is ignored by flit, see https://github.com/pypa/flit/issues/525. However, it's still possible to replace it now. Once the support in flit is added, the value will be used automatically.