### PR TITLE
Fix 'Test and lint' workflow running on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,11 @@ jobs:
   tests:
     name: Run tests
 
+    # if 'schedule' was the trigger,
+    # don't run it on contributors' forks
     if: >-
-      # if 'schedule' was the trigger,
-      # don't run it on contributors' forks
-      ${{
-        github.event_name != 'schedule'
-        || (
-          github.repository == 'python/typing_extensions'
-          && github.event_name == 'schedule'
-        )
-      }}
+      github.repository == 'python/typing_extensions'
+      || github.event_name != 'schedule'
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Same thing as #525. The 'Third party tests' workflow no longer runs on forks, but the 'Test and lint' workflow also has scheduled tests which weren't fixed.

This should stop the remaining scheduled tests from running on forks. Closes #522.