### PR TITLE
Backport evaluate_forward_ref() changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   on Python versions <3.10. PEP 604 was introduced in Python 3.10, and
   `typing_extensions` does not generally attempt to backport PEP-604 methods
   to prior versions.
+- Further update `typing_extensions.evaluate_forward_ref` with changes in Python 3.14.
 
 # Release 4.14.0rc1 (May 24, 2025)
 


### PR DESCRIPTION
Refer to python/cpython#133961

I copied the tests from Python 3.14. Two don't pass but could probably be
made to pass by backporting more of annotationlib, but that's more than
I think we should do now.

Fixes #608
