### PR TITLE
Do not use slots for `_TypedDictSpecialForm`

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5290,6 +5290,8 @@ class TypedDictTests(BaseTestCase):
              'z': 'Required[undefined]'},
         )
 
+    def test_dunder_dict(self):
+        self.assertIsInstance(TypedDict.__dict__, dict)
 
 class AnnotatedTests(BaseTestCase):
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1272,8 +1272,6 @@ else:
         return td
 
     class _TypedDictSpecialForm(_SpecialForm, _root=True):
-        __slots__ = ('_name', '__doc__', '_getitem')
-
         def __call__(
             self,
             typename,


### PR DESCRIPTION
Fixes https://github.com/python/typing_extensions/issues/615.