### PR TITLE
Remove PEP-604 methods from `Sentinel` on Python <3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+- Remove `__or__` and `__ror__` methods from `typing_extensions.Sentinel`
+  on Python versions <3.10. PEP 604 was introduced in Python 3.10, and
+  `typing_extensions` does not generally attempt to backport PEP-604 methods
+  to prior versions.
+
 # Release 4.14.0rc1 (May 24, 2025)
 
 - Drop support for Python 3.8 (including PyPy-3.8). Patch by [Victorien Plot](https://github.com/Viicos).

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -4247,7 +4247,7 @@ class Sentinel:
     if sys.version_info >= (3, 10):
         def __or__(self, other):
             return typing.Union[self, other]
-    
+
         def __ror__(self, other):
             return typing.Union[other, self]
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -4244,11 +4244,12 @@ class Sentinel:
         def __call__(self, *args, **kwargs):
             raise TypeError(f"{type(self).__name__!r} object is not callable")
 
-    def __or__(self, other):
-        return typing.Union[self, other]
-
-    def __ror__(self, other):
-        return typing.Union[other, self]
+    if sys.version_info >= (3, 10):
+        def __or__(self, other):
+            return typing.Union[self, other]
+    
+        def __ror__(self, other):
+            return typing.Union[other, self]
 
     def __getstate__(self):
         raise TypeError(f"Cannot pickle {type(self).__name__!r} object")


### PR DESCRIPTION
We don't generally try to "backport PEP 604" on Python <3.10; this is more consistent with our features