### PR TITLE
Run shellcheck on GitHub Actions `run` steps as part of pre-commit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,9 +63,10 @@ jobs:
           path: dist/
       - name: Install wheel
         run: |
-          export path_to_file=$(find dist -type f -name "typing_extensions-*.whl")
+          path_to_file="$(find dist -type f -name "typing_extensions-*.whl")"
+          export path_to_file
           echo "::notice::Installing wheel: $path_to_file"
-          python -m pip install --user $path_to_file
+          python -m pip install --user "$path_to_file"
           python -m pip list
       - name: Run typing_extensions tests against installed package
         run: rm src/typing_extensions.py && python src/test_typing_extensions.py
@@ -89,10 +90,11 @@ jobs:
           path: dist/
       - name: Unpack and test source distribution
         run: |
-          export path_to_file=$(find dist -type f -name "typing_extensions-*.tar.gz")
+          path_to_file="$(find dist -type f -name "typing_extensions-*.tar.gz")"
+          export path_to_file
           echo "::notice::Unpacking source distribution: $path_to_file"
-          tar xzf $path_to_file -C dist/
-          cd ${path_to_file%.tar.gz}/src
+          tar xzf "$path_to_file" -C dist/
+          cd "${path_to_file%.tar.gz}/src"
           python test_typing_extensions.py
 
   test-sdist-installed:
@@ -114,9 +116,10 @@ jobs:
           path: dist/
       - name: Install source distribution
         run: |
-          export path_to_file=$(find dist -type f -name "typing_extensions-*.tar.gz")
+          path_to_file="$(find dist -type f -name "typing_extensions-*.tar.gz")"
+          export path_to_file
           echo "::notice::Installing source distribution: $path_to_file"
-          python -m pip install --user $path_to_file
+          python -m pip install --user "$path_to_file"
           python -m pip list
       - name: Run typing_extensions tests against installed package
         run: rm src/typing_extensions.py && python src/test_typing_extensions.py
