### PR TITLE
Coverage: increase percentage precision

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ known-first-party = ["typing_extensions", "_typed_dict_test_helper"]
 
 [tool.coverage.report]
 fail_under = 96
+precision = 1
 show_missing = true
 # Omit files that are created in temporary directories during tests.
 # If not explicitly omitted they will result in warnings in the report.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ known-first-party = ["typing_extensions", "_typed_dict_test_helper"]
 
 [tool.coverage.report]
 fail_under = 96
-precision = 1
+precision = 2
 show_missing = true
 # Omit files that are created in temporary directories during tests.
 # If not explicitly omitted they will result in warnings in the report.


### PR DESCRIPTION
Add some extra digits to the coverage percentages so that smaller changes are more visible.

This only affects what gets printed by `coverage` commands in the CI. The actual coverage measurements and the PR comment appearance are unaffected.

Sample: [before](https://github.com/python/typing_extensions/actions/runs/17210438936) [after](https://github.com/brianschubert/typing_extensions/actions/runs/17211209801)