### PR TITLE
Add more jsonschema pre-commit hooks

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -35,7 +35,7 @@ jobs:
       github.repository == 'python/typing_extensions'
       || github.event_name != 'schedule'
     steps:
-      - run: true
+      - run: "true"
 
   pydantic:
     name: pydantic tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,8 @@ repos:
     rev: 0.33.0
     hooks:
       - id: check-dependabot
+      - id: check-github-workflows
+      - id: check-readthedocs
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.24.1
     hooks:


### PR DESCRIPTION
`check-readthedocs` reports no errors but `check-jsonschema` complains:

```
Schema validation errors were encountered.
  .github/workflows/third_party.yml::$.jobs.skip-schedule-on-fork: {'name': 'Check for schedule trigger on fork', 'runs-on': 'ubuntu-latest', 'if': "github.repository == 'python/typing_extensions' || github.event_name != 'schedule'", 'steps': [{'run': True}]} is not valid under any of the given schemas
  Underlying errors caused this.

  Best Match:
    $.jobs.skip-schedule-on-fork: 'uses' is a required property
  Best Deep Match:
    $.jobs.skip-schedule-on-fork.steps[0].run: True is not of type 'string'

  1 other errors were produced. Use '--verbose' to see all errors.
```