### PR TITLE
Support for pickling sentinel objects as singletons

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1076,9 +1076,6 @@ Sentinel objects
    A type used to define sentinel values. The *name* argument should be the
    name of the variable to which the return value shall be assigned.
 
-   A sentinel is bound to the module it is created within,
-   sentinels are not equal to similar named sentinels from other modules.
-
    Assigning attributes to a sentinel including `__weakref__` is forbidden.
 
    Example::
@@ -1093,16 +1090,18 @@ Sentinel objects
       ...
       >>> func(MISSING)
 
-   Sentinels defined inside a class scope should use a :term:`qualified name`.
-
-   Example::
-
-      >>> class MyClass:
-      ...     MISSING = sentinel('MyClass.MISSING')
-
    .. versionadded:: 4.14.0
 
       See :pep:`661`
+
+   .. versionchanged:: 4.16.0
+
+      Now supports pickle and will be reduced as a singleton.
+      Renamed from `Sentinel` to `sentinel`, `Sentinel` is deprecated.
+      Automatic `repr` string no longer has angle brackets.
+      `repr` parameter was deprecated.
+      `name` as a keyword is deprecated.
+      Subclasssing and attribute assignment are deprecated.
 
 
 Pure aliases

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1076,7 +1076,7 @@ Sentinel objects
    A type used to define sentinel values. The *name* argument should be the
    name of the variable to which the return value shall be assigned.
 
-   Assigning attributes to a sentinel including `__weakref__` is forbidden.
+   Assigning attributes to a sentinel is deprecated.
 
    Example::
 
@@ -1096,12 +1096,15 @@ Sentinel objects
 
    .. versionchanged:: 4.16.0
 
+      The implementation of this class has been updated to conform to
+      the accepted version of :pep:`661`.
+
       Now supports pickle and will be reduced as a singleton.
       Renamed from `Sentinel` to `sentinel`, `Sentinel` is deprecated.
       Automatic `repr` string no longer has angle brackets.
       `repr` parameter was deprecated.
       `name` as a keyword is deprecated.
-      Subclasssing and attribute assignment are deprecated.
+      Subclassing and attribute assignment are deprecated.
 
 
 Pure aliases

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1071,16 +1071,15 @@ Capsule objects
 Sentinel objects
 ~~~~~~~~~~~~~~~~
 
-.. class:: sentinel(name, /, *, repr=None)
+.. class:: sentinel(name, /)
 
    A type used to define sentinel values. The *name* argument should be the
    name of the variable to which the return value shall be assigned.
 
-   If *repr* is provided, it will be used for the :meth:`~object.__repr__`
-   of the sentinel object. If not provided, ``"<name>"`` will be used.
-
    A sentinel is bound to the module it is created within,
    sentinels are not equal to similar named sentinels from other modules.
+
+   Assigning attributes to a sentinel including `__weakref__` is forbidden.
 
    Example::
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1071,7 +1071,7 @@ Capsule objects
 Sentinel objects
 ~~~~~~~~~~~~~~~~
 
-.. class:: Sentinel(name, module_name=None, *, repr=None)
+.. class:: Sentinel(name, *, module_name=None, repr=None)
 
    A type used to define sentinel values. The *name* argument should be the
    name of the variable to which the return value shall be assigned.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1071,10 +1071,13 @@ Capsule objects
 Sentinel objects
 ~~~~~~~~~~~~~~~~
 
-.. class:: Sentinel(name, repr=None)
+.. class:: Sentinel(name, module_name=None, *, repr=None)
 
    A type used to define sentinel values. The *name* argument should be the
    name of the variable to which the return value shall be assigned.
+
+   *module_name* is the module where the sentinel is defined.
+   Defaults to the current modules ``__name__``.
 
    If *repr* is provided, it will be used for the :meth:`~object.__repr__`
    of the sentinel object. If not provided, ``"<name>"`` will be used.
@@ -1090,6 +1093,13 @@ Sentinel objects
       ...         assert_type(arg, int)
       ...
       >>> func(MISSING)
+
+   Sentinels defined inside a class scope should use a :term:`qualified name`.
+
+   Example::
+
+      >>> class MyClass:
+      ...     MISSING = Sentinel('MyClass.MISSING')
 
    .. versionadded:: 4.14.0
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1071,21 +1071,21 @@ Capsule objects
 Sentinel objects
 ~~~~~~~~~~~~~~~~
 
