### PR TITLE
docs: Fix "Final[42]"

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -133,7 +133,7 @@ Example usage::
    False
    >>> is_literal(get_origin(typing.Literal[42]))
    True
-   >>> is_literal(get_origin(typing_extensions.Final[42]))
+   >>> is_literal(get_origin(typing_extensions.Final[int]))
    False
 
 Python version support


### PR DESCRIPTION
This fails at runtime in older versions, and in any case it is an invalid type.

Fixes #531