### PR TITLE
Bump intersphinx base for Python docs to 3.13

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ extensions = ['sphinx.ext.intersphinx', '_extensions.gh_link']
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
-intersphinx_mapping = {'py': ('https://docs.python.org/3.13', None)}
+intersphinx_mapping = {'py': ('https://docs.python.org/3', None)}
 
 add_module_names = False
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ extensions = ['sphinx.ext.intersphinx', '_extensions.gh_link']
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
-intersphinx_mapping = {'py': ('https://docs.python.org/3.12', None)}
+intersphinx_mapping = {'py': ('https://docs.python.org/3.13', None)}
 
 add_module_names = False
 


### PR DESCRIPTION
I noticed that the docs are missing intersphinx links to the Python docs for features added to `typing` in 3.13. I was going to add some, but discovered this wasn't possible since intersphinx is currently set up to link to the Python 3.12 docs.

This PR updates intersphinx to link to the Python 3.13 docs, making e.g. `` :py:data:`typing.TypeIs` `` possible.