### PR TITLE
Fix third party scheduled tests running on forks

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -28,16 +28,11 @@ concurrency:
 jobs:
   pydantic:
     name: pydantic tests
+    # if 'schedule' was the trigger,
+    # don't run it on contributors' forks
     if: >-
-      # if 'schedule' was the trigger,
-      # don't run it on contributors' forks
-      ${{
-        github.event_name != 'schedule'
-        || (
-          github.repository == 'python/typing_extensions'
-          && github.event_name == 'schedule'
-        )
-      }}
+      github.repository == 'python/typing_extensions'
+      || github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:
@@ -72,16 +67,11 @@ jobs:
 
   typing_inspect:
     name: typing_inspect tests
+    # if 'schedule' was the trigger,
+    # don't run it on contributors' forks
     if: >-
-      # if 'schedule' was the trigger,
-      # don't run it on contributors' forks
-      ${{
-        github.event_name != 'schedule'
-        || (
-          github.repository == 'python/typing_extensions'
-          && github.event_name == 'schedule'
-        )
-      }}
+      github.repository == 'python/typing_extensions'
+      || github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:
@@ -117,16 +107,11 @@ jobs:
 
   pyanalyze:
     name: pyanalyze tests
+    # if 'schedule' was the trigger,
+    # don't run it on contributors' forks
     if: >-
-      # if 'schedule' was the trigger,
-      # don't run it on contributors' forks
-      ${{
-        github.event_name != 'schedule'
-        || (
-          github.repository == 'python/typing_extensions'
-          && github.event_name == 'schedule'
-        )
-      }}
+      github.repository == 'python/typing_extensions'
+      || github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:
@@ -163,16 +148,11 @@ jobs:
 
   typeguard:
     name: typeguard tests
+    # if 'schedule' was the trigger,
+    # don't run it on contributors' forks
     if: >-
-      # if 'schedule' was the trigger,
-      # don't run it on contributors' forks
-      ${{
-        github.event_name != 'schedule'
-        || (
-          github.repository == 'python/typing_extensions'
-          && github.event_name == 'schedule'
-        )
-      }}
+      github.repository == 'python/typing_extensions'
+      || github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:
@@ -210,16 +190,11 @@ jobs:
 
   typed-argument-parser:
     name: typed-argument-parser tests
+    # if 'schedule' was the trigger,
+    # don't run it on contributors' forks
     if: >-
-      # if 'schedule' was the trigger,
-      # don't run it on contributors' forks
-      ${{
-        github.event_name != 'schedule'
-        || (
-          github.repository == 'python/typing_extensions'
-          && github.event_name == 'schedule'
-        )
-      }}
+      github.repository == 'python/typing_extensions'
+      || github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:
@@ -262,16 +237,11 @@ jobs:
 
   mypy:
     name: stubtest & mypyc tests
+    # if 'schedule' was the trigger,
+    # don't run it on contributors' forks
     if: >-
-      # if 'schedule' was the trigger,
-      # don't run it on contributors' forks
-      ${{
-        github.event_name != 'schedule'
-        || (
-          github.repository == 'python/typing_extensions'
-          && github.event_name == 'schedule'
-        )
-      }}
+      github.repository == 'python/typing_extensions'
+      || github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:
@@ -309,16 +279,11 @@ jobs:
 
   cattrs:
     name: cattrs tests
+    # if 'schedule' was the trigger,
+    # don't run it on contributors' forks
     if: >-
-      # if 'schedule' was the trigger,
-      # don't run it on contributors' forks
-      ${{
-        github.event_name != 'schedule'
-        || (
-          github.repository == 'python/typing_extensions'
-          && github.event_name == 'schedule'
-        )
-      }}
+      github.repository == 'python/typing_extensions'
+      || github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -26,13 +26,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pydantic:
-    name: pydantic tests
+  skip-schedule-on-fork:
+    name: Check for schedule trigger on fork
+    runs-on: ubuntu-latest
     # if 'schedule' was the trigger,
     # don't run it on contributors' forks
     if: >-
       github.repository == 'python/typing_extensions'
       || github.event_name != 'schedule'
+    steps:
+      - run: true
+
+  pydantic:
+    name: pydantic tests
+    needs: skip-schedule-on-fork
     strategy:
       fail-fast: false
       matrix:
@@ -67,11 +74,7 @@ jobs:
 
   typing_inspect:
     name: typing_inspect tests
-    # if 'schedule' was the trigger,
-    # don't run it on contributors' forks
-    if: >-
-      github.repository == 'python/typing_extensions'
-      || github.event_name != 'schedule'
+    needs: skip-schedule-on-fork
     strategy:
       fail-fast: false
       matrix:
@@ -107,11 +110,7 @@ jobs:
 
   pyanalyze:
     name: pyanalyze tests
-    # if 'schedule' was the trigger,
-    # don't run it on contributors' forks
-    if: >-
-      github.repository == 'python/typing_extensions'
-      || github.event_name != 'schedule'
+    needs: skip-schedule-on-fork
     strategy:
       fail-fast: false
       matrix:
@@ -148,11 +147,7 @@ jobs:
 
   typeguard:
     name: typeguard tests
-    # if 'schedule' was the trigger,
-    # don't run it on contributors' forks
-    if: >-
-      github.repository == 'python/typing_extensions'
-      || github.event_name != 'schedule'
+    needs: skip-schedule-on-fork
     strategy:
       fail-fast: false
       matrix:
@@ -190,11 +185,7 @@ jobs:
 
   typed-argument-parser:
     name: typed-argument-parser tests
-    # if 'schedule' was the trigger,
-    # don't run it on contributors' forks
-    if: >-
-      github.repository == 'python/typing_extensions'
-      || github.event_name != 'schedule'
+    needs: skip-schedule-on-fork
     strategy:
       fail-fast: false
       matrix:
@@ -237,11 +228,7 @@ jobs:
 
   mypy:
     name: stubtest & mypyc tests
-    # if 'schedule' was the trigger,
-    # don't run it on contributors' forks
-    if: >-
-      github.repository == 'python/typing_extensions'
-      || github.event_name != 'schedule'
+    needs: skip-schedule-on-fork
     strategy:
       fail-fast: false
       matrix:
@@ -279,11 +266,7 @@ jobs:
 
   cattrs:
     name: cattrs tests
-    # if 'schedule' was the trigger,
-    # don't run it on contributors' forks
-    if: >-
-      github.repository == 'python/typing_extensions'
-      || github.event_name != 'schedule'
+    needs: skip-schedule-on-fork
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Background in #226, #522 

Moves a comment to outside of the `if:` condition so that the condition doesn't always evaluate to true (see https://github.com/python/typing_extensions/issues/522#issuecomment-2557882155).

Also did some opportunistic refactoring:

* Simplified the condition: `A || (B && ~A)` is equivalent to `A || B`
* Refactored the repeated condition into a single predicate job. This way we don't have to repeat the same logic in each test job. I made this change in a separate commit which I can roll back if keeping the original setup is preferred.