### PR TITLE
Update flit to use PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # Build system requirements.
 [build-system]
-requires = ["flit_core >=3.4,<4"]
+requires = ["flit_core >=3.11,<4"]
 build-backend = "flit_core.buildapi"
 
 # Project metadata
@@ -10,7 +10,8 @@ version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 readme = "README.md"
 requires-python = ">=3.8"
-license = { text = "PSF-2.0" }
+license = "PSF-2.0"
+license-files = ["LICENSE"]
 keywords = [
     "annotations",
     "backport",
@@ -30,7 +31,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Python Software Foundation License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
Flit `3.11` was released today with basic support for PEP 639.
https://flit.pypa.io/en/stable/history.html#version-3-11

Followup to #507, replaces #451.