### PR TITLE
Expand protocol allowlist to match CPythons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Add support for `AsyncIterator`, `io.Reader`, `io.Writer` and `os.PathLike` protocols.
 - Fix incorrect behaviour on Python 3.9 and Python 3.10 that meant that
   calling `isinstance` with `typing_extensions.Concatenate[...]` or
   `typing_extensions.Unpack[...]` as the first argument could have a different

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-- Add support for `AsyncIterator`, `io.Reader`, `io.Writer` and `os.PathLike` protocols.
+- Add support for `AsyncIterator`, `io.Reader`, `io.Writer` and `os.PathLike` protocols
+  as bases for other protocls.
 - Fix incorrect behaviour on Python 3.9 and Python 3.10 that meant that
   calling `isinstance` with `typing_extensions.Concatenate[...]` or
   `typing_extensions.Unpack[...]` as the first argument could have a different

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -11,6 +11,7 @@ import inspect
 import io
 import itertools
 import pickle
+import os
 import re
 import subprocess
 import sys
@@ -3869,7 +3870,13 @@ class ProtocolTests(BaseTestCase):
             class CustomProtocol(TestCase, Protocol):
                 pass
 
+        class CustomPathLikeProtocol(os.PathLike, Protocol):
+            pass
+
         class CustomContextManager(typing.ContextManager, Protocol):
+            pass
+
+        class CustomAsyncIterator(typing.AsyncIterator, Protocol):
             pass
 
     @skip_if_py312b1

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7071,13 +7071,13 @@ class AllTests(BaseTestCase):
             }
         if sys.version_info < (3, 13):
             exclude |= {
-                'NamedTuple', 'Protocol', 'runtime_checkable', 'Generator',
+                'NamedTuple', 'runtime_checkable', 'Generator',
                 'AsyncGenerator', 'ContextManager', 'AsyncContextManager',
                 'ParamSpec', 'TypeVar', 'TypeVarTuple', 'get_type_hints',
             }
         if sys.version_info < (3, 14):
             exclude |= {
-                'TypeAliasType'
+                'TypeAliasType', 'Protocol'
             }
         if not typing_extensions._PEP_728_IMPLEMENTED:
             exclude |= {'TypedDict', 'is_typeddict'}

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -10,8 +10,8 @@ import importlib
 import inspect
 import io
 import itertools
-import pickle
 import os
+import pickle
 import re
 import subprocess
 import sys

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -614,10 +614,11 @@ else:
 _PROTO_ALLOWLIST = {
     'collections.abc': [
         'Callable', 'Awaitable', 'Iterable', 'Iterator', 'AsyncIterable',
-        'AsyncIterator','Hashable', 'Sized', 'Container', 'Collection',
-        'Reversible', 'Buffer'
+        'AsyncIterator', 'Hashable', 'Sized', 'Container', 'Collection',
+        'Reversible', 'Buffer',
     ],
     'contextlib': ['AbstractContextManager', 'AbstractAsyncContextManager'],
+    'io': ['Reader', 'Writer'],
     'typing_extensions': ['Buffer'],
     'os': ['PathLike'],
 }
@@ -655,8 +656,10 @@ def _caller(depth=1, default='__main__'):
 
 # `__match_args__` attribute was removed from protocol members in 3.13,
 # we want to backport this change to older Python versions.
-# Breakpoint: https://github.com/python/cpython/pull/110683
-if sys.version_info >= (3, 13):
+# 3.14 additionally added `io.Reader`, `io.Writer` and `os.PathLike` to
+# the list of allowed non-protocol bases.
+# https://github.com/python/cpython/issues/127647
+if sys.version_info >= (3, 14):
     Protocol = typing.Protocol
 else:
     def _allow_reckless_class_checks(depth=2):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -657,7 +657,7 @@ def _caller(depth=1, default='__main__'):
 # `__match_args__` attribute was removed from protocol members in 3.13,
 # we want to backport this change to older Python versions.
 # 3.14 additionally added `io.Reader`, `io.Writer` and `os.PathLike` to
-# the list of allowed non-protocol bases.
+# the list of allowed protocol allowlist.
 # https://github.com/python/cpython/issues/127647
 if sys.version_info >= (3, 14):
     Protocol = typing.Protocol

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -614,10 +614,12 @@ else:
 _PROTO_ALLOWLIST = {
     'collections.abc': [
         'Callable', 'Awaitable', 'Iterable', 'Iterator', 'AsyncIterable',
-        'Hashable', 'Sized', 'Container', 'Collection', 'Reversible', 'Buffer',
+        'AsyncIterator','Hashable', 'Sized', 'Container', 'Collection',
+        'Reversible', 'Buffer'
     ],
     'contextlib': ['AbstractContextManager', 'AbstractAsyncContextManager'],
     'typing_extensions': ['Buffer'],
+    'os': ['PathLike'],
 }
 
 


### PR DESCRIPTION
Discovered by running the CPython 3.12 test_typing.py over typing_extensions.

https://github.com/JanEricNitschke/typing_extensions/actions/runs/17633620675/job/50105726688#step:7:38

Originally failing test: https://github.com/python/cpython/blob/3.12/Lib/test/test_typing.py#L4047

Current situation in 3.14: https://github.com/python/cpython/blob/3.14/Lib/test/test_typing.py#L4373

And the current allow list: https://github.com/python/cpython/blob/main/Lib/typing.py#L1894