### PR TITLE
Do not refer to PEP 705 as being experimental

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -409,8 +409,8 @@ Special typing primitives
    raises a :py:exc:`DeprecationWarning` when this syntax is used in Python 3.12
    or lower and fails with a :py:exc:`TypeError` in Python 3.13 and higher.
 
-   ``typing_extensions`` supports the experimental :data:`ReadOnly` qualifier
-   proposed by :pep:`705`. It is reflected in the following attributes:
+   ``typing_extensions`` supports the :data:`ReadOnly` qualifier
+   introduced by :pep:`705`. It is reflected in the following attributes:
 
    .. attribute:: __readonly_keys__
 


### PR DESCRIPTION
Note that the documentation related to PEP 728 is mostly outdated as well, but I figured we should wait for it to be implemented in CPython first so that we could copy over the documentation from there.