### PR TITLE
Fix `isinstance(Unpack[Ts], TypeVar)` to be `False` in 3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ aliases that have a `Concatenate` special form as their argument.
   to reflect Python 3.13+ behavior: A value assigned to `__total__` in the class body of a
   `TypedDict` will be overwritten by the `total` argument of the `TypedDict` constructor.
   Patch by [Daraan](https://github.com/Daraan), backporting a CPython PR by Jelle Zijlstra.
+- Fix for Python 3.11 that now `isinstance(typing_extensions.Unpack[...], TypeVar)` 
+  evaluates to `False`, however still `True` for <3.11.
+  Patch by [Daraan](https://github.com/Daraan)
 
 # Release 4.12.2 (June 7, 2024)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6172,6 +6172,12 @@ class UnpackTests(BaseTestCase):
         self.assertEqual(nested_tuple_bare, TupleAliasTsT[Unpack[Tuple[str, int]], object])
         self.assertEqual(nested_tuple_bare, TupleAliasTsT[Unpack[Tuple[str]], Unpack[Tuple[int]], object])
 
+    @skipUnless(TYPING_3_11_0, "Needed for backport")
+    def test_type_var_inheritance(self):
+        Ts = TypeVarTuple("Ts")
+        self.assertFalse(isinstance(Unpack[Ts], TypeVar))
+        self.assertFalse(isinstance(Unpack[Ts], typing.TypeVar))
+
 
 class TypeVarTupleTests(BaseTestCase):
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2657,7 +2657,7 @@ elif sys.version_info[:2] >= (3, 9):  # 3.9+
             self.__doc__ = _UNPACK_DOC
 
     class _UnpackAlias(typing._GenericAlias, _root=True):
-        if sys.version_info[:2] < (3, 11):
+        if sys.version_info < (3, 11):
             # needed for compatibility with Generic[Unpack[Ts]]
             __class__ = typing.TypeVar
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2657,7 +2657,9 @@ elif sys.version_info[:2] >= (3, 9):  # 3.9+
             self.__doc__ = _UNPACK_DOC
 
     class _UnpackAlias(typing._GenericAlias, _root=True):
-        __class__ = typing.TypeVar
+        if sys.version_info[:2] < (3, 11):
+            # needed for compatibility with Generic[Unpack[Ts]]
+            __class__ = typing.TypeVar
 
         @property
         def __typing_unpacked_tuple_args__(self):


### PR DESCRIPTION
In relation to #538 a minor fix for 3.11 only. For <3.11 it's currently a necessary trick to keep the `__class__ = typing.TypeVar` attribute allow using `Generic[Unpack[Ts]]`.

I am not sure if the additional test is that important, I slightly in favor of removing it again.