### PR TITLE
Add SQLAlchemy to third-party daily tests

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -323,7 +323,7 @@ jobs:
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Checkout sqlalchemy
-        run: git clone -b ${{ matrix.checkout-ref }} --depth=1 https://github.com/sqlalchemy/sqlalchemy.git && git clone -b ${{ matrix.checkout-ref }} --depth=1 https://github.com/sqlalchemy/sqlalchemy.git
+        run: git clone -b ${{ matrix.checkout-ref }} --depth=1 https://github.com/sqlalchemy/sqlalchemy.git || git clone -b ${{ matrix.checkout-ref }} --depth=1 https://github.com/sqlalchemy/sqlalchemy.git
       - name: Checkout typing_extensions
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -300,6 +300,49 @@ jobs:
       - name: Run cattrs tests
         run: cd cattrs; pdm run pytest tests
 
+  sqlalchemy:
+    name: sqlalchemy tests
+    needs: skip-schedule-on-fork
+    strategy:
+      fail-fast: false
+      matrix:
+        # PyPy is deliberately omitted here, since SQLAlchemy's tests
+        # fail on PyPy for reasons unrelated to typing_extensions.
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+    # sqlalchemy tests fail when using the Ubuntu 24.04 runner
+    # https://github.com/sqlalchemy/sqlalchemy/commit/8d73205f352e68c6603e90494494ef21027ec68f
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Checkout sqlalchemy
+        run: git clone --depth=1 https://github.com/sqlalchemy/sqlalchemy.git || git clone --depth=1 https://github.com/sqlalchemy/sqlalchemy.git
+      - name: Checkout typing_extensions
+        uses: actions/checkout@v4
+        with:
+          path: typing-extensions-latest
+      - name: Install test dependencies
+        run: |
+          cd sqlalchemy
+          uv add --editable ../typing-extensions-latest
+          uv add tox setuptools
+          uv sync
+      - name: List installed dependencies
+        # Note: additional dependencies are installed when running tox below
+        run: cd sqlalchemy; uv pip list
+      - name: Run sqlalchemy tests
+        run: |
+          cd sqlalchemy
+          uv run tox -e github-nocext -- -q --nomemory --notimingintensive
+        env:
+          TOX_WORKERS: -n4
+
   create-issue-on-failure:
     name: Create an issue if daily tests failed
     runs-on: ubuntu-latest
@@ -312,6 +355,7 @@ jobs:
       - typed-argument-parser
       - mypy
       - cattrs
+      - sqlalchemy
 
     if: >-
         ${{
@@ -326,6 +370,7 @@ jobs:
             || needs.typed-argument-parser.result == 'failure'
             || needs.mypy.result == 'failure'
             || needs.cattrs.result == 'failure'
+            || needs.sqlalchemy.result == 'failure'
           )
         }}
 

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -309,6 +309,7 @@ jobs:
         # PyPy is deliberately omitted here, since SQLAlchemy's tests
         # fail on PyPy for reasons unrelated to typing_extensions.
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        checkout-ref: [ "main", "rel_2_0" ]
     # sqlalchemy tests fail when using the Ubuntu 24.04 runner
     # https://github.com/sqlalchemy/sqlalchemy/commit/8d73205f352e68c6603e90494494ef21027ec68f
     runs-on: ubuntu-22.04
@@ -322,7 +323,7 @@ jobs:
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Checkout sqlalchemy
-        run: git clone --depth=1 https://github.com/sqlalchemy/sqlalchemy.git || git clone --depth=1 https://github.com/sqlalchemy/sqlalchemy.git
+        run: for i in {1..2}; do git clone -b ${{ matrix.checkout-ref }} --depth=1 https://github.com/sqlalchemy/sqlalchemy.git && break; done
       - name: Checkout typing_extensions
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -328,19 +328,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: typing-extensions-latest
-      - name: Install test dependencies
-        run: |
-          cd sqlalchemy
-          uv add --editable ../typing-extensions-latest
-          uv add tox setuptools
-          uv sync
+      - name: Install sqlalchemy test dependencies
+        run: uv pip install --system tox setuptools
+      - name: Install typing_extensions latest
+        run: uv pip install --system -e 'typing-extensions @ ./typing-extensions-latest'
       - name: List installed dependencies
         # Note: additional dependencies are installed when running tox below
-        run: cd sqlalchemy; uv pip list
+        run: uv pip list
       - name: Run sqlalchemy tests
         run: |
           cd sqlalchemy
