### PR TITLE
Add zizmor as a pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Check package metadata
         env:
           GITHUB_REF: ${{ github.ref }}
-        run: python scripts/check_package.py "${github.ref}"
+        run: python scripts/check_package.py "${GITHUB_REF}"
       - name: Install pypa/build
         run: |
           # Be wary of running `pip install` here, since it becomes easy for us to

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,12 +24,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Check package metadata
-        run: python scripts/check_package.py ${{ github.ref }}
+        env:
+          GITHUB_REF: ${{ github.ref }}
+        run: python scripts/check_package.py "${github.ref}"
       - name: Install pypa/build
         run: |
           # Be wary of running `pip install` here, since it becomes easy for us to
@@ -52,6 +56,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -78,6 +84,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -103,6 +111,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -146,4 +156,4 @@ jobs:
       - name: Ensure exactly one sdist and one wheel have been downloaded
         run: test $(ls dist/*.tar.gz | wc -l) = 1 && test $(ls dist/*.whl | wc -l) = 1
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc

--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -63,6 +63,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: typing-extensions-latest
+          persist-credentials: false
       - name: Add local version of typing_extensions as a dependency
         run: cd pydantic; uv add --editable ../typing-extensions-latest
       - name: Install pydantic test dependencies
@@ -94,6 +95,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: typing-extensions-latest
+          persist-credentials: false
       - name: Install typing_inspect test dependencies
         run: |
           set -x
@@ -131,6 +133,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: typing-extensions-latest
+          persist-credentials: false
       - name: Install pycroscope test requirements
         run: |
           set -x
@@ -168,6 +171,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: typing-extensions-latest
+          persist-credentials: false
       - name: Install typeguard test requirements
         run: |
           set -x
@@ -205,6 +209,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: typing-extensions-latest
+          persist-credentials: false
       - name: Configure git for typed-argument-parser tests
         # typed-argument parser does this in their CI,
         # and the tests fail unless we do this
@@ -249,6 +254,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: typing-extensions-latest
+          persist-credentials: false
       - name: Install mypy test requirements
         run: |
           set -x
@@ -284,6 +290,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: typing-extensions-latest
+          persist-credentials: false
       - name: Install pdm for cattrs
         run: pip install pdm
       - name: Add latest typing-extensions as a dependency
@@ -326,6 +333,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: typing-extensions-latest
+          persist-credentials: false
       - name: Install sqlalchemy test dependencies
         run: uv pip install --system tox setuptools
       - name: List installed dependencies
@@ -362,6 +370,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: typing-extensions-latest
+          persist-credentials: false
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Run litestar tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,10 @@ repos:
     rev: v1.7.7
     hooks:
       - id: actionlint
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.11.0
+    hooks:
+      - id: zizmor
   - repo: meta
     hooks:
       - id: check-hooks-apply


### PR DESCRIPTION
Zizmor is a linter that checks GitHub workflow files for security vulnerabilities. We run it in CI for Ruff and uv over at Astral. Since typing_extensions is a top-10 PyPI package and take security pretty seriously in general, I think it makes sense for this repo to add it as a pre-commit hook too.

On `main`, zizmor has the following complaints regarding our GitHub workflows:

<details>
<summary>Zizmor complaints</summary>

```
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/ci.yml:59:9
   |
59 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/publish.yml:26:9
   |
26 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/publish.yml:54:9
   |
54 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/publish.yml:80:9
   |
80 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/publish.yml:105:9
    |
105 |       - uses: actions/checkout@v4
    |         ------------------------- does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

error[template-injection]: code injection via template expansion
  --> .github/workflows/publish.yml:32:50
   |
32 |         run: python scripts/check_package.py ${{ github.ref }}
   |         ^^^ this run block                       ^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
   --> .github/workflows/publish.yml:149:9
    |
149 |         uses: pypa/gh-action-pypi-publish@release/v1
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/third_party.yml:62:9
   |
62 |         - name: Checkout typing_extensions
   |  _________-
63 | |         uses: actions/checkout@v4
64 | |         with:
65 | |           path: typing-extensions-latest
   | |________________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/third_party.yml:93:9
   |
93 |         - name: Checkout typing_extensions
   |  _________-
94 | |         uses: actions/checkout@v4
95 | |         with:
96 | |           path: typing-extensions-latest
   | |________________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/third_party.yml:130:9
    |
130 |         - name: Checkout typing_extensions
    |  _________-
131 | |         uses: actions/checkout@v4
132 | |         with:
133 | |           path: typing-extensions-latest
    | |________________________________________- does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/third_party.yml:167:9
    |
167 |         - name: Checkout typing_extensions
    |  _________-
168 | |         uses: actions/checkout@v4
169 | |         with:
170 | |           path: typing-extensions-latest
    | |________________________________________- does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/third_party.yml:204:9
    |
204 |         - name: Checkout typing_extensions
    |  _________-
205 | |         uses: actions/checkout@v4
206 | |         with:
207 | |           path: typing-extensions-latest
    | |________________________________________- does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/third_party.yml:248:9
    |
248 |         - name: Checkout typing_extensions
    |  _________-
249 | |         uses: actions/checkout@v4
250 | |         with:
251 | |           path: typing-extensions-latest
    | |________________________________________- does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/third_party.yml:283:9
    |
283 |         - name: Checkout typing_extensions
    |  _________-
284 | |         uses: actions/checkout@v4
285 | |         with:
286 | |           path: typing-extensions-latest
    | |________________________________________- does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/third_party.yml:325:9
    |
325 |         - name: Checkout typing_extensions
    |  _________-
326 | |         uses: actions/checkout@v4
327 | |         with:
328 | |           path: typing-extensions-latest
    | |________________________________________- does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/third_party.yml:361:9
    |
361 |         - name: Checkout typing_extensions
    |  _________-
362 | |         uses: actions/checkout@v4
363 | |         with:
364 | |           path: typing-extensions-latest
    | |________________________________________- does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix
```

</details>

The three rules that have violations are:
- `artipacked`:
  - Docs: https://docs.zizmor.sh/audits/#artipacked
  - Writeup of how this was previously exploited: https://unit42.paloaltonetworks.com/github-repo-artifacts-leak-tokens/
- `template-injection`: this is the motivation for this change in `publish.yaml`:
  ```diff
  - run: python scripts/check_package.py ${{ github.ref }}
  + env:
  +   GITHUB_REF: ${{ github.ref }}
  +     run: python scripts/check_package.py "${GITHUB_REF}"
  ```

  - Docs: https://docs.zizmor.sh/audits/#template-injection. The docs here also explain why the diff above fixes this vulnerability.
  - Writeup on the GitHub blog: https://securitylab.github.com/resources/github-actions-untrusted-input/
- `unpinned-uses`
  - Docs: https://docs.zizmor.sh/audits/#unpinned-uses
  - Writeup of how this was previously exploited: https://unit42.paloaltonetworks.com/github-actions-supply-chain-attack/