### PR TITLE
Add some miscellaneous tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+- Raise `TypeError` when attempting to subclass `typing_extensions.ParamSpec` on
+  Python 3.9. The `typing` implementation has always raised an error, and the
+  `typing_extensions` implementation has raised an error on Python 3.10+ since
+  `typing_extensions` v4.6.0. Patch by Brian Schubert.
+
 # Release 4.15.0rc1 (August 18, 2025)
 
 - Add the `@typing_extensions.disjoint_base` decorator, as specified

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -2247,7 +2247,6 @@ class GeneratorTests(BaseTestCase):
         self.assertRaises(AttributeError, lambda: origin.__dunder__)
 
         # ...and certain known attributes
-        old_name = alias._name
         alias._name = "NewName"
         self.assertEqual(alias._name, "NewName")
         self.assertRaises(AttributeError, lambda: origin._name)

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6028,12 +6028,8 @@ class ParamSpecTests(BaseTestCase):
         self.assertEqual(result1, result2)
 
     def test_subclass(self):
-        if sys.version_info >= (3, 10):
-            with self.assertRaises(TypeError):
-                class MyParamSpec(ParamSpec):
-                    pass
-        else:
-            class MyParamSpec(ParamSpec):  # Does not raise
+        with self.assertRaises(TypeError):
+            class MyParamSpec(ParamSpec):
                 pass
 
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5553,25 +5553,6 @@ class GetTypeHintsTests(BaseTestCase):
             get_type_hints(foobar, globals(), locals(), include_extras=True),
             {'x': List[Annotated[int, (1, 10)]]}
         )
-        def foobar2(x: list['X']): ...
-        if sys.version_info >= (3, 11):
-            self.assertEqual(
-                get_type_hints(foobar2, globals(), locals()),
-                {'x': list[int]}
-            )
-            self.assertEqual(
-                get_type_hints(foobar2, globals(), locals(), include_extras=True),
-                {'x': list[Annotated[int, (1, 10)]]}
-            )
-        else:  # TODO: evaluate nested forward refs in Python < 3.11
-            self.assertEqual(
-                get_type_hints(foobar2, globals(), locals()),
-                {'x': list['X']}
-            )
-            self.assertEqual(
-                get_type_hints(foobar2, globals(), locals(), include_extras=True),
-                {'x': list['X']}
-            )
         BA = Tuple[Annotated[T, (1, 0)], ...]
         def barfoo(x: BA): ...
         self.assertEqual(get_type_hints(barfoo, globals(), locals())['x'], Tuple[T, ...])
@@ -5590,6 +5571,19 @@ class GetTypeHintsTests(BaseTestCase):
         self.assertIs(
             get_type_hints(barfoo3, globals(), locals(), include_extras=True)["x"],
             BA2
+        )
+
+    @skipUnless(sys.version_info >= (3, 11), "TODO: evaluate nested forward refs in Python < 3.11")
+    def test_get_type_hints_genericalias(self):
+        def foobar(x: list['X']): ...
+        X = Annotated[int, (1, 10)]
+        self.assertEqual(
+            get_type_hints(foobar, globals(), locals()),
+            {'x': list[int]}
+        )
+        self.assertEqual(
+            get_type_hints(foobar, globals(), locals(), include_extras=True),
+            {'x': list[Annotated[int, (1, 10)]]}
         )
 
     def test_get_type_hints_refs(self):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -531,6 +531,14 @@ class BottomTypeTestsMixin:
             pickled = pickle.dumps(self.bottom_type, protocol=proto)
             self.assertIs(self.bottom_type, pickle.loads(pickled))
 
+    @skipUnless(TYPING_3_10_0, "PEP 604 has yet to be")
+    def test_or(self):
+        self.assertEqual(self.bottom_type | int, Union[self.bottom_type, int])
+        self.assertEqual(int | self.bottom_type, Union[int, self.bottom_type])
+
+        self.assertEqual(get_args(self.bottom_type | int), (self.bottom_type, int))
+        self.assertEqual(get_args(int | self.bottom_type), (int, self.bottom_type))
+
 
 class NoReturnTests(BottomTypeTestsMixin, BaseTestCase):
     bottom_type = NoReturn
@@ -5332,6 +5340,17 @@ class TypedDictTests(BaseTestCase):
     def test_dunder_dict(self):
         self.assertIsInstance(TypedDict.__dict__, dict)
 
+    @skipUnless(TYPING_3_10_0, "PEP 604 has yet to be")
+    def test_or(self):
+        class TD(TypedDict):
+            a: int
+
+        self.assertEqual(TD | int, Union[TD, int])
+        self.assertEqual(int | TD, Union[int, TD])
+
+        self.assertEqual(get_args(TD | int), (TD, int))
+        self.assertEqual(get_args(int | TD), (int, TD))
+
 class AnnotatedTests(BaseTestCase):
 
     def test_repr(self):
@@ -6393,6 +6412,14 @@ class LiteralStringTests(BaseTestCase):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             pickled = pickle.dumps(LiteralString, protocol=proto)
             self.assertIs(LiteralString, pickle.loads(pickled))
+
+    @skipUnless(TYPING_3_10_0, "PEP 604 has yet to be")
+    def test_or(self):
+        self.assertEqual(LiteralString | int, Union[LiteralString, int])
+        self.assertEqual(int | LiteralString, Union[int, LiteralString])
+
+        self.assertEqual(get_args(LiteralString | int), (LiteralString, int))
+        self.assertEqual(get_args(int | LiteralString), (int, LiteralString))
 
 
 class SelfTests(BaseTestCase):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7804,58 +7804,54 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         self.assertEqual(A[float, [range], int].__args__, (float, (range,), int))
 
 
-class NoDefaultTests(BaseTestCase):
+class TypedDictSentinelMixin:
     @skip_if_py313_beta_1
     def test_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            s = pickle.dumps(NoDefault, proto)
+            s = pickle.dumps(self.sentinel_type, proto)
             loaded = pickle.loads(s)
-            self.assertIs(NoDefault, loaded)
+            self.assertIs(self.sentinel_type, loaded)
 
     @skip_if_py313_beta_1
     def test_doc(self):
-        self.assertIsInstance(NoDefault.__doc__, str)
+        self.assertIsInstance(self.sentinel_type.__doc__, str)
 
     def test_constructor(self):
-        self.assertIs(NoDefault, type(NoDefault)())
+        self.assertIs(self.sentinel_type, type(self.sentinel_type)())
         with self.assertRaises(TypeError):
-            type(NoDefault)(1)
-
-    def test_repr(self):
-        self.assertRegex(repr(NoDefault), r'typing(_extensions)?\.NoDefault')
+            type(self.sentinel_type)(1)
 
     def test_no_call(self):
         with self.assertRaises(TypeError):
-            NoDefault()
+            self.sentinel_type()
 
     @skip_if_py313_beta_1
     def test_immutable(self):
         with self.assertRaises(AttributeError):
-            NoDefault.foo = 'bar'
+            self.sentinel_type.foo = 'bar'
         with self.assertRaises(AttributeError):
-            NoDefault.foo
+            self.sentinel_type.foo
 
         # TypeError is consistent with the behavior of NoneType
         with self.assertRaises(TypeError):
-            type(NoDefault).foo = 3
+            type(self.sentinel_type).foo = 3
         with self.assertRaises(AttributeError):
-            type(NoDefault).foo
+            type(self.sentinel_type).foo
 
 
-class NoExtraItemsTests(BaseTestCase):
-    def test_pickling(self):
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            s = pickle.dumps(NoExtraItems, proto)
-            loaded = pickle.loads(s)
-            self.assertIs(NoExtraItems, loaded)
+class NoDefaultTests(TypedDictSentinelMixin, BaseTestCase):
+    sentinel_type = NoDefault
 
-    def test_doc(self):
-        self.assertIsInstance(NoExtraItems.__doc__, str)
+    def test_repr(self):
+        if hasattr(typing, 'NoDefault'):
+            mod_name = 'typing'
+        else:
+            mod_name = "typing_extensions"
+        self.assertEqual(repr(NoDefault), f"{mod_name}.NoDefault")
 
-    def test_constructor(self):
-        self.assertIs(NoExtraItems, type(NoExtraItems)())
-        with self.assertRaises(TypeError):
-            type(NoExtraItems)(1)
+
+class NoExtraItemsTests(TypedDictSentinelMixin, BaseTestCase):
+    sentinel_type = NoExtraItems
 
     def test_repr(self):
         if hasattr(typing, 'NoExtraItems'):
@@ -7863,22 +7859,6 @@ class NoExtraItemsTests(BaseTestCase):
         else:
             mod_name = "typing_extensions"
         self.assertEqual(repr(NoExtraItems), f"{mod_name}.NoExtraItems")
-
-    def test_no_call(self):
-        with self.assertRaises(TypeError):
-            NoExtraItems()
-
-    def test_immutable(self):
-        with self.assertRaises(AttributeError):
-            NoExtraItems.foo = 'bar'
-        with self.assertRaises(AttributeError):
-            NoExtraItems.foo
-
-        # TypeError is consistent with the behavior of NoneType
-        with self.assertRaises(TypeError):
-            type(NoExtraItems).foo = 3
-        with self.assertRaises(AttributeError):
-            type(NoExtraItems).foo
 
 
 class TypeVarInferVarianceTests(BaseTestCase):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -2279,27 +2279,6 @@ class OtherABCTests(BaseTestCase):
         self.assertEqual(Alias._name, "NewName")
         self.assertEqual(Foo._name, "Foo")
 
-    def test_invalid_specialization(self):
-        if hasattr(typing_extensions, "_SpecialGenericAlias"):
-            mod = typing_extensions
-        else:
-            mod = typing
-        class Foo: ...
-        Alias = mod._SpecialGenericAlias(Foo, 2)
-
-        msg = re.escape("Too few arguments for typing.Foo; actual 1, expected 2")
-        with self.assertRaisesRegex(TypeError, msg):
-            Alias[int]
-
-        msg = re.escape("Too many arguments for typing.Foo; actual 3, expected 2")
-        with self.assertRaisesRegex(TypeError, msg):
-            Alias[int, int, int]
-
-        Alias0 = mod._SpecialGenericAlias(Foo, 0)
-        msg = re.escape("typing.Foo is not a generic class")
-        with self.assertRaisesRegex(TypeError, msg):
-            Alias0[int]
-
 
 class TypeTests(BaseTestCase):
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7804,7 +7804,7 @@ class TypeVarLikeDefaultsTests(BaseTestCase):
         self.assertEqual(A[float, [range], int].__args__, (float, (range,), int))
 
 
-class TypedDictSentinelMixin:
+class SentinelTestsMixin:
     @skip_if_py313_beta_1
     def test_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -7839,7 +7839,7 @@ class TypedDictSentinelMixin:
             type(self.sentinel_type).foo
 
 
-class NoDefaultTests(TypedDictSentinelMixin, BaseTestCase):
+class NoDefaultTests(SentinelTestsMixin, BaseTestCase):
     sentinel_type = NoDefault
 
     def test_repr(self):
@@ -7850,7 +7850,7 @@ class NoDefaultTests(TypedDictSentinelMixin, BaseTestCase):
         self.assertEqual(repr(NoDefault), f"{mod_name}.NoDefault")
 
 
-class NoExtraItemsTests(TypedDictSentinelMixin, BaseTestCase):
+class NoExtraItemsTests(SentinelTestsMixin, BaseTestCase):
     sentinel_type = NoExtraItems
 
     def test_repr(self):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -5582,7 +5582,7 @@ class GetTypeHintsTests(BaseTestCase):
             BA2
         )
 
-    @skipUnless(sys.version_info >= (3, 11), "TODO: evaluate nested forward refs in Python < 3.11")
+    @skipUnless(TYPING_3_11_0, "TODO: evaluate nested forward refs in Python < 3.11")
     def test_get_type_hints_genericalias(self):
         def foobar(x: list['X']): ...
         X = Annotated[int, (1, 10)]

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -1925,6 +1925,9 @@ else:
         def __call__(self, *args, **kwargs):
             pass
 
+        def __init_subclass__(cls) -> None:
+            raise TypeError(f"type '{__name__}.ParamSpec' is not an acceptable base type")
+
 
 # 3.9
 if not hasattr(typing, 'Concatenate'):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -524,7 +524,9 @@ else:
 
 
     class _SpecialGenericAlias(typing._SpecialGenericAlias, _root=True):
-        def __init__(self, origin, nparams, *, inst=True, name=None, defaults=()):
+        def __init__(self, origin, nparams, *, defaults, inst=True, name=None):
+            assert nparams > 0, "`nparams` must be a positive integer"
+            assert defaults, "Must always specify a non-empty sequence for `defaults`"
             super().__init__(origin, nparams, inst=inst, name=name)
             self._defaults = defaults
 
@@ -542,20 +544,14 @@ else:
             msg = "Parameters to generic types must be types."
             params = tuple(typing._type_check(p, msg) for p in params)
             if (
-                self._defaults
-                and len(params) < self._nparams
+                len(params) < self._nparams
                 and len(params) + len(self._defaults) >= self._nparams
             ):
                 params = (*params, *self._defaults[len(params) - self._nparams:])
             actual_len = len(params)
 
             if actual_len != self._nparams:
-                if self._defaults:
-                    expected = f"at least {self._nparams - len(self._defaults)}"
-                else:
-                    expected = str(self._nparams)
-                if not self._nparams:
-                    raise TypeError(f"{self} is not a generic class")
+                expected = f"at least {self._nparams - len(self._defaults)}"
                 raise TypeError(
                     f"Too {'many' if actual_len > self._nparams else 'few'}"
                     f" arguments for {self};"


### PR DESCRIPTION
Add tests to exercise some previously unexercised lines:
* `_SpecialGenericAlias.__setattr__()` for non-dunder, non-"allowed" attributes ([src](https://github.com/python/typing_extensions/blob/98104053ea8d49bcdd247804e5fa9f73136acbd4/src/typing_extensions.py#L535-L536))
* Wrong number of type arguments given to a `_SpecialGenericAlias` from without defaults ([src](https://github.com/python/typing_extensions/blob/98104053ea8d49bcdd247804e5fa9f73136acbd4/src/typing_extensions.py#L556))
* Attempting to specialize a `_SpecialGenericAlias` with 0 type parameters ([src](https://github.com/python/typing_extensions/blob/98104053ea8d49bcdd247804e5fa9f73136acbd4/src/typing_extensions.py#L558))
* Setting `<thing>.__module__` on Python implementations that don't supply `sys._getframemodulename` or `sys._getframe` ([src](https://github.com/python/typing_extensions/blob/98104053ea8d49bcdd247804e5fa9f73136acbd4/src/typing_extensions.py#L622-L623))
* Calling `get_type_hints()` with `types.GenericAlias` ([src](https://github.com/python/typing_extensions/blob/98104053ea8d49bcdd247804e5fa9f73136acbd4/src/typing_extensions.py#L1454-L1457))
* Exception raised by `__init_subclass__()` of `ParamSpec` ([src](https://github.com/python/typing_extensions/blob/67d37fed1298e050f74d5acc95b2621bd37837ad/src/typing_extensions.py#L1825-L1826))
* The methods `__or__()` and `__ror__()` of `_SpecialForm` ([src](https://github.com/python/typing_extensions/blob/98104053ea8d49bcdd247804e5fa9f73136acbd4/src/typing_extensions.py#L259-L263))
* The methods `__repr__` and `__reduce__` of `NoExtraItems` (test case copied from `NoDefaultTests`) ([src](https://github.com/python/typing_extensions/blob/98104053ea8d49bcdd247804e5fa9f73136acbd4/src/typing_extensions.py#L1027-L1031))