-.. class:: Sentinel(name, *, module_name=None, repr=None)
+.. class:: sentinel(name, /, *, repr=None)
 
    A type used to define sentinel values. The *name* argument should be the
    name of the variable to which the return value shall be assigned.
 
-   *module_name* is the module where the sentinel is defined.
-   Defaults to the current modules ``__name__``.
-
    If *repr* is provided, it will be used for the :meth:`~object.__repr__`
    of the sentinel object. If not provided, ``"<name>"`` will be used.
 
+   A sentinel is bound to the module it is created within,
+   sentinels are not equal to similar named sentinels from other modules.
+
    Example::
 
-      >>> from typing_extensions import Sentinel, assert_type
-      >>> MISSING = Sentinel('MISSING')
+      >>> from typing_extensions import sentinel, assert_type
+      >>> MISSING = sentinel('MISSING')
       >>> def func(arg: int | MISSING = MISSING) -> None:
       ...     if arg is MISSING:
       ...         assert_type(arg, MISSING)
@@ -1099,7 +1099,7 @@ Sentinel objects
    Example::
 
       >>> class MyClass:
-      ...     MISSING = Sentinel('MyClass.MISSING')
+      ...     MISSING = sentinel('MyClass.MISSING')
 
    .. versionadded:: 4.14.0
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -102,6 +102,7 @@ from typing_extensions import (
     reveal_type,
     runtime,
     runtime_checkable,
+    sentinel,
     type_repr,
 )
 
@@ -9541,42 +9542,42 @@ class EvaluateForwardRefTests(BaseTestCase):
 
 
 class TestSentinels(BaseTestCase):
-    SENTINEL = Sentinel("TestSentinels.SENTINEL")
+    SENTINEL = sentinel("TestSentinels.SENTINEL")
 
     def test_sentinel_no_repr(self):
-        sentinel_no_repr = Sentinel('sentinel_no_repr')
+        sentinel_no_repr = sentinel('sentinel_no_repr')
 
-        self.assertEqual(sentinel_no_repr._name, 'sentinel_no_repr')
-        self.assertEqual(repr(sentinel_no_repr), '<sentinel_no_repr>')
+        self.assertEqual(sentinel_no_repr.__name__, 'sentinel_no_repr')
+        self.assertEqual(repr(sentinel_no_repr), 'sentinel_no_repr')
 
     def test_sentinel_explicit_repr(self):
-        sentinel_explicit_repr = Sentinel('sentinel_explicit_repr', repr='explicit_repr')
+        sentinel_explicit_repr = sentinel('sentinel_explicit_repr', repr='explicit_repr')
 
         self.assertEqual(repr(sentinel_explicit_repr), 'explicit_repr')
 
     @skipIf(sys.version_info < (3, 10), reason='New unions not available in 3.9')
     def test_sentinel_type_expression_union(self):
-        sentinel = Sentinel('sentinel')
+        sentinel_type = sentinel('sentinel')
 
-        def func1(a: int | sentinel = sentinel): pass
-        def func2(a: sentinel | int = sentinel): pass
+        def func1(a: int | sentinel_type = sentinel_type): pass
+        def func2(a: sentinel_type | int = sentinel_type): pass
 
-        self.assertEqual(func1.__annotations__['a'], Union[int, sentinel])
-        self.assertEqual(func2.__annotations__['a'], Union[sentinel, int])
+        self.assertEqual(func1.__annotations__['a'], Union[int, sentinel_type])
+        self.assertEqual(func2.__annotations__['a'], Union[sentinel_type, int])
 
     def test_sentinel_not_callable(self):
-        sentinel = Sentinel('sentinel')
+        sentinel_ = sentinel('sentinel')
         with self.assertRaisesRegex(
             TypeError,
-            "'Sentinel' object is not callable"
+            "'sentinel' object is not callable"
         ):
-            sentinel()
+            sentinel_()
 
     def test_sentinel_copy_identity(self):
         self.assertIs(self.SENTINEL, copy.copy(self.SENTINEL))
         self.assertIs(self.SENTINEL, copy.deepcopy(self.SENTINEL))
 
