### PR TITLE
Change issue text on thirdy_party failure to include exact run URL

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -394,5 +394,5 @@ jobs:
               owner: "python",
               repo: "typing_extensions",
               title: `Third-party tests failed on ${new Date().toDateString()}`,
-              body: "Full history of runs listed here: https://github.com/python/typing_extensions/actions/workflows/third_party.yml",
+              body: "Run listed here: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
             })


### PR DESCRIPTION
Based on [this SO answer](https://stackoverflow.com/a/70566764/), it's possible generate a URL for the current workflow run. We can use this in the issue body to save a few clicks and make it easier to find the right run when looking at old issues.

I tried this on my fork and it seems to be working great. Here's an example of a workflow run that prints its own URL using this setup (see the error in the dummy-print-url job): https://github.com/brianschubert/typing_extensions/actions/runs/12205086165