### PR TITLE
Add sphinx-lint as a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,10 @@ repos:
       - id: forbid-submodules
       - id: mixed-line-ending
         args: [--fix=lf]
+  - repo: https://github.com/sphinx-contrib/sphinx-lint
+    rev: v1.0.0
+    hooks:
+      - id: sphinx-lint
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.33.0
     hooks:


### PR DESCRIPTION
The tool checks for correctness issues in `.rst` files, and our documentation uses reStructured text. It doesn't currently find any issues in our docs.