-        anonymous_sentinel = Sentinel("anonymous_sentinel")
+        anonymous_sentinel = sentinel("anonymous_sentinel")
         self.assertIs(anonymous_sentinel, copy.copy(anonymous_sentinel))
         self.assertIs(anonymous_sentinel, copy.deepcopy(anonymous_sentinel))
 
@@ -9585,13 +9586,24 @@ class TestSentinels(BaseTestCase):
             self.assertIs(self.SENTINEL, pickle.loads(pickle.dumps(self.SENTINEL, protocol=proto)))
 
     def test_sentinel_picklable_anonymous(self):
-        anonymous_sentinel = Sentinel("anonymous_sentinel")  # Anonymous sentinel can not be pickled
+        anonymous_sentinel = sentinel("anonymous_sentinel")  # Anonymous sentinel can not be pickled
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             with self.assertRaisesRegex(
                 pickle.PicklingError,
                 r"attribute lookup anonymous_sentinel on \w+ failed|not found as \w+.anonymous_sentinel"
             ):
                 self.assertIs(anonymous_sentinel, pickle.loads(pickle.dumps(anonymous_sentinel, protocol=proto)))
+
+    def test_sentinel_deprecated(self):
+        with self.assertWarnsRegex(DeprecationWarning, r"Subclassing sentinel is forbidden by PEP 661"):
+            class SentinelSubclass(Sentinel):
+                pass
+
+        with self.assertWarnsRegex(DeprecationWarning, r"Sentinel was renamed to typing_extensions.sentinel"):
+            my_sentinel = Sentinel(name="my_sentinel")
+        with self.assertWarnsRegex(DeprecationWarning, r"Setting attributes on sentinel is deprecated"):
+            my_sentinel.foo = "bar"
+
 
 def load_tests(loader, tests, pattern):
     import doctest

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -9550,7 +9550,7 @@ class TestSentinels(BaseTestCase):
         self.assertEqual(sentinel_no_repr.__name__, 'sentinel_no_repr')
         self.assertEqual(repr(sentinel_no_repr), 'sentinel_no_repr')
 
-    def test_sentinel_explicit_repr(self):
+    def test_sentinel_deprecated_explicit_repr(self):
         sentinel_explicit_repr = sentinel('sentinel_explicit_repr', repr='explicit_repr')
 
         self.assertEqual(repr(sentinel_explicit_repr), 'explicit_repr')

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -9599,8 +9599,7 @@ class TestSentinels(BaseTestCase):
             class SentinelSubclass(Sentinel):
                 pass
 
-        with self.assertWarnsRegex(DeprecationWarning, r"Sentinel was renamed to typing_extensions.sentinel"):
-            my_sentinel = Sentinel(name="my_sentinel")
+        my_sentinel = Sentinel(name="my_sentinel")
         with self.assertWarnsRegex(DeprecationWarning, r"Setting attributes on sentinel is deprecated"):
             my_sentinel.foo = "bar"
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -9551,7 +9551,7 @@ class TestSentinels(BaseTestCase):
         self.assertEqual(repr(sentinel_no_repr), 'sentinel_no_repr')
 
     def test_sentinel_deprecated_explicit_repr(self):
-        with self.assertWarnsRegex(DeprecationWarning, r"'repr' is deprecated and must be removed"):
+        with self.assertWarnsRegex(DeprecationWarning, r"'repr' parameter is deprecated and will be removed"):
             sentinel_explicit_repr = sentinel('sentinel_explicit_repr', repr='explicit_repr')
 
         self.assertEqual(repr(sentinel_explicit_repr), 'explicit_repr')
@@ -9596,15 +9596,15 @@ class TestSentinels(BaseTestCase):
                 self.assertIs(anonymous_sentinel, pickle.loads(pickle.dumps(anonymous_sentinel, protocol=proto)))
 
     def test_sentinel_deprecated(self):
-        with self.assertWarnsRegex(DeprecationWarning, r"Subclassing sentinel is forbidden by PEP 661"):
+        with self.assertWarnsRegex(DeprecationWarning, r"Subclassing sentinel is deprecated"):
             class SentinelSubclass(Sentinel):
                 pass
         with self.assertRaisesRegex(TypeError, r"First parameter 'name' is required"):
             sentinel()
 