-          uv run tox -e github-nocext -- -q --nomemory --notimingintensive
+          tox -e github-nocext -- -q --nomemory --notimingintensive
         env:
           TOX_WORKERS: -n4
 

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -323,7 +323,7 @@ jobs:
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Checkout sqlalchemy
-        run: for i in {1..2}; do git clone -b ${{ matrix.checkout-ref }} --depth=1 https://github.com/sqlalchemy/sqlalchemy.git && break; done
+        run: git clone -b ${{ matrix.checkout-ref }} --depth=1 https://github.com/sqlalchemy/sqlalchemy.git && git clone -b ${{ matrix.checkout-ref }} --depth=1 https://github.com/sqlalchemy/sqlalchemy.git
       - name: Checkout typing_extensions
         uses: actions/checkout@v4
         with:
@@ -342,8 +342,6 @@ jobs:
           tox -e github-nocext \
             --force-dep "typing-extensions @ file://$(pwd)/../typing-extensions-latest" \
             -- -q --nomemory --notimingintensive
-        env:
-          TOX_WORKERS: -n4
 
   create-issue-on-failure:
     name: Create an issue if daily tests failed

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -330,15 +330,18 @@ jobs:
           path: typing-extensions-latest
       - name: Install sqlalchemy test dependencies
         run: uv pip install --system tox setuptools
-      - name: Install typing_extensions latest
-        run: uv pip install --system -e 'typing-extensions @ ./typing-extensions-latest'
       - name: List installed dependencies
-        # Note: additional dependencies are installed when running tox below
+        # Note: tox installs SQLAlchemy and its dependencies in a different isolated
+        # environment before running the tests. To see the dependencies installed
+        # in the test environment, look for the line 'freeze> python -m pip freeze --all'
+        # in the output of the test step below.
         run: uv pip list
       - name: Run sqlalchemy tests
         run: |
           cd sqlalchemy
-          tox -e github-nocext -- -q --nomemory --notimingintensive
+          tox -e github-nocext \
+            --force-dep "typing-extensions @ file://$(pwd)/../typing-extensions-latest" \
+            -- -q --nomemory --notimingintensive
         env:
           TOX_WORKERS: -n4
 


### PR DESCRIPTION
Brought up in [#560](https://github.com/python/typing_extensions/issues/560#issuecomment-2755270696):

> It's unfortunate that none of these checks caught the SQLAlchemy issue in advance here. I think a good action item for us would be to add SQLAlchemy to the list of projects we run the test suites for on a nightly basis; that will help ensure that this doesn't happen again.

[SQLAlchemy](https://github.com/sqlalchemy/sqlalchemy) relies heavily on runtime introspection, is actively maintained, and has a test suite that runs pretty fast (~5m). Seems like a good candidate for the daily tests.

These tests are based on SQLAlchemy's [`run-test.yaml`](https://github.com/sqlalchemy/sqlalchemy/blob/main/.github/workflows/run-test.yaml) & [`run-on-pr.yaml`](https://github.com/sqlalchemy/sqlalchemy/blob/main/.github/workflows/run-on-pr.yaml) workflows, with some setup borrowed from the pydantic tests. 

A few notes about the setup:
* The tests pin the ubuntu-22.04 runner instead of using ubuntu-latest. This is done in the SQLAlchemy tests (https://github.com/sqlalchemy/sqlalchemy/commit/8d73205f352e68c6603e90494494ef21027ec68f). For whatever reason the tests fail on the Ubuntu 24.04 runner.
* PyPy tests are omitted. SQLAlchemy's CI [includes PyPy tests](https://github.com/sqlalchemy/sqlalchemy/blob/b52ade871ed7b55813c096932b034dd2238f7c88/.github/workflows/run-test.yaml#L40), but they currently fail ([example](https://github.com/sqlalchemy/sqlalchemy/actions/runs/14093101838/job/39474379966#step:6:3606)) and [are ignored](https://github.com/sqlalchemy/sqlalchemy/blob/main/.github/workflows/run-test.yaml#L121).
* The current failures are related to the issue from [#560](https://github.com/python/typing_extensions/issues/560):
  ```none
  AssertionError: <class 'typing.TypeAliasType'> is not <class 'typing_extensions.TypeAliasType'>
  ```
  The tests run green when using typing-extensions v4.12.2 ([example run on my fork](https://github.com/brianschubert/typing_extensions/actions/runs/14095739156/job/39482580410)).

