### PR TITLE
Implement support for PEP 764 (inline typed dictionaries)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 - Drop support for Python 3.8 (including PyPy-3.8). Patch by [Victorien Plot](https://github.com/Viicos).
+- Add support for inline typed dictionaries ([PEP 764](https://peps.python.org/pep-0764/)).
+  Patch by [Victorien Plot](https://github.com/Viicos).
 
 # Release 4.13.2 (April 10, 2025)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5066,6 +5066,41 @@ class TypedDictTests(BaseTestCase):
             class TD(TypedDict, closed=True, extra_items=range):
                 x: str
 
+    def test_inlined_too_many_arguments(self):
+        with self.assertRaises(TypeError):
+            TypedDict[{"a": int}, "extra"]
+
+    def test_inlined_not_a_dict(self):
+        with self.assertRaises(TypeError):
+            TypedDict["not_a_dict"]
+
+    def test_inlined_empty(self):
+        TD = TypedDict[{}]
+        self.assertEqual(TD.__required_keys__, set())
+
+    def test_inlined(self):
+        TD = TypedDict[{
+            "a": int,
+            "b": Required[int],
+            "c": NotRequired[int],
+            "d": ReadOnly[int],
+        }]
+        self.assertIsSubclass(TD, dict)
+        self.assertIsSubclass(TD, typing.MutableMapping)
+        self.assertNotIsSubclass(TD, collections.abc.Sequence)
+        self.assertTrue(is_typeddict(TD))
+        self.assertEqual(TD.__name__, "<inlined TypedDict>")
+        self.assertEqual(TD.__module__, __name__)
+        self.assertEqual(TD.__bases__, (dict,))
+        self.assertEqual(TD.__total__, True)
+        self.assertEqual(TD.__required_keys__, {"a", "b", "d"})
+        self.assertEqual(TD.__optional_keys__, {"c"})
+        self.assertEqual(TD.__readonly_keys__, {"d"})
+        self.assertEqual(TD.__mutable_keys__, {"a", "b", "c"})
+
+        inst = TD(a=1, b=2, d=3)
+        self.assertIs(type(inst), dict)
+        self.assertEqual(inst["a"], 1)
 
 class AnnotatedTests(BaseTestCase):
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5066,19 +5066,29 @@ class TypedDictTests(BaseTestCase):
             class TD(TypedDict, closed=True, extra_items=range):
                 x: str
 
-    def test_inlined_too_many_arguments(self):
+    def test_typed_dict_signature(self):
+        self.assertListEqual(
+            list(inspect.signature(TypedDict).parameters),
+            ['typename', 'fields', 'total', 'closed', 'extra_items', 'kwargs']
+        )
+
+    def test_inline_too_many_arguments(self):
         with self.assertRaises(TypeError):
             TypedDict[{"a": int}, "extra"]
 
-    def test_inlined_not_a_dict(self):
+    def test_inline_not_a_dict(self):
         with self.assertRaises(TypeError):
             TypedDict["not_a_dict"]
 
-    def test_inlined_empty(self):
+    def test_inline_empty(self):
         TD = TypedDict[{}]
         self.assertEqual(TD.__required_keys__, set())
 
-    def test_inlined(self):
+    def test_inline_argument_as_tuple(self):
+        TD = TypedDict[({},)]
+        self.assertEqual(TD.__required_keys__, set())
+
+    def test_inline(self):
         TD = TypedDict[{
             "a": int,
             "b": Required[int],

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5080,9 +5080,19 @@ class TypedDictTests(BaseTestCase):
         with self.assertRaises(TypeError):
             TypedDict["not_a_dict"]
 
+        # a tuple of elements isn't allowed, even if the first element is a dict:
+        with self.assertRaises(TypeError):
+            TypedDict[({"key": int},)]
+
     def test_inline_empty(self):
         TD = TypedDict[{}]
+        self.assertTrue(TD.__total__)
+        self.assertTrue(TD.__closed__)
+        self.assertEqual(TD.__extra_items__, NoExtraItems)
         self.assertEqual(TD.__required_keys__, set())
+        self.assertEqual(TD.__optional_keys__, set())
+        self.assertEqual(TD.__readonly_keys__, set())
+        self.assertEqual(TD.__mutable_keys__,  set())
 
     def test_inline(self):
         TD = TypedDict[{
@@ -5096,9 +5106,15 @@ class TypedDictTests(BaseTestCase):
         self.assertNotIsSubclass(TD, collections.abc.Sequence)
         self.assertTrue(is_typeddict(TD))
         self.assertEqual(TD.__name__, "<inline TypedDict>")
+        self.assertEqual(
+            TD.__annotations__,
+            {"a": int, "b": Required[int], "c": NotRequired[int], "d": ReadOnly[int]},
+        )
         self.assertEqual(TD.__module__, __name__)
         self.assertEqual(TD.__bases__, (dict,))
-        self.assertEqual(TD.__total__, True)
+        self.assertTrue(TD.__total__)
+        self.assertTrue(TD.__closed__)
+        self.assertEqual(TD.__extra_items__, NoExtraItems)
         self.assertEqual(TD.__required_keys__, {"a", "b", "d"})
         self.assertEqual(TD.__optional_keys__, {"c"})
         self.assertEqual(TD.__readonly_keys__, {"d"})

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5086,8 +5086,8 @@ class TypedDictTests(BaseTestCase):
 
     def test_inline_empty(self):
         TD = TypedDict[{}]
-        self.assertTrue(TD.__total__)
-        self.assertTrue(TD.__closed__)
+        self.assertIs(TD.__total__, True)
+        self.assertIs(TD.__closed__, True)
         self.assertEqual(TD.__extra_items__, NoExtraItems)
         self.assertEqual(TD.__required_keys__, set())
         self.assertEqual(TD.__optional_keys__, set())
@@ -5112,8 +5112,8 @@ class TypedDictTests(BaseTestCase):
         )
         self.assertEqual(TD.__module__, __name__)
         self.assertEqual(TD.__bases__, (dict,))
-        self.assertTrue(TD.__total__)
-        self.assertTrue(TD.__closed__)
+        self.assertIs(TD.__total__, True)
+        self.assertIs(TD.__closed__, True)
         self.assertEqual(TD.__extra_items__, NoExtraItems)
         self.assertEqual(TD.__required_keys__, {"a", "b", "d"})
         self.assertEqual(TD.__optional_keys__, {"c"})

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5084,10 +5084,6 @@ class TypedDictTests(BaseTestCase):
         TD = TypedDict[{}]
         self.assertEqual(TD.__required_keys__, set())
 
-    def test_inline_argument_as_tuple(self):
-        TD = TypedDict[({},)]
-        self.assertEqual(TD.__required_keys__, set())
-
     def test_inline(self):
         TD = TypedDict[{
             "a": int,

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5089,7 +5089,7 @@ class TypedDictTests(BaseTestCase):
         self.assertIsSubclass(TD, typing.MutableMapping)
         self.assertNotIsSubclass(TD, collections.abc.Sequence)
         self.assertTrue(is_typeddict(TD))
-        self.assertEqual(TD.__name__, "<inlined TypedDict>")
+        self.assertEqual(TD.__name__, "<inline TypedDict>")
         self.assertEqual(TD.__module__, __name__)
         self.assertEqual(TD.__bases__, (dict,))
         self.assertEqual(TD.__total__, True)

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1216,7 +1216,7 @@ else:
             args,
             typing_is_inline=True,
             total=True,
-            closed=None,
+            closed=True,
             extra_items=NoExtraItems,
         )
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1206,16 +1206,14 @@ else:
         See PEP 655 for more details on Required and NotRequired.
         """
         # This runs when creating inline TypedDicts:
-        if not isinstance(args, tuple):
-            args = (args,)
-        if len(args) != 1 or not isinstance(args[0], dict):
+        if not isinstance(args, dict):
             raise TypeError(
                 "TypedDict[...] should be used with a single dict argument"
             )
 
         return _create_typeddict(
             "<inline TypedDict>",
-            args[0],
+            args,
             typing_is_inline=True,
             total=True,
             closed=None,

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -846,13 +846,6 @@ else:
             pass
 
 
-def _ensure_subclassable(mro_entries):
-    def inner(obj):
-        obj.__mro_entries__ = mro_entries
-        return obj
-    return inner
-
-
 _NEEDS_SINGLETONMETA = (
     not hasattr(typing, "NoDefault") or not hasattr(typing, "NoExtraItems")
 )
@@ -1161,7 +1154,9 @@ else:
                 **kwargs,
             )
 
-    @_ensure_subclassable(lambda bases: (_TypedDict,))
+        def __mro_entries__(self, bases):
+            return (_TypedDict,)
+
     @_TypedDictSpecialForm
     def TypedDict(self, args):
         """A simple typed namespace. At runtime it is equivalent to a plain dict.
@@ -3239,7 +3234,6 @@ else:
         assert NamedTuple in bases
         return (_NamedTuple,)
 
-    @_ensure_subclassable(_namedtuple_mro_entries)
     def NamedTuple(typename, fields=_marker, /, **kwargs):
         """Typed version of namedtuple.
 
@@ -3304,6 +3298,8 @@ else:
         nt = _make_nmtuple(typename, fields, module=_caller())
         nt.__orig_bases__ = (NamedTuple,)
         return nt
+
+    NamedTuple.__mro_entries__ = _namedtuple_mro_entries
 
 
 if hasattr(collections.abc, "Buffer"):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1078,17 +1078,73 @@ else:
 
     _TypedDict = type.__new__(_TypedDictMeta, 'TypedDict', (), {})
 
+
+    class _TypedDictSpecialForm(_ExtensionsSpecialForm, _root=True):
+        def __call__(
+            self,
+            typename,
+            fields=_marker,
+            /,
+            *,
+            total=True,
+            closed=None,
+            extra_items=NoExtraItems,
+            __typing_is_inline__=False,
+            **kwargs
+        ):
+            if fields is _marker or fields is None:
+                if fields is _marker:
+                    deprecated_thing = (
+                        "Failing to pass a value for the 'fields' parameter"
+                    )
+                else:
+                    deprecated_thing = "Passing `None` as the 'fields' parameter"
+
+                example = f"`{typename} = TypedDict({typename!r}, {{}})`"
+                deprecation_msg = (
+                    f"{deprecated_thing} is deprecated and will be disallowed in "
+                    "Python 3.15. To create a TypedDict class with 0 fields "
+                    "using the functional syntax, pass an empty dictionary, e.g. "
+                ) + example + "."
+                warnings.warn(deprecation_msg, DeprecationWarning, stacklevel=2)
+                # Support a field called "closed"
+                if closed is not False and closed is not True and closed is not None:
+                    kwargs["closed"] = closed
+                    closed = None
+                # Or "extra_items"
+                if extra_items is not NoExtraItems:
+                    kwargs["extra_items"] = extra_items
+                    extra_items = NoExtraItems
+                fields = kwargs
+            elif kwargs:
+                raise TypeError("TypedDict takes either a dict or keyword arguments,"
+                                " but not both")
+            if kwargs:
+                if sys.version_info >= (3, 13):
+                    raise TypeError("TypedDict takes no keyword arguments")
+                warnings.warn(
+                    "The kwargs-based syntax for TypedDict definitions is deprecated "
+                    "in Python 3.11, will be removed in Python 3.13, and may not be "
+                    "understood by third-party type checkers.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
+            ns = {'__annotations__': dict(fields)}
+            module = _caller(depth=5 if __typing_is_inline__ else 2)
+            if module is not None:
+                # Setting correct module is necessary to make typed dict classes
+                # pickleable.
+                ns['__module__'] = module
+
+            td = _TypedDictMeta(typename, (), ns, total=total, closed=closed,
+                                extra_items=extra_items)
+            td.__orig_bases__ = (TypedDict,)
+            return td
+
     @_ensure_subclassable(lambda bases: (_TypedDict,))
-    def TypedDict(
-        typename,
-        fields=_marker,
-        /,
-        *,
-        total=True,
-        closed=None,
-        extra_items=NoExtraItems,
-        **kwargs
-    ):
+    @_TypedDictSpecialForm
+    def TypedDict(self, args):
         """A simple typed namespace. At runtime it is equivalent to a plain dict.
 
         TypedDict creates a dictionary type such that a type checker will expect all
@@ -1135,52 +1191,16 @@ else:
 
         See PEP 655 for more details on Required and NotRequired.
         """
-        if fields is _marker or fields is None:
-            if fields is _marker:
-                deprecated_thing = "Failing to pass a value for the 'fields' parameter"
-            else:
-                deprecated_thing = "Passing `None` as the 'fields' parameter"
-
-            example = f"`{typename} = TypedDict({typename!r}, {{}})`"
-            deprecation_msg = (
-                f"{deprecated_thing} is deprecated and will be disallowed in "
-                "Python 3.15. To create a TypedDict class with 0 fields "
-                "using the functional syntax, pass an empty dictionary, e.g. "
-            ) + example + "."
-            warnings.warn(deprecation_msg, DeprecationWarning, stacklevel=2)
-            # Support a field called "closed"
-            if closed is not False and closed is not True and closed is not None:
-                kwargs["closed"] = closed
-                closed = None
-            # Or "extra_items"
-            if extra_items is not NoExtraItems:
-                kwargs["extra_items"] = extra_items
-                extra_items = NoExtraItems
-            fields = kwargs
-        elif kwargs:
-            raise TypeError("TypedDict takes either a dict or keyword arguments,"
-                            " but not both")
-        if kwargs:
-            if sys.version_info >= (3, 13):
-                raise TypeError("TypedDict takes no keyword arguments")
-            warnings.warn(
-                "The kwargs-based syntax for TypedDict definitions is deprecated "
-                "in Python 3.11, will be removed in Python 3.13, and may not be "
-                "understood by third-party type checkers.",
-                DeprecationWarning,
-                stacklevel=2,
+        # This runs when creating inline TypedDicts:
+        if not isinstance(args, tuple):
+            args = (args,)
+        if len(args) != 1 or not isinstance(args[0], dict):
+            raise TypeError(
+                "TypedDict[...] should be used with a single dict argument"
             )
 
-        ns = {'__annotations__': dict(fields)}
-        module = _caller()
-        if module is not None:
-            # Setting correct module is necessary to make typed dict classes pickleable.
-            ns['__module__'] = module
-
-        td = _TypedDictMeta(typename, (), ns, total=total, closed=closed,
-                            extra_items=extra_items)
-        td.__orig_bases__ = (TypedDict,)
-        return td
+        # Delegate to _TypedDictSpecialForm.__call__:
+        return self("<inlined TypedDict>", args[0], __typing_is_inline__=True)
 
     _TYPEDDICT_TYPES = (typing._TypedDictMeta, _TypedDictMeta)
 


### PR DESCRIPTION
As suggested in https://github.com/python/typing_extensions/pull/579#discussion_r2030276351.

Only downside is that the parent frame to be fetched is different depending on which syntax (functional or inline) is used. This means we need an extra argument (called `__typing_is_inline__` in this PR) to differentiate the two. This isn't required in https://github.com/python/typing_extensions/pull/579.

There are also some issues on 3.8:

- `_ensure_subclassable()` assumes it applies on functions on pypy for Python 3.8:

    https://github.com/python/typing_extensions/blob/281d7b0ca6edad384e641d1066b759c280602919/src/typing_extensions.py#L866-L878

    which isn't the case here (the decorator is applied on the `_TypedDictSpecialForm` instance).

- `typing._SpecialForm` is implemented quite differently on 3.8, so we would need to redefine `__getitem__()` on `_TypedDictSpecialForm`.

~~Maybe support for 3.8 should be dropped first.~~ done in https://github.com/python/typing_extensions/pull/585.
