### PR TITLE
Enable Python 3.13 in cattrs 3rd party tests

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -271,8 +271,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # skip 3.13 because msgspec doesn't support 3.13 yet
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Was disabled because msgspec didn't support 3.13. msgspec 0.19.0 has since been released with 3.13 support, and cattrs has been updated