### PR TITLE
Ensure init called in protocol subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Fix `__init__` in subclasses of protocols.
 - Fix incorrect behaviour on Python 3.9 and Python 3.10 that meant that
   calling `isinstance` with `typing_extensions.Concatenate[...]` or
   `typing_extensions.Unpack[...]` as the first argument could have a different

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-- Fix `__init__` in subclasses of protocols.
+- Non-protocol subclasses of `Protocol` ignore now the
+  `__init__` method inherited from protocol base classes.
 - Fix incorrect behaviour on Python 3.9 and Python 3.10 that meant that
   calling `isinstance` with `typing_extensions.Concatenate[...]` or
   `typing_extensions.Unpack[...]` as the first argument could have a different

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -664,10 +664,6 @@ else:
         """
         return _caller(depth) in {'abc', 'functools', None}
 
-    def _no_init(self, *args, **kwargs):
-        if type(self)._is_protocol:
-            raise TypeError('Protocols cannot be instantiated')
-
     def _type_check_issubclass_arg_1(arg):
         """Raise TypeError if `arg` is not an instance of `type`
         in `issubclass(arg, <protocol>)`.
@@ -831,7 +827,7 @@ else:
 
             # Prohibit instantiation for protocol classes
             if cls._is_protocol and cls.__init__ is Protocol.__init__:
-                cls.__init__ = _no_init
+                cls.__init__ = typing._no_init_or_replace_init
 
 
 # Breakpoint: https://github.com/python/cpython/pull/113401


### PR DESCRIPTION
Discovered through CPython 3.12 test_typing.py: https://github.com/JanEricNitschke/typing_extensions/actions/runs/17639167194/job/50121940225#step:7:36

Tests are from here:
- https://github.com/python/cpython/pull/27545
- https://github.com/python/cpython/pull/28121
- https://github.com/python/cpython/pull/28121

Code is from current CPython: 
- https://github.com/python/cpython/blob/main/Lib/typing.py#L1843
- https://github.com/python/cpython/blob/main/Lib/typing.py#L2121