### PR TITLE
Add support for sentinels (PEP 661)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ New features:
   Patch by [Victorien Plot](https://github.com/Viicos).
 - Add `typing_extensions.Reader` and `typing_extensions.Writer`. Patch by
   Sebastian Rittau.
-- Add support for sentinels ([PEP 661](https://peps.python.org/pep-0661/)).
+- Add support for sentinels ([PEP 661](https://peps.python.org/pep-0661/)). Patch by
+  [Victorien Plot](https://github.com/Viicos).
 
 # Release 4.13.2 (April 10, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ New features:
 - Add `typing_extensions.Reader` and `typing_extensions.Writer`. Patch by
   Sebastian Rittau.
 - Fix tests for Python 3.14. Patch by Jelle Zijlstra.
+- Add support for sentinels ([PEP 661](https://peps.python.org/pep-0661/)).
 
 # Release 4.13.2 (April 10, 2025)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1017,6 +1017,34 @@ Capsule objects
    .. versionadded:: 4.12.0
 
 
+Sentinel objects
+~~~~~~~~~~~~~~~~
+
+.. class:: Sentinel(name, repr=None)
+
+   A type used to define sentinel values. The *name* argument should be the
+   name of the variable to which the return value shall be assigned.
+
+   If *repr* is provided, it will be used for the :meth:`~object.__repr__`
+   of the sentinel object. If not provided, ``"<name>"`` will be used.
+
+   Example::
+
+      >>> from typing_extensions import Sentinel, assert_type
+      >>> MISSING = Sentinel('MISSING')
+      >>> def func(arg: int | MISSING = MISSING) -> None:
+      ...     if arg is MISSING:
+      ...         assert_type(arg, MISSING)
+      ...     else:
+      ...         assert_type(arg, int)
+      ...
+      >>> func(MISSING)
+
+   .. versionadded:: 4.14.0
+
+      See :pep:`661`
+
+
 Pure aliases
 ~~~~~~~~~~~~
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -9096,11 +9096,6 @@ class TestSentinels(BaseTestCase):
         self.assertEqual(sentinel_no_repr._name, 'sentinel_no_repr')
         self.assertEqual(repr(sentinel_no_repr), '<sentinel_no_repr>')
 
-        sentinel_no_repr_dots = Sentinel('Test.sentinel_no_repr')
-
-        self.assertEqual(sentinel_no_repr_dots._name, 'Test.sentinel_no_repr')
-        self.assertEqual(repr(sentinel_no_repr), '<sentinel_no_repr>')
-
     def test_sentinel_explicit_repr(self):
         sentinel_explicit_repr = Sentinel('sentinel_explicit_repr', repr='explicit_repr')
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -66,6 +66,7 @@ from typing_extensions import (
     ReadOnly,
     Required,
     Self,
+    Sentinel,
     Set,
     Tuple,
     Type,
@@ -9086,6 +9087,42 @@ class TestEvaluateForwardRefs(BaseTestCase):
         else:
             self.assertIs(evaluate_forward_ref(typing.ForwardRef("Final", is_argument=False), globals=vars(typing)), Final)
             self.assertIs(evaluate_forward_ref(typing.ForwardRef("ClassVar", is_argument=False), globals=vars(typing)), ClassVar)
+
+
+class TestSentinels(BaseTestCase):
+    def test_sentinel_no_repr(self):
+        sentinel_no_repr = Sentinel('sentinel_no_repr')
+
+        self.assertEqual(sentinel_no_repr._name, 'sentinel_no_repr')
+        self.assertEqual(repr(sentinel_no_repr), '<sentinel_no_repr>')
+
+        sentinel_no_repr_dots = Sentinel('Test.sentinel_no_repr')
+
+        self.assertEqual(sentinel_no_repr_dots._name, 'Test.sentinel_no_repr')
+        self.assertEqual(repr(sentinel_no_repr), '<sentinel_no_repr>')
+
+    def test_sentinel_explicit_repr(self):
+        sentinel_explicit_repr = Sentinel('sentinel_explicit_repr', repr='explicit_repr')
+
+        self.assertEqual(repr(sentinel_explicit_repr), 'explicit_repr')
+
+    @skipIf(sys.version_info < (3, 10), reason='New unions not available in 3.9')
+    def test_sentinel_type_expression_union(self):
+        sentinel = Sentinel('sentinel')
+
+        def func1(a: int | sentinel = sentinel): pass
+        def func2(a: sentinel | int = sentinel): pass
+
+        self.assertEqual(func1.__annotations__['a'], Union[int, sentinel])
+        self.assertEqual(func2.__annotations__['a'], Union[sentinel, int])
+
+    def test_sentinel_not_callable(self):
+        sentinel = Sentinel('sentinel')
+        with self.assertRaisesRegex(
+            TypeError,
+            "'Sentinel' object is not callable"
+        ):
+            sentinel()
 
 
 if __name__ == '__main__':

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -9124,6 +9124,14 @@ class TestSentinels(BaseTestCase):
         ):
             sentinel()
 
+    def test_sentinel_not_picklable(self):
+        sentinel = Sentinel('sentinel')
+        with self.assertRaisesRegex(
+            TypeError,
+            "Cannot pickle 'Sentinel' object"
+        ):
+            pickle.dumps(sentinel)
+
 
 if __name__ == '__main__':
     main()

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -4238,10 +4238,10 @@ class Sentinel:
             raise TypeError(f"{type(self).__name__!r} object is not callable")
 
     def __or__(self, other):
-        return Union[self, other]
+        return typing.Union[self, other]
 
     def __ror__(self, other):
-        return Union[other, self]
+        return typing.Union[other, self]
 
     def __getstate__(self):
         raise TypeError(f"Cannot pickle {type(self).__name__!r} object")

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -4238,7 +4238,7 @@ class Sentinel:
     def __init__(
         self,
         name: str,
-        repr: str | None = None,
+        repr: typing.Optional[str] = None,
     ):
         self._name = name
         self._repr = repr if repr is not None else f'<{name.split(".")[-1]}>'

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1,4 +1,3 @@
-# pyright: ignore
 import abc
 import builtins
 import collections
@@ -4227,12 +4226,10 @@ else:
 class Sentinel:
     """Create a unique sentinel object.
 
-    *name* should be the fully-qualified name of the variable to which the
-    return value shall be assigned.
+    *name* should be the name of the variable to which the return value shall be assigned.
 
     *repr*, if supplied, will be used for the repr of the sentinel object.
-    If not provided, "<name>" will be used (with any leading class names
-    removed).
+    If not provided, "<name>" will be used.
     """
 
     def __init__(
@@ -4241,7 +4238,7 @@ class Sentinel:
         repr: typing.Optional[str] = None,
     ):
         self._name = name
-        self._repr = repr if repr is not None else f'<{name.split(".")[-1]}>'
+        self._repr = repr if repr is not None else f'<{name}>'
 
     def __repr__(self):
         return self._repr

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -4246,15 +4246,6 @@ class Sentinel:
     def __repr__(self):
         return self._repr
 
-    def __reduce__(self):
-        return (
-            type(self),
-            (
-                self._name,
-                self._repr,
-            )
-        )
-
     if sys.version_info < (3, 11):
         # The presence of this method convinces typing._type_check
         # that Sentinels are types.

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1,3 +1,4 @@
+# pyright: ignore
 import abc
 import builtins
 import collections
@@ -89,6 +90,7 @@ __all__ = [
     'overload',
     'override',
     'Protocol',
+    'Sentinel',
     'reveal_type',
     'runtime',
     'runtime_checkable',
@@ -4220,6 +4222,50 @@ else:
             format=format,
             owner=owner,
         )
+
+
+class Sentinel:
+    """Create a unique sentinel object.
+
+    *name* should be the fully-qualified name of the variable to which the
+    return value shall be assigned.
+
+    *repr*, if supplied, will be used for the repr of the sentinel object.
+    If not provided, "<name>" will be used (with any leading class names
+    removed).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        repr: str | None = None,
+    ):
+        self._name = name
+        self._repr = repr if repr is not None else f'<{name.split(".")[-1]}>'
+
+    def __repr__(self):
+        return self._repr
+
+    def __reduce__(self):
+        return (
+            type(self),
+            (
+                self._name,
+                self._repr,
+            )
+        )
+
+    if sys.version_info < (3, 11):
+        # The presence of this method convinces typing._type_check
+        # that Sentinels are types.
+        def __call__(self, *args, **kwargs):
+            raise TypeError(f"{type(self).__name__!r} object is not callable")
+
+    def __or__(self, other):
+        return Union[self, other]
+
+    def __ror__(self, other):
+        return Union[other, self]
 
 
 # Aliases for items that are in typing in all supported versions.

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -4258,6 +4258,9 @@ class Sentinel:
     def __ror__(self, other):
         return Union[other, self]
 
+    def __getstate__(self):
+        raise TypeError(f"Cannot pickle {type(self).__name__!r} object")
+
 
 # Aliases for items that are in typing in all supported versions.
 # Explicitly assign these (rather than using `from typing import *` at the top),


### PR DESCRIPTION
Fixes https://github.com/python/typing_extensions/issues/591.

Regarding the pickling behavior, no matter if the sentinel is defined at the module level or in a nested scope, this seems tricky to handle. Ideally, I'd like to have the following working:

```python
sentinel = Sentinel('sentinel')

class A:
    def __init__(self):
        self.s = sentinel

a = A()
a.s is sentinel  # True

import pickle

a_r = pickle.loads(pickle.dumps(a))

a_r.s is sentinel  # False
```

Considering unplicking data can be done across interpreter runs, this isn't really achievable, but still will be surprising.