-        with self.assertWarnsRegex(DeprecationWarning, r"'name' is positional-only and must not be a keyword parameter"):
+        with self.assertWarnsRegex(DeprecationWarning, r"Passing 'name' as a keyword argument is deprecated"):
             my_sentinel = Sentinel(name="my_sentinel")
-        with self.assertWarnsRegex(DeprecationWarning, r"Setting attributes on sentinel is deprecated"):
+        with self.assertWarnsRegex(DeprecationWarning, r"Setting attribute 'foo' on sentinel objects is deprecated"):
             my_sentinel.foo = "bar"
 
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -9551,7 +9551,8 @@ class TestSentinels(BaseTestCase):
         self.assertEqual(repr(sentinel_no_repr), 'sentinel_no_repr')
 
     def test_sentinel_deprecated_explicit_repr(self):
-        sentinel_explicit_repr = sentinel('sentinel_explicit_repr', repr='explicit_repr')
+        with self.assertWarnsRegex(DeprecationWarning, r"'repr' is deprecated and must be removed"):
+            sentinel_explicit_repr = sentinel('sentinel_explicit_repr', repr='explicit_repr')
 
         self.assertEqual(repr(sentinel_explicit_repr), 'explicit_repr')
 
@@ -9598,8 +9599,11 @@ class TestSentinels(BaseTestCase):
         with self.assertWarnsRegex(DeprecationWarning, r"Subclassing sentinel is forbidden by PEP 661"):
             class SentinelSubclass(Sentinel):
                 pass
+        with self.assertRaisesRegex(TypeError, r"First parameter 'name' is required"):
+            sentinel()
 
-        my_sentinel = Sentinel(name="my_sentinel")
+        with self.assertWarnsRegex(DeprecationWarning, r"'name' is positional-only and must not be a keyword parameter"):
+            my_sentinel = Sentinel(name="my_sentinel")
         with self.assertWarnsRegex(DeprecationWarning, r"Setting attributes on sentinel is deprecated"):
             my_sentinel.foo = "bar"
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -174,8 +174,8 @@ class Sentinel:
     def __init__(
         self,
         name: str,
-        module_name: typing.Optional[str] = None,
         *,
+        module_name: typing.Optional[str] = None,
         repr: typing.Optional[str] = None,
     ):
         self._name = name
@@ -206,7 +206,7 @@ class Sentinel:
         return self._name  # Module is taken from the __module__ attribute
 
 
-_marker = Sentinel("sentinel", __name__)
+_marker = Sentinel("sentinel", module_name=__name__)
 
 # The functions below are modified copies of typing internal helpers.
 # They are needed by _ProtocolMeta and they provide support for PEP 646.

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -176,80 +176,87 @@ def _caller(depth=1, default='__main__'):
 # Placeholder for sentinel methods, because sentinels can not have their own sentinels
 _sentinel_placeholder = object()
 
