### PR TITLE
Fix TypeError with evaluate_forward_ref on some 3.10 and 3.9 versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+Bugfixes and changed features:
+- Fix `TypeError` when using `evaluate_forward_ref` on Python 3.10.1-2 and 3.9.8-10.
+  Patch by [Daraan](https://github.com/Daraan).
+
 # Release 4.13.0 (March 25, 2025)
 
 No user-facing changes since 4.13.0rc1.

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -4371,7 +4371,11 @@ else:
         A lax Python 3.11+ like version of typing._type_check
         """
         if hasattr(typing, "_type_convert"):
-            if _FORWARD_REF_HAS_CLASS:
+            if (
+                sys.version_info >= (3, 10, 3)
+                or (3, 9, 10) < sys.version_info[:3] < (3, 10)
+            ):
+                # allow_special_forms introduced later cpython/#30926 (bpo-46539)
                 type_ = typing._type_convert(
                     value,
                     module=module,


### PR DESCRIPTION
The `allow_special_forms` keyword was not introduced together with `__forward_is_class__` in 3.10.1 and 3.9.8, but later. This PR corrects the version range. 