@@ -144,6 +147,6 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Ensure exactly one sdist and one wheel have been downloaded
-        run: test $(ls dist/*.tar.gz | wc -l) = 1 && test $(ls dist/*.whl | wc -l) = 1
+        run: test "$(find dist/*.tar.gz | wc -l | xargs)" = 1 && test "$(find dist/*.whl | wc -l | xargs)" = 1
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -98,7 +98,7 @@ jobs:
         run: |
           set -x
           cd typing_inspect
-          uv pip install --system -r test-requirements.txt --exclude-newer $(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)
+          uv pip install --system -r test-requirements.txt --exclude-newer "$(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)"
       - name: Install typing_extensions latest
         run: uv pip install --system "typing-extensions @ ./typing-extensions-latest"
       - name: List all installed dependencies
@@ -135,7 +135,7 @@ jobs:
         run: |
           set -x
           cd pycroscope
-          uv pip install --system 'pycroscope[tests] @ .' --exclude-newer $(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)
+          uv pip install --system 'pycroscope[tests] @ .' --exclude-newer "$(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)"
       - name: Install typing_extensions latest
         run: uv pip install --system "typing-extensions @ ./typing-extensions-latest"
       - name: List all installed dependencies
@@ -172,7 +172,7 @@ jobs:
         run: |
           set -x
           cd typeguard
-          uv pip install --system "typeguard @ ." --group test  --exclude-newer $(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)
+          uv pip install --system "typeguard @ ." --group test  --exclude-newer "$(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)"
       - name: Install typing_extensions latest
         run: uv pip install --system "typing-extensions @ ./typing-extensions-latest"
       - name: List all installed dependencies
@@ -215,8 +215,8 @@ jobs:
         run: |
           set -x
           cd typed-argument-parser
-          uv pip install --system "typed-argument-parser @ ."  --exclude-newer $(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)
-          uv pip install --system pytest  --exclude-newer $(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)
+          uv pip install --system "typed-argument-parser @ ."  --exclude-newer "$(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)"
+          uv pip install --system pytest  --exclude-newer "$(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)"
       - name: Install typing_extensions latest
         run: uv pip install --system "typing-extensions @ ./typing-extensions-latest"
       - name: List all installed dependencies
@@ -253,7 +253,7 @@ jobs:
         run: |
           set -x
           cd mypy
-          uv pip install --system -r test-requirements.txt  --exclude-newer $(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)
+          uv pip install --system -r test-requirements.txt  --exclude-newer "$(git show -s --date=format:'%Y-%m-%dT%H:%M:%SZ' --format=%cd HEAD)"
           uv pip install --system -e .
       - name: Install typing_extensions latest
         run: uv pip install --system "typing-extensions @ ./typing-extensions-latest"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,11 @@ repos:
     rev: v1.7.7
     hooks:
       - id: actionlint
+        additional_dependencies:
+          # actionlint has a shellcheck integration which extracts shell scripts in `run:` steps from GitHub Actions
+          # and checks these with shellcheck. This is arguably its most useful feature,
+          # but the integration only works if shellcheck is installed
+          - "github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.10.0"
   - repo: meta
     hooks:
       - id: check-hooks-apply


### PR DESCRIPTION
actionlint has an optional shellcheck integration which scrapes the `run` steps of GitHub workflows and passes them to shellcheck. We have some reasonably complex workflows in this repo, and shellcheck finds some issues in some of them:

<details>
<summary>Shellcheck complaints regarding our GitHub workflows</summary>

```
.github/workflows/publish.yml:65:9: shellcheck reported issue in this script: SC2155:warning:1:8: Declare and assign separately to avoid masking return values [shellcheck]
   |
65 |         run: |
   |         ^~~~
.github/workflows/publish.yml:65:9: shellcheck reported issue in this script: SC2086:info:3:30: Double quote to prevent globbing and word splitting [shellcheck]
   |
65 |         run: |
   |         ^~~~
.github/workflows/publish.yml:91:9: shellcheck reported issue in this script: SC2155:warning:1:8: Declare and assign separately to avoid masking return values [shellcheck]
   |
91 |         run: |
   |         ^~~~
.github/workflows/publish.yml:91:9: shellcheck reported issue in this script: SC2086:info:3:9: Double quote to prevent globbing and word splitting [shellcheck]
   |
91 |         run: |
   |         ^~~~
.github/workflows/publish.yml:91:9: shellcheck reported issue in this script: SC2086:info:4:4: Double quote to prevent globbing and word splitting [shellcheck]
   |
91 |         run: |
   |         ^~~~
.github/workflows/publish.yml:116:9: shellcheck reported issue in this script: SC2155:warning:1:8: Declare and assign separately to avoid masking return values [shellcheck]
    |
116 |         run: |
    |         ^~~~
.github/workflows/publish.yml:116:9: shellcheck reported issue in this script: SC2086:info:3:30: Double quote to prevent globbing and word splitting [shellcheck]
    |
116 |         run: |
    |         ^~~~
.github/workflows/publish.yml:147:9: shellcheck reported issue in this script: SC2046:warning:1:6: Quote this to prevent word splitting [shellcheck]
    |
147 |         run: test $(ls dist/*.tar.gz | wc -l) = 1 && test $(ls dist/*.whl | wc -l) = 1
    |         ^~~~
.github/workflows/publish.yml:147:9: shellcheck reported issue in this script: SC2012:info:1:8: Use find instead of ls to better handle non-alphanumeric filenames [shellcheck]
    |
147 |         run: test $(ls dist/*.tar.gz | wc -l) = 1 && test $(ls dist/*.whl | wc -l) = 1
    |         ^~~~
.github/workflows/publish.yml:147:9: shellcheck reported issue in this script: SC2046:warning:1:46: Quote this to prevent word splitting [shellcheck]
    |
147 |         run: test $(ls dist/*.tar.gz | wc -l) = 1 && test $(ls dist/*.whl | wc -l) = 1
    |         ^~~~
.github/workflows/publish.yml:147:9: shellcheck reported issue in this script: SC2012:info:1:48: Use find instead of ls to better handle non-alphanumeric filenames [shellcheck]
    |
147 |         run: test $(ls dist/*.tar.gz | wc -l) = 1 && test $(ls dist/*.whl | wc -l) = 1
    |         ^~~~
.github/workflows/third_party.yml:98:9: shellcheck reported issue in this script: SC2046:warning:3:66: Quote this to prevent word splitting [shellcheck]
   |
98 |         run: |
   |         ^~~~
.github/workflows/third_party.yml:135:9: shellcheck reported issue in this script: SC2046:warning:3:65: Quote this to prevent word splitting [shellcheck]
    |
135 |         run: |
    |         ^~~~
.github/workflows/third_party.yml:172:9: shellcheck reported issue in this script: SC2046:warning:3:71: Quote this to prevent word splitting [shellcheck]
    |
172 |         run: |
    |         ^~~~
.github/workflows/third_party.yml:215:9: shellcheck reported issue in this script: SC2046:warning:3:70: Quote this to prevent word splitting [shellcheck]
    |
215 |         run: |
    |         ^~~~
.github/workflows/third_party.yml:215:9: shellcheck reported issue in this script: SC2046:warning:4:49: Quote this to prevent word splitting [shellcheck]
    |
215 |         run: |
    |         ^~~~
.github/workflows/third_party.yml:253:9: shellcheck reported issue in this script: SC2046:warning:3:67: Quote this to prevent word splitting [shellcheck]
    |
253 |         run: |
    |         ^~~~
```

</details>

This PR enables actionlint's shellcheck integration in our `.pre-commit-config.yaml` file, and fixes the complaints shellcheck has regarding our GitHub workflows. I tested locally in a shell that the new shell snippets produce the same results as before, and I tested locally that `uvx pre-commit run -a` still passes on this PR branch. (Note that we don't yet run pre-commit in CI.)