+if hasattr(builtins, "sentinel"):  # 3.15+
+    sentinel = builtins.sentinel
+else:
+    class sentinel:
+        """Create a unique sentinel object.
 
-class sentinel:
-    """Create a unique sentinel object.
+        *name* should be the name of the variable to which the return value
+        shall be assigned.
+        """
 
-    *name* should be the name of the variable to which the return value shall be assigned.
-    """
+        def __init__(
+            self,
+            __name: str = _sentinel_placeholder,
+            /,
+            repr: typing.Optional[str] = None,
+            *,
+            name: str = _sentinel_placeholder,
+        ) -> None:
+            if name is not _sentinel_placeholder:
+                warnings.warn(
+                    "Passing 'name' as a keyword argument is deprecated; "
+                    "pass it positionally instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                __name = name
+            if __name is _sentinel_placeholder:
+                raise TypeError("First parameter 'name' is required")
+            if repr is not None:
+                warnings.warn(
+                    "The 'repr' parameter is deprecated "
+                    "and will be removed in Python 3.15.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
 
-    def __init__(
-        self,
-        __name: str = _sentinel_placeholder,
-        /,
-        repr: typing.Optional[str] = None,
-        *,
-        name: str = _sentinel_placeholder,
-    ) -> None:
-        if name is not _sentinel_placeholder:
+            self.__name__ = __name
+            self._repr = repr if repr is not None else __name
+
+            # For pickling as a singleton:
+            self.__module__ = _caller()
+
+        def __init_subclass__(cls):
             warnings.warn(
-                "Passing 'name' as a keyword argument is deprecated; pass it positionally instead.",
+                "Subclassing sentinel is deprecated "
+                "and will be disallowed in Python 3.15",
                 DeprecationWarning,
                 stacklevel=2,
             )
-            __name = name
-        if __name is _sentinel_placeholder:
-            raise TypeError("First parameter 'name' is required")
-        if repr is not None:
-            warnings.warn(
-                "The 'repr' parameter is deprecated and will be removed in Python 3.15.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            super().__init_subclass__()
 
-        self.__name__ = __name
-        self._repr = repr if repr is not None else __name
+        def __setattr__(self, attr: str, value: object) -> None:
+            if attr not in {"__name__", "_repr", "__module__"}:
+                warnings.warn(
+                    f"Setting attribute {attr!r} on sentinel objects is deprecated "
+                    "and will be disallowed in Python 3.15.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            super().__setattr__(attr, value)
 
-        # For pickling as a singleton:
-        self.__module__ = _caller()
+        def __repr__(self):
+            return self._repr
 
-    def __init_subclass__(cls):
-        warnings.warn(
-            "Subclassing sentinel is deprecated and will be disallowed in Python 3.15",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init_subclass__()
+        if sys.version_info < (3, 11):
+            # The presence of this method convinces typing._type_check
+            # that Sentinels are types.
+            def __call__(self, *args, **kwargs):
+                raise TypeError(f"{type(self).__name__!r} object is not callable")
 
-    def __setattr__(self, attr: str, value: object) -> None:
-        if attr not in {"__name__", "_repr", "__module__"}:
-            warnings.warn(
-                f"Setting attribute {attr!r} on sentinel objects is deprecated and will be disallowed in Python 3.15.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        super().__setattr__(attr, value)
+        # Breakpoint: https://github.com/python/cpython/pull/21515
+        if sys.version_info >= (3, 10):
+            def __or__(self, other):
+                return typing.Union[self, other]
 
-    def __repr__(self):
-        return self._repr
+            def __ror__(self, other):
+                return typing.Union[other, self]
 
-    if sys.version_info < (3, 11):
-        # The presence of this method convinces typing._type_check
-        # that Sentinels are types.
-        def __call__(self, *args, **kwargs):
-            raise TypeError(f"{type(self).__name__!r} object is not callable")
-
-    # Breakpoint: https://github.com/python/cpython/pull/21515
-    if sys.version_info >= (3, 10):
-        def __or__(self, other):
-            return typing.Union[self, other]
-
-        def __ror__(self, other):
-            return typing.Union[other, self]
-
-    def __reduce__(self) -> str:
-        """Reduce this sentinel to a singleton."""
-        return self.__name__  # Module is taken from the __module__ attribute
+        def __reduce__(self) -> str:
+            """Reduce this sentinel to a singleton."""
+            return self.__name__  # Module is taken from the __module__ attribute
 
 Sentinel = sentinel
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -232,12 +232,7 @@ class sentinel:
         """Reduce this sentinel to a singleton."""
         return self.__name__  # Module is taken from the __module__ attribute
 
-with warnings.catch_warnings():  # Allow sentinel subclass for backwards compatibility
-    warnings.simplefilter("ignore")
-
-    @deprecated("""Sentinel was renamed to typing_extensions.sentinel""")
-    class Sentinel(sentinel):
-        pass
+Sentinel = sentinel
 
 _marker = sentinel("sentinel")
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -173,27 +173,42 @@ def _caller(depth=1, default='__main__'):
     return None
 
 
+# Placeholder for sentinel methods, because sentinels can not have their own sentinels
+_sentinel_placeholder = object()
+
+
 class sentinel:
     """Create a unique sentinel object.
 
     *name* should be the name of the variable to which the return value shall be assigned.
     """
 
-    @overload
-    def __init__(self, name: str, /): ...
-
-    @overload
-    @deprecated("'name' must be positional-only, \
-'repr' is deprecated and must be removed.")
-    def __init__(self, name: str, repr: typing.Optional[str] = None): ...
-
     def __init__(
         self,
-        name: str,
+        __name: str = _sentinel_placeholder,
+        /,
         repr: typing.Optional[str] = None,
-    ):
-        self.__name__ = name
-        self._repr = repr if repr is not None else name
+        *,
+        name: str = _sentinel_placeholder,
+    ) -> None:
+        if name is not _sentinel_placeholder:
+            warnings.warn(
+                "'name' is positional-only and must not be a keyword parameter",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            __name = name
+        if __name is _sentinel_placeholder:
+            raise TypeError("First parameter 'name' is required")
+        if repr is not None:
+            warnings.warn(
+                "'repr' is deprecated and must be removed",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        self.__name__ = __name
+        self._repr = repr if repr is not None else __name
 
         # For pickling as a singleton:
         self.__module__ = _caller()

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -213,8 +213,12 @@ class sentinel:
         # For pickling as a singleton:
         self.__module__ = _caller()
 
-    @deprecated("Subclassing sentinel is forbidden by PEP 661")
     def __init_subclass__(cls):
+        warnings.warn(
+            "Subclassing sentinel is forbidden by PEP 661",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init_subclass__()
 
     def __setattr__(self, attr: str, value: object) -> None:

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -159,6 +159,19 @@ _PEP_696_IMPLEMENTED = sys.version_info >= (3, 13, 0, "beta")
 # Added with bpo-45166 to 3.10.1+ and some 3.9 versions
 _FORWARD_REF_HAS_CLASS = "__forward_is_class__" in typing.ForwardRef.__slots__
 
+
+def _caller(depth=1, default='__main__'):
+    try:
+        return sys._getframemodulename(depth + 1) or default
+    except AttributeError:  # For platforms without _getframemodulename()
+        pass
+    try:
+        return sys._getframe(depth + 1).f_globals.get('__name__', default)
+    except (AttributeError, ValueError):  # For platforms without _getframe()
+        pass
+    return None
+
+
 class Sentinel:
     """Create a unique sentinel object.
 
@@ -645,18 +658,6 @@ def _get_protocol_attrs(cls):
             if (not attr.startswith('_abc_') and attr not in _EXCLUDED_ATTRS):
                 attrs.add(attr)
     return attrs
-
-
-def _caller(depth=1, default='__main__'):
-    try:
-        return sys._getframemodulename(depth + 1) or default
-    except AttributeError:  # For platforms without _getframemodulename()
-        pass
-    try:
-        return sys._getframe(depth + 1).f_globals.get('__name__', default)
-    except (AttributeError, ValueError):  # For platforms without _getframe()
-        pass
-    return None
 
 
 # `__match_args__` attribute was removed from protocol members in 3.13,

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -193,7 +193,7 @@ class sentinel:
     ) -> None:
         if name is not _sentinel_placeholder:
             warnings.warn(
-                "'name' is positional-only and must not be a keyword parameter",
+                "Passing 'name' as a keyword argument is deprecated; pass it positionally instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -202,7 +202,7 @@ class sentinel:
             raise TypeError("First parameter 'name' is required")
         if repr is not None:
             warnings.warn(
-                "'repr' is deprecated and must be removed",
+                "The 'repr' parameter is deprecated and will be removed in Python 3.15.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -215,7 +215,7 @@ class sentinel:
 
     def __init_subclass__(cls):
         warnings.warn(
-            "Subclassing sentinel is forbidden by PEP 661",
+            "Subclassing sentinel is deprecated and will be disallowed in Python 3.15",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -224,7 +224,7 @@ class sentinel:
     def __setattr__(self, attr: str, value: object) -> None:
         if attr not in {"__name__", "_repr", "__module__"}:
             warnings.warn(
-                "Setting attributes on sentinel is deprecated",
+                f"Setting attribute {attr!r} on sentinel objects is deprecated and will be disallowed in Python 3.15.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -91,6 +91,7 @@ __all__ = [
     'overload',
     'override',
     'Protocol',
+    'sentinel',
     'Sentinel',
     'reveal_type',
     'runtime',
@@ -172,30 +173,45 @@ def _caller(depth=1, default='__main__'):
     return None
 
 
-class Sentinel:
+class sentinel:
     """Create a unique sentinel object.
 
     *name* should be the name of the variable to which the return value shall be assigned.
-
-    *module_name* is the module where the sentinel is defined.
-    Defaults to the current modules ``__name__``.
 
     *repr*, if supplied, will be used for the repr of the sentinel object.
     If not provided, "<name>" will be used.
     """
 
+    @overload
+    def __init__(self, name: str, /, *, repr: typing.Optional[str] = None): ...
+
+    @overload
+    @deprecated("'name' must be positional-only, 'repr' must be keyword-only.")
+    def __init__(self, name: str, repr: typing.Optional[str] = None): ...
+
     def __init__(
         self,
         name: str,
-        *,
-        module_name: typing.Optional[str] = None,
         repr: typing.Optional[str] = None,
     ):
-        self._name = name
-        self._repr = repr if repr is not None else f'<{name}>'
+        self.__name__ = name
+        self._repr = repr if repr is not None else name
 
         # For pickling as a singleton:
-        self.__module__ = module_name if module_name is not None else _caller()
+        self.__module__ = _caller()
+
+    @deprecated("Subclassing sentinel is forbidden by PEP 661")
+    def __init_subclass__(cls):
+        super().__init_subclass__()
+
+    def __setattr__(self, attr: str, value: object) -> None:
+        if attr not in {"__name__", "_repr", "__module__"}:
+            warnings.warn(
+                "Setting attributes on sentinel is deprecated",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        super().__setattr__(attr, value)
 
     def __repr__(self):
         return self._repr
@@ -216,10 +232,17 @@ class Sentinel:
 
     def __reduce__(self) -> str:
         """Reduce this sentinel to a singleton."""
-        return self._name  # Module is taken from the __module__ attribute
+        return self.__name__  # Module is taken from the __module__ attribute
 
+with warnings.catch_warnings():  # Allow sentinel subclass for backwards compatibility
+    warnings.simplefilter("ignore")
 
-_marker = Sentinel("sentinel", module_name=__name__)
+    @deprecated("""Sentinel was renamed to typing_extensions.sentinel""")
+    class Sentinel(sentinel):
+        pass
+
+_marker = sentinel("sentinel")
+
 
 # The functions below are modified copies of typing internal helpers.
 # They are needed by _ProtocolMeta and they provide support for PEP 646.

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -177,16 +177,14 @@ class sentinel:
     """Create a unique sentinel object.
 
     *name* should be the name of the variable to which the return value shall be assigned.
-
-    *repr*, if supplied, will be used for the repr of the sentinel object.
-    If not provided, "<name>" will be used.
     """
 
     @overload
-    def __init__(self, name: str, /, *, repr: typing.Optional[str] = None): ...
+    def __init__(self, name: str, /): ...
 
     @overload
-    @deprecated("'name' must be positional-only, 'repr' must be keyword-only.")
+    @deprecated("'name' must be positional-only, \
+'repr' is deprecated and must be removed.")
     def __init__(self, name: str, repr: typing.Optional[str] = None): ...
 
     def __init__(


### PR DESCRIPTION
My attempt at implementing [PEP 661](https://peps.python.org/pep-0661/) since I was unhappy with #594. I'm hoping that this is a PR of decent quality and not just me desperately wanting pickle support.

Changes made to Sentinel:

- ~~Added `module_name` parameter following PEP implementation and tweaking that to use the local `_caller` helper function. Breaking change due to `repr` becoming a keyword parameter.~~ `module_name` removed due to changes in PEP 661.
- `name` requires qualified names to support pickle singletons, this is tested and documented.
- Added `__reduce__` to track Sentinel by name and module_name.
- Added copy and pickle tests. There were several other use-cases for pickle from the PEP 661 discussion. The PEP requires that the sentinel identity is preserved during these operations.
- Updated documentation for Sentinel.

For a while I still supported the `repr` parameter and after following the [PEP 661 discussion](https://discuss.python.org/t/pep-661-sentinel-values/9126) I ended up implementing the truthiness tweaks mentioned there, but then I ended up scrapping all of that so that I could follow the PEP more closely, but they would be easy to reintroduce later if desired.

I'm unsure of how to mention version changes in the docs. Replacing `repr` with `module_name` is technically a breaking change.

Closes #720
Closes #742 