### PR TITLE
DOC: add missing `versionadded` metadata for `TypeAlias`

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -363,6 +363,8 @@ Special typing primitives
 
    See :py:data:`typing.TypeAlias` and :pep:`613`. In ``typing`` since 3.10.
 
+   .. versionadded:: 3.10.0.0
+
 .. class:: TypeAliasType(name, value, *, type_params=())
 
    See :py:class:`typing.TypeAliasType` and :pep:`695`. In ``typing`` since 3.12.


### PR DESCRIPTION
According to git blame, `TypeAlias` was added in https://github.com/python/typing_extensions/commit/d362ccb6504bf52618796822e8e6ffa9091575a4, which GitHub's UI indicates was included as early as 3.10.0.0