### PR TITLE
docs: enable nitpicky mode

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -56,6 +56,10 @@ html_sidebars = {
 # Don't include object entries (e.g. functions, classes) in the table of contents.
 toc_object_entries = False
 
+# Warn about all references where the target cannot be found.
+nitpicky = True
+
+
 class MyTranslator(HTML5Translator):
     """Adds a link target to name without `typing_extensions.` prefix."""
     def visit_desc_signature(self, node: Element) -> None:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -303,7 +303,7 @@ Special typing primitives
       ``default=None`` is passed, and to :data:`NoDefault` if no value is passed.
 
       Previously, passing ``None`` would result in :attr:`!__default__` being set
-      to :py:class:`types.NoneType`, and passing no value for the parameter would
+      to :py:data:`types.NoneType`, and passing no value for the parameter would
       result in :attr:`!__default__` being set to ``None``.
 
    .. versionchanged:: 4.12.0
@@ -470,7 +470,7 @@ Special typing primitives
 
       ``TypedDict`` is now a function rather than a class.
       This brings ``typing_extensions.TypedDict`` closer to the implementation
-      of :py:mod:`typing.TypedDict` on Python 3.9 and higher.
+      of :py:class:`typing.TypedDict` on Python 3.9 and higher.
 
    .. versionchanged:: 4.7.0
 
@@ -525,7 +525,7 @@ Special typing primitives
       ``default=None`` is passed, and to :data:`NoDefault` if no value is passed.
 
       Previously, passing ``None`` would result in :attr:`!__default__` being set
-      to :py:class:`types.NoneType`, and passing no value for the parameter would
+      to :py:data:`types.NoneType`, and passing no value for the parameter would
       result in :attr:`!__default__` being set to ``None``.
 
    .. versionchanged:: 4.12.0
@@ -556,7 +556,7 @@ Special typing primitives
       ``default=None`` is passed, and to :data:`NoDefault` if no value is passed.
 
       Previously, passing ``None`` would result in :attr:`!__default__` being set
-      to :py:class:`types.NoneType`, and passing no value for the parameter would
+      to :py:data:`types.NoneType`, and passing no value for the parameter would
       result in :attr:`!__default__` being set to ``None``.
 
    .. versionchanged:: 4.12.0
@@ -798,7 +798,7 @@ Functions
    * Raises :exc:`TypeError` when it encounters certain objects that are
      not valid type hints.
    * Replaces type hints that evaluate to :const:`!None` with
-     :class:`types.NoneType`.
+     :data:`types.NoneType`.
    * Supports the :attr:`Format.FORWARDREF` and
      :attr:`Format.STRING` formats.
 
@@ -1368,7 +1368,7 @@ versions of Python, but all are listed here for completeness.
 
 .. data:: Union
 
-   See :py:data:`typing.Union`.
+   See :py:class:`typing.Union`.
 
    .. versionadded:: 4.7.0
 


### PR DESCRIPTION
Sphinx has an option to warn about references missing targets, aka [nitpicky mode](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-nitpicky).

Enabling this mode in the docs build reveals the following warnings:
```text
.../typing_extensions/doc/index.rst:305: WARNING: py:class reference target not found: types.NoneType [ref.class]
.../typing_extensions/doc/index.rst:471: WARNING: py:mod reference target not found: typing.TypedDict [ref.mod]
.../typing_extensions/doc/index.rst:527: WARNING: py:class reference target not found: types.NoneType [ref.class]
.../typing_extensions/doc/index.rst:558: WARNING: py:class reference target not found: types.NoneType [ref.class]
.../typing_extensions/doc/index.rst:800: WARNING: py:class reference target not found: types.NoneType [ref.class]
.../typing_extensions/doc/index.rst:1371: WARNING: py:data reference target not found: typing.Union [ref.data]
```

Spot checks show that these hits are indeed missing links:
* https://typing-extensions.readthedocs.io/en/latest/#:~:text=types.NoneType
* https://typing-extensions.readthedocs.io/en/latest/#:~:text=closer%20to%20the%20implementation%20of-,typing.TypedDict
* https://typing-extensions.readthedocs.io/en/latest/#:~:text=typing.Union

This fixes those cross-references and leaves nitpicky mode enabled in `conf.py` to help catch similar issues going forward.