### PR TITLE
Add development versioning scheming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,10 @@ Starting with version 4.0.0, `typing_extensions` uses
 [Semantic Versioning](https://semver.org/). See the documentation
 for more detail.
 
+## Development versions
+After meaningful updates, but without concrete plans for a release, the version can pre increased once in [pyproject.toml](/pyproject.toml) file and appended with a `.dev` suffix, e.g. `4.0.1.dev`.
+Further development versions adjust their suffix in following increasing way `.dev1`, `.dev2`, ...
+
 # Type stubs
 
 A stub file for `typing_extensions` is maintained
@@ -54,7 +58,7 @@ may have installed.
 # Workflow for PyPI releases
 
 - Make sure you follow the versioning policy in the documentation
-  (e.g., release candidates before any feature release)
+  (e.g., release candidates before any feature release, do not release development versions)
 
 - Ensure that GitHub Actions reports no errors.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,8 @@ Starting with version 4.0.0, `typing_extensions` uses
 for more detail.
 
 ## Development versions
-After meaningful updates, but without concrete plans for a release, the version can pre increased once in [pyproject.toml](/pyproject.toml) file and appended with a `.dev` suffix, e.g. `4.0.1.dev`.
-Further development versions adjust their suffix in following increasing way `.dev1`, `.dev2`, ...
+After a release the version is increased once in the [pyproject.toml](/pyproject.toml) file and appended with a `.dev` suffix, e.g. `4.0.1.dev`.
+Further subsequent updates, i.e. to `.dev2`, are not planned between releases.
 
 # Type stubs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,9 @@ Starting with version 4.0.0, `typing_extensions` uses
 [Semantic Versioning](https://semver.org/). See the documentation
 for more detail.
 
-## Development versions
-After a release the version is increased once in the [pyproject.toml](/pyproject.toml) file and appended with a `.dev` suffix, e.g. `4.0.1.dev`.
+## Development version
+After a release the version is increased once in [pyproject.toml](/pyproject.toml) and
+appended with a `.dev` suffix, e.g. `4.0.1.dev`.
 Further subsequent updates, i.e. to `.dev2`, are not planned between releases.
 
 # Type stubs
@@ -72,3 +73,6 @@ may have installed.
 
 - Release automation will finish the release. You'll have to manually
   approve the last step before upload.
+
+- After the release has been published on PyPI the version of the repositiory
+  is upgraded to the next [development versions](#development-version).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ for more detail.
 ## Development version
 After a release the version is increased once in [pyproject.toml](/pyproject.toml) and
 appended with a `.dev` suffix, e.g. `4.0.1.dev`.
-Further subsequent updates, i.e. to `.dev2`, are not planned between releases.
+Further subsequent updates are not planned between releases.
 
 # Type stubs
 
@@ -74,5 +74,4 @@ may have installed.
 - Release automation will finish the release. You'll have to manually
   approve the last step before upload.
 
-- After the release has been published on PyPI the version of the repositiory
-  is upgraded to the next [development versions](#development-version).
+- After the release has been published on PyPI upgrade the version in number in [pyproject.toml](/pyproject.toml) to a `dev` version of the next planned release. For example, change 4.1.1 to 4.X.X.dev, see also [Development versions](#development-version). # TODO decide on major vs. minor increase.


### PR DESCRIPTION
In relation to #528 I've written a proposal on how and vaguely when to add development versions.

I've oriented myself on the [packaging](https://packaging.python.org/en/latest/discussions/versioning/#valid-version-numbers) versioning, and decided against the hyphen `-` suffix for pre-releases.

Further input and ideas are welcome.