### PR TITLE
check-python-version-instead-of-hasattr

### DIFF
--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2274,7 +2274,7 @@ else:
         raise TypeError(f"{self} is not subscriptable")
 
 
-if hasattr(typing, "Self"):  # 3.11+
+if sys.version_info >= (3, 11):
     Self = typing.Self
 else:
     @_SpecialForm


### PR DESCRIPTION
why it is important - because other packages could for some reason monkey patch this variable:

https://github.com/pyqtgraph/pyqtgraph/issues/3352