### PR TITLE
Fix recursive use of Concatenate when mixing modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ aliases that have a `Concatenate` special form as their argument.
 - Fix that lists and ... could not be used for parameter expressions for `TypeAliasType`
   instances before Python 3.11.
   Patch by [Daraan](https://github.com/Daraan).
+- Fix error on Python 3.10 when using `typing.Concatenate` and 
+  `typing_extensions.Concatenate` together. Patch by [Daraan](https://github.com/Daraan).
 
 # Release 4.12.2 (June 7, 2024)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5376,9 +5376,15 @@ class ConcatenateTests(BaseTestCase):
     @skipUnless(TYPING_3_10_0, "Concatenate not available in <3.10")
     def test_typing_compatibility(self):
         P = ParamSpec('P')
-        C = Concatenate[int, P][typing.Concatenate[int, P]]
-        self.assertEqual(C, Concatenate[int, int, P])
-        self.assertEqual(get_args(C), (int, int, P))
+        C1 = Concatenate[int, P][typing.Concatenate[int, P]]
+        self.assertEqual(C1, Concatenate[int, int, P])
+        self.assertEqual(get_args(C1), (int, int, P))
+
+        C2 = typing.Concatenate[int, P][Concatenate[int, P]]
+        with self.subTest("typing compatibility with typing_extensions"):
+            if sys.version_info < (3, 10, 3):
+                self.skipTest("Unpacking not introduced until 3.10.3")
+            self.assertEqual(get_args(C2), (int, int, P))
 
     def test_valid_uses(self):
         P = ParamSpec('P')

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5373,6 +5373,13 @@ class ConcatenateTests(BaseTestCase):
         self.assertNotEqual(d, c)
         self.assertNotEqual(d, Concatenate)
 
+    @skipUnless(TYPING_3_10_0, "Concatenate not available in <3.10")
+    def test_typing_compatibility(self):
+        P = ParamSpec('P')
+        C = Concatenate[int, P][typing.Concatenate[int, P]]
+        self.assertEqual(C, Concatenate[int, int, P])
+        self.assertEqual(get_args(C), (int, int, P))
+
     def test_valid_uses(self):
         P = ParamSpec('P')
         T = TypeVar('T')

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1801,21 +1801,20 @@ else:
 
     # 3.10
     if sys.version_info < (3, 11):
-        _typing_ConcatenateGenericAlias = _ConcatenateGenericAlias
 
-        class _ConcatenateGenericAlias(_typing_ConcatenateGenericAlias, _root=True):
+        class _ConcatenateGenericAlias(typing._ConcatenateGenericAlias, _root=True):
             # needed for checks in collections.abc.Callable to accept this class
             __module__ = "typing"
 
             def copy_with(self, params):
                 if isinstance(params[-1], (list, tuple)):
                     return (*params[:-1], *params[-1])
-                if isinstance(params[-1], _ConcatenateGenericAlias):
+                if isinstance(params[-1], typing._ConcatenateGenericAlias):
                     params = (*params[:-1], *params[-1].__args__)
                 elif not (params[-1] is ... or isinstance(params[-1], ParamSpec)):
                     raise TypeError("The last parameter to Concatenate should be a "
                             "ParamSpec variable or ellipsis.")
-                return super(_typing_ConcatenateGenericAlias, self).copy_with(params)
+                return super(typing._ConcatenateGenericAlias, self).copy_with(params)
 
 
 # 3.8-3.9.2


### PR DESCRIPTION
Fixes that this code sample throws an error for 3.10:
```python
P = ParamSpec("P")
typing_extensions.Concatenate[int, P][typing.Concatenate[int, P]]
```

> TypeError: The last parameter to Concatenate should be a ParamSpec variable or ellipsis.