### PR TITLE
Don't delete previous coverage comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,5 +212,5 @@ jobs:
           github.event_name == 'pull_request'
           && github.event.pull_request.head.repo.full_name == github.repository
         with:
-          recreate: true
+          hide_and_recreate: true
           path: code-coverage-results.md


### PR DESCRIPTION
c.f. https://github.com/python/typing_extensions/pull/651#issuecomment-3214598062

This makes the coverage workflow hide the previous comment instead of deleting it. 

https://github.com/marocchino/sticky-pull-request-comment?tab=readme-ov-file#hide-the-previous-comment-and-add-a-comment-at-the-end