### PR TITLE
Improve testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           - "3.14"
           - "pypy3.9"
           - "pypy3.10"
+          - "pypy3.11"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -291,8 +291,6 @@ jobs:
           cd cattrs
           pdm remove typing-extensions
           pdm add --dev ../typing-extensions-latest
-          pdm update --group=docs pendulum  # pinned version in lockfile is incompatible with py313 as of 2025/05/05
-          pdm sync --clean
       - name: Install cattrs test dependencies
         run: cd cattrs; pdm install --dev -G :all
       - name: List all installed dependencies


### PR DESCRIPTION
- Test with PyPy 3.11 as well as PyPy 3.9 and PyPy 3.10
- Remove a hack for installing cattrs on 3.13 that is no longer required