### PR TITLE
Implement support for PEP 764 (inline typed dictionaries)

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5066,6 +5066,38 @@ class TypedDictTests(BaseTestCase):
             class TD(TypedDict, closed=True, extra_items=range):
                 x: str
 
+    def test_inlined_too_many_arguments(self):
+        with self.assertRaises(TypeError):
+            TypedDict[{"a": int}, "extra"]
+
+    def test_inlined_not_a_dict(self):
+        with self.assertRaises(TypeError):
+            TypedDict["not_a_dict"]
+
+    def test_inlined(self):
+        TD = TypedDict[{
+            "a": int,
+            "b": Required[int],
+            "c": NotRequired[int],
+            "d": ReadOnly[int],
+        }]
+        self.assertIsSubclass(TD, dict)
+        self.assertIsSubclass(TD, typing.MutableMapping)
+        self.assertNotIsSubclass(TD, collections.abc.Sequence)
+        self.assertTrue(is_typeddict(TD))
+        self.assertEqual(TD.__name__, "<inlined TypedDict>")
+        self.assertEqual(TD.__module__, __name__)
+        self.assertEqual(TD.__bases__, (dict,))
+        self.assertEqual(TD.__total__, True)
+        self.assertEqual(TD.__required_keys__, {"a", "b", "d"})
+        self.assertEqual(TD.__optional_keys__, {"c"})
+        self.assertEqual(TD.__readonly_keys__, {"d"})
+        self.assertEqual(TD.__mutable_keys__, {"a", "b", "c"})
+
+        inst = TD(a=1, b=2, d=3)
+        self.assertIs(type(inst), dict)
+        self.assertEqual(inst["a"], 1)
+
 
 class AnnotatedTests(BaseTestCase):
 
@@ -6629,7 +6661,7 @@ class AllTests(BaseTestCase):
             exclude |= {
                 'TypeAliasType'
             }
-        if not typing_extensions._PEP_728_IMPLEMENTED:
+        if not typing_extensions._PEP_728_OR_764_IMPLEMENTED:
             exclude |= {'TypedDict', 'is_typeddict'}
         for item in typing_extensions.__all__:
             if item not in exclude and hasattr(typing, item):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5074,6 +5074,10 @@ class TypedDictTests(BaseTestCase):
         with self.assertRaises(TypeError):
             TypedDict["not_a_dict"]
 
+    def test_inlined_empty(self):
+        TD = TypedDict[{}]
+        self.assertEqual(TD.__required_keys__, set())
+
     def test_inlined(self):
         TD = TypedDict[{
             "a": int,


### PR DESCRIPTION
Fixes https://github.com/python/typing_extensions/issues/572.

As discussed in the [PEP thread](https://discuss.python.org/t/78779), I've tried implementing inlined typed dictionaries as instances of a new `InlinedTypedDict` class, that would look like:

```python
class InlinedTypedDict:
    def __init__(self, fields):
        required_keys = set()
        optional_keys = set()
        readonly_keys = set()
        mutable_keys = set()

        for ann_key, ann_type in fields.items():
            qualifiers = set(_get_typeddict_qualifiers(ann_type))

            if NotRequired not in qualifiers:
                required_keys.add(ann_key)
            else:
                optional_keys.add(ann_key)

            if ReadOnly in qualifiers:
                readonly_keys.add(ann_key)
            else:
                mutable_keys.add(ann_key)

        assert required_keys.isdisjoint(optional_keys), (
            f"Required keys overlap with optional keys:"
            f" {required_keys=}, {optional_keys=}"
        )

        self.__required_keys__ = frozenset(required_keys)
        self.__optional_keys__ = frozenset(optional_keys)
        self.__readonly_keys__ = frozenset(readonly_keys)
        self.__mutable_keys__ = frozenset(mutable_keys)
        self.__total__ = True

    def __call__(self, *args, **kwargs):
        return dict(*args, **kwargs)
```

But I don't think it is worth the effort:
- We still need to set `__mro_entries__` on `InlinedTypedDict` to allow subclassing inlined TDs. To be compatible with the existing logic in `_TypedDictMeta.__new__`, we would most likely need to create an inner "real" TypedDict class matching the `InlinedTypedDict` instance.
- Although the logic `InlinedTypedDict.__init__()` is simpler as it is guaranteed to not have base classes, logic is still duplicated in two places.

Having `"<inlined TypedDict>"` as a `__name__` might be considered as a slightly ugly implementation detail, but considering the above it is worth the trade-off.