### PR TITLE
Fix tests on Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
           cd src
           python --version  # just to make sure we're running the right one
           python -m unittest test_typing_extensions.py
-        continue-on-error: ${{ endsWith(matrix.python-version, '-dev') }}
 
       - name: Test CPython typing test suite
         # Test suite fails on PyPy even without typing_extensions
@@ -80,7 +79,6 @@ jobs:
           # Run the typing test suite from CPython with typing_extensions installed,
           # because we monkeypatch typing under some circumstances.
           python -c 'import typing_extensions; import test.__main__' test_typing -v
-        continue-on-error: ${{ endsWith(matrix.python-version, '-dev') }}
 
   linting:
     name: Lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ New features:
   Patch by [Victorien Plot](https://github.com/Viicos).
 - Add `typing_extensions.Reader` and `typing_extensions.Writer`. Patch by
   Sebastian Rittau.
+- Fix tests for Python 3.14. Patch by Jelle Zijlstra.
 
 # Release 4.13.2 (April 10, 2025)
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5176,7 +5176,7 @@ class TypedDictTests(BaseTestCase):
     def test_delayed_type_check(self):
         # _type_check is also applied later
         class Z(TypedDict):
-            a: undefined
+            a: undefined  # noqa: F821
 
         with self.assertRaises(NameError):
             Z.__annotations__
@@ -5185,15 +5185,15 @@ class TypedDictTests(BaseTestCase):
         with self.assertRaisesRegex(TypeError, "Plain typing.Final is not valid as type argument"):
             Z.__annotations__
 
-        undefined = None
+        undefined = None  # noqa: F841
         self.assertEqual(Z.__annotations__, {'a': type(None)})
 
     @skipUnless(TYPING_3_14_0, "Only supported on 3.14")
     def test_deferred_evaluation(self):
         class A(TypedDict):
-            x: NotRequired[undefined]
-            y: ReadOnly[undefined]
-            z: Required[undefined]
+            x: NotRequired[undefined]  # noqa: F821
+            y: ReadOnly[undefined]  # noqa: F821
+            z: Required[undefined]  # noqa: F821
 
         self.assertEqual(A.__required_keys__, frozenset({'y', 'z'}))
         self.assertEqual(A.__optional_keys__, frozenset({'x'}))

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5154,9 +5154,9 @@ class TypedDictTests(BaseTestCase):
 
     def test_annotations(self):
         # _type_check is applied
-        with self.assertRaisesRegex(TypeError, "Plain typing.Final is not valid as type argument"):
+        with self.assertRaisesRegex(TypeError, "Plain typing.Optional is not valid as type argument"):
             class X(TypedDict):
-                a: Final
+                a: Optional
 
         # _type_convert is applied
         class Y(TypedDict):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -103,6 +103,11 @@ from typing_extensions import (
     runtime_checkable,
 )
 
+if sys.version_info >= (3, 14):
+    from test.support import EqualToForwardRef
+else:
+    EqualToForwardRef = typing.ForwardRef
+
 NoneType = type(None)
 T = TypeVar("T")
 KT = TypeVar("KT")
@@ -5164,7 +5169,6 @@ class TypedDictTests(BaseTestCase):
             b: "int"
         if sys.version_info >= (3, 14):
             import annotationlib
-            from test.support import EqualToForwardRef
 
             fwdref = EqualToForwardRef('int', module=__name__)
             self.assertEqual(Y.__annotations__, {'a': type(None), 'b': fwdref})
@@ -6022,7 +6026,7 @@ class ConcatenateTests(BaseTestCase):
         U2 = Unpack[Ts]
         self.assertEqual(C2[U1], (str, int, str))
         self.assertEqual(C2[U2], (str, Unpack[Ts]))
-        self.assertEqual(C2["U2"], (str, typing.ForwardRef("U2")))
+        self.assertEqual(C2["U2"], (str, EqualToForwardRef("U2")))
 
         if (3, 12, 0) <= sys.version_info < (3, 12, 4):
             with self.assertRaises(AssertionError):
@@ -7309,8 +7313,8 @@ class TypeVarTests(BaseTestCase):
             self.assertEqual(X | "x", Union[X, "x"])
             self.assertEqual("x" | X, Union["x", X])
             # make sure the order is correct
-            self.assertEqual(get_args(X | "x"), (X, typing.ForwardRef("x")))
-            self.assertEqual(get_args("x" | X), (typing.ForwardRef("x"), X))
+            self.assertEqual(get_args(X | "x"), (X, EqualToForwardRef("x")))
+            self.assertEqual(get_args("x" | X), (EqualToForwardRef("x"), X))
 
     def test_union_constrained(self):
         A = TypeVar('A', str, bytes)
@@ -8878,7 +8882,7 @@ class TestEvaluateForwardRefs(BaseTestCase):
             type_params=None,
             format=Format.FORWARDREF,
         )
-        self.assertEqual(evaluated_ref, typing.ForwardRef("doesnotexist2"))
+        self.assertEqual(evaluated_ref, EqualToForwardRef("doesnotexist2"))
 
     def test_evaluate_with_type_params(self):
         # Use a T name that is not in globals

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1025,10 +1025,14 @@ else:
             if "__annotations__" in ns:
                 own_annotations = ns["__annotations__"]
             elif sys.version_info >= (3, 14):
-                own_annotate = annotationlib.get_annotate_from_class_namespace(ns)
+                if hasattr(annotationlib, "get_annotate_from_class_namespace"):
+                    own_annotate = annotationlib.get_annotate_from_class_namespace(ns)
+                else:
+                    # 3.14.0a7 and earlier
+                    own_annotate = ns.get("__annotate__")
                 if own_annotate is not None:
                     own_annotations = annotationlib.call_annotate_function(
-                        own_annotate, annotationlib.Format.FORWARDREF, owner=tp_dict
+                        own_annotate, Format.FORWARDREF, owner=tp_dict
                     )
                 else:
                     own_annotations = {}
@@ -1114,14 +1118,14 @@ else:
                     if own_annotate is not None:
                         own = annotationlib.call_annotate_function(
                             own_annotate, format, owner=tp_dict)
-                        if format != annotationlib.Format.STRING:
+                        if format != Format.STRING:
                             own = {
                                 n: typing._type_check(tp, msg, module=tp_dict.__module__)
                                 for n, tp in own.items()
                             }
-                    elif format == annotationlib.Format.STRING:
+                    elif format == Format.STRING:
                         own = annotationlib.annotations_to_string(own_annotations)
-                    elif format in (annotationlib.Format.FORWARDREF, annotationlib.Format.VALUE):
+                    elif format in (Format.FORWARDREF, Format.VALUE):
                         own = own_checked_annotations
                     else:
                         raise NotImplementedError(format)


### PR DESCRIPTION
* Support deferred evaluation in `typing_extensions.TypedDict`
* Account for ForwardRef caching being removed (python/cpython#129465). `test_nested_strings` in our test suite was passing accidentally due to ForwardRef caching.