### PR TITLE
Move CI to "ubuntu-latest"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,23 +54,23 @@ jobs:
           - "pypy3.9"
           - "pypy3.10"
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: astral-sh/setup-uv@v5
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          enable-cache: false
+          allow-prereleases: true
 
       - name: Test typing_extensions
         run: |
           # Be wary of running `pip install` here, since it becomes easy for us to
           # accidentally pick up typing_extensions as installed by a dependency
           cd src
-          python --version
+          python --version  # just to make sure we're running the right one
           python -m unittest test_typing_extensions.py
 
       - name: Test CPython typing test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,17 +60,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
 
       - name: Test typing_extensions
         run: |
           # Be wary of running `pip install` here, since it becomes easy for us to
           # accidentally pick up typing_extensions as installed by a dependency
           cd src
-          python -m unittest test_typing_extensions.py
+          $UV_PYTHON -m unittest test_typing_extensions.py
 
       - name: Test CPython typing test suite
         # Test suite fails on PyPy even without typing_extensions
@@ -79,7 +78,7 @@ jobs:
           cd src
           # Run the typing test suite from CPython with typing_extensions installed,
           # because we monkeypatch typing under some circumstances.
-          python -c 'import typing_extensions; import test.__main__' test_typing -v
+          $UV_PYTHON -c 'import typing_extensions; import test.__main__' test_typing -v
 
   linting:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: false
 
       - name: Test typing_extensions
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
           # Be wary of running `pip install` here, since it becomes easy for us to
           # accidentally pick up typing_extensions as installed by a dependency
           cd src
-          $UV_PYTHON -m unittest test_typing_extensions.py
+          python --version
+          python -m unittest test_typing_extensions.py
 
       - name: Test CPython typing test suite
         # Test suite fails on PyPy even without typing_extensions
@@ -78,7 +79,7 @@ jobs:
           cd src
           # Run the typing test suite from CPython with typing_extensions installed,
           # because we monkeypatch typing under some circumstances.
-          $UV_PYTHON -c 'import typing_extensions; import test.__main__' test_typing -v
+          python -c 'import typing_extensions; import test.__main__' test_typing -v
 
   linting:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           - "pypy3.9"
           - "pypy3.10"
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -312,7 +312,7 @@ jobs:
         checkout-ref: [ "main", "rel_2_0" ]
     # sqlalchemy tests fail when using the Ubuntu 24.04 runner
     # https://github.com/sqlalchemy/sqlalchemy/commit/8d73205f352e68c6603e90494494ef21027ec68f
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - name: Setup Python

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -8844,9 +8844,12 @@ class TestEvaluateForwardRefs(BaseTestCase):
         self.assertIs(evaluate_forward_ref(typing.ForwardRef("int"), globals={"int": str}), str)
         import builtins
 
-        from test import support
-        with support.swap_attr(builtins, "int", dict):
+        real_int = builtins.int
+        try:
+            builtins.int = dict
             self.assertIs(evaluate_forward_ref(typing.ForwardRef("int")), dict)
+        finally:
+            builtins.int = real_int
 
     def test_nested_strings(self):
         # This variable must have a different name TypeVar


### PR DESCRIPTION
GitHub is decommissioning Ubuntu 20.04. I wouldn't expect our tests to
have a lot of OS version dependencies, so let's try just running
ubuntu-latest everywhere.
