### PR TITLE
fix: update pyproject.toml with OSI approved license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
+    "License :: OSI Approved :: Python Software Foundation License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
This will add the OSI approved license to the package

https://github.com/pypa/trove-classifiers/blob/7e3e9e0c1135492b5a630d60d8abac15fb1d81ee/src/trove_classifiers/__init__.py#L336C5-L336C68