### PR TITLE
Fix duplicated keywords for typing._ConcatenateGenericAlias in 3.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+Bugfixes and changed features:
+- Fix regression in 4.13.0 on Python 3.10.2 causing a `TypeError` when using `Concatenate`.
+  Patch by [Daraan](https://github.com/Daraan).
+
 # Release 4.13.0 (March 25, 2025)
 
 No user-facing changes since 4.13.0rc1.

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2072,7 +2072,7 @@ def _create_concatenate_alias(origin, parameters):
     if parameters[-1] is ... and sys.version_info < (3, 9, 2):
         # Hack: Arguments must be types, replace it with one.
         parameters = (*parameters[:-1], _EllipsisDummy)
-    if sys.version_info >= (3, 10, 2):
+    if sys.version_info >= (3, 10, 3):
         concatenate = _ConcatenateGenericAlias(origin, parameters,
                                         _typevar_types=(TypeVar, ParamSpec),
                                         _paramspec_tvars=True)


### PR DESCRIPTION
Fixes #556
 - #556

class `_ConcatenateGenericAlias.__init__` with hardcoded keywords was only removed in 3.10.3

https://github.com/python/cpython/blob/a58ebcc701dd6c43630df941481475ff0f615a81/Lib/typing.py#L1271-L1278

Tested with python 3.10.0-4