### PR TITLE
Fix cross-references for `ParamSpecArgs`/`ParamSpecKwargs`

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -312,10 +312,9 @@ Special typing primitives
       with :py:class:`typing.ParamSpec` on Python 3.13+.
 
 .. class:: ParamSpecArgs
+           ParamSpecKwargs
 
-.. class:: ParamSpecKwargs
-
-   See :py:class:`typing.ParamSpecArgs` and :py:class:`typing.ParamSpecKwargs`.
+   See :py:data:`typing.ParamSpecArgs` and :py:data:`typing.ParamSpecKwargs`.
    In ``typing`` since 3.10.
 
 .. class:: Protocol


### PR DESCRIPTION
The current references to `typing.ParamSpec{Args,Kwargs}` don't generate links: https://typing-extensions.readthedocs.io/en/latest/#typing_extensions.ParamSpecKwargs

The [upstream docs](https://github.com/python/cpython/blob/98b4cd6fe9348ac24d5c72379393f4711d057d7e/Doc/library/typing.rst?plain=1#L2216-L2217) use `.. data::`, so I guess we need to use `:py:data:` here.

Also merge `ParamSpecArgs` and `ParamSpecKwargs` into one directive while we're here. This slightly improves the spacing but shouldn't otherwise affect the docs (in particular, links to either name will still work).