### PR TITLE
Fix error message when subclassing TypeVarTuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Fix error message when trying to subclass `typing_extensions.TypeVarTuple`.
 - Fix incorrect behaviour on Python 3.9 and Python 3.10 that meant that
   calling `isinstance` with `typing_extensions.Concatenate[...]` or
   `typing_extensions.Unpack[...]` as the first argument could have a different

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
-- Fix error message when trying to subclass `typing_extensions.TypeVarTuple`.
+- Update error message when attempting to subclass `typing_extensions.TypeVarTuple`
+  to align with the message produced by `typing` in Python 3.12+.
+  Patch by Jan-Eric Nitschke.
 - Fix incorrect behaviour on Python 3.9 and Python 3.10 that meant that
   calling `isinstance` with `typing_extensions.Concatenate[...]` or
   `typing_extensions.Unpack[...]` as the first argument could have a different

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6809,12 +6809,11 @@ class TypeVarTupleTests(BaseTestCase):
             class F(type(*Ts)): pass
         with self.assertRaisesRegex(TypeError, CANNOT_SUBCLASS_TYPE):
             class G(type(Unpack[Ts])): pass
-        with self.assertRaisesRegex(TypeError,
-                                    r'Cannot subclass (typing|typing_extensions)\.Unpack'):
+        with self.assertRaises(TypeError):
             class H(Unpack): pass
-        with self.assertRaisesRegex(TypeError, r'Cannot subclass (typing|typing_extensions)\.Unpack\[Ts\]'):
+        with self.assertRaises(TypeError):
             class I(*Ts): pass  # noqa: E742
-        with self.assertRaisesRegex(TypeError, r'Cannot subclass (typing|typing_extensions)\.Unpack\[Ts\]'):
+        with self.assertRaises(TypeError):
             class J(Unpack[Ts]): pass
 
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6813,7 +6813,7 @@ class TypeVarTupleTests(BaseTestCase):
                                     r'Cannot subclass typing\.Unpack'):
             class H(Unpack): pass
         with self.assertRaisesRegex(TypeError, r'Cannot subclass typing.Unpack\[Ts\]'):
-            class I(*Ts): pass
+            class I(*Ts): pass  # noqa: E742
         with self.assertRaisesRegex(TypeError, r'Cannot subclass typing.Unpack\[Ts\]'):
             class J(Unpack[Ts]): pass
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -110,6 +110,10 @@ T = TypeVar("T")
 KT = TypeVar("KT")
 VT = TypeVar("VT")
 
+CANNOT_SUBCLASS_TYPE = 'Cannot subclass special typing classes'
+NOT_A_BASE_TYPE = r"type '(?:typing|typing_extensions).%s' is not an acceptable base type"
+CANNOT_SUBCLASS_INSTANCE = 'Cannot subclass an instance of %s'
+
 # Flags used to mark tests that only apply after a specific
 # version of the typing module.
 TYPING_3_10_0 = sys.version_info[:3] >= (3, 10, 0)
@@ -6791,6 +6795,27 @@ class TypeVarTupleTests(BaseTestCase):
                 z = pickle.loads(pickle.dumps(typevartuple, proto))
                 self.assertEqual(z.__name__, typevartuple.__name__)
                 self.assertEqual(z.__default__, typevartuple.__default__)
+
+    def test_cannot_subclass(self):
+        with self.assertRaisesRegex(TypeError, NOT_A_BASE_TYPE % 'TypeVarTuple'):
+            class C(TypeVarTuple): pass
+        Ts = TypeVarTuple('Ts')
+        with self.assertRaisesRegex(TypeError,
+                CANNOT_SUBCLASS_INSTANCE % 'TypeVarTuple'):
+            class D(Ts): pass
+        with self.assertRaisesRegex(TypeError, CANNOT_SUBCLASS_TYPE):
+            class E(type(Unpack)): pass
+        with self.assertRaisesRegex(TypeError, CANNOT_SUBCLASS_TYPE):
+            class F(type(*Ts)): pass
+        with self.assertRaisesRegex(TypeError, CANNOT_SUBCLASS_TYPE):
+            class G(type(Unpack[Ts])): pass
+        with self.assertRaisesRegex(TypeError,
+                                    r'Cannot subclass typing\.Unpack'):
+            class H(Unpack): pass
+        with self.assertRaisesRegex(TypeError, r'Cannot subclass typing.Unpack\[Ts\]'):
+            class I(*Ts): pass
+        with self.assertRaisesRegex(TypeError, r'Cannot subclass typing.Unpack\[Ts\]'):
+            class J(Unpack[Ts]): pass
 
 
 class FinalDecoratorTests(BaseTestCase):

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6810,11 +6810,11 @@ class TypeVarTupleTests(BaseTestCase):
         with self.assertRaisesRegex(TypeError, CANNOT_SUBCLASS_TYPE):
             class G(type(Unpack[Ts])): pass
         with self.assertRaisesRegex(TypeError,
-                                    r'Cannot subclass typing\.Unpack'):
+                                    r'Cannot subclass (typing|typing_extensions)\.Unpack'):
             class H(Unpack): pass
-        with self.assertRaisesRegex(TypeError, r'Cannot subclass typing.Unpack\[Ts\]'):
+        with self.assertRaisesRegex(TypeError, r'Cannot subclass (typing|typing_extensions)\.Unpack\[Ts\]'):
             class I(*Ts): pass  # noqa: E742
-        with self.assertRaisesRegex(TypeError, r'Cannot subclass typing.Unpack\[Ts\]'):
+        with self.assertRaisesRegex(TypeError, r'Cannot subclass (typing|typing_extensions)\.Unpack\[Ts\]'):
             class J(Unpack[Ts]): pass
 
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2637,7 +2637,9 @@ elif hasattr(typing, "TypeVarTuple"):  # 3.11+
             return tvt
 
         def __init_subclass__(self, *args, **kwds):
-            raise TypeError("Cannot subclass special typing classes")
+            raise TypeError(
+                f"type '{__name__}.TypeVarTuple' is not an acceptable base type"
+            )
 
 else:  # <=3.10
     class TypeVarTuple(_DefaultMixin):

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2635,7 +2635,7 @@ elif hasattr(typing, "TypeVarTuple"):  # 3.11+
 
             tvt.__typing_prepare_subst__ = _typevartuple_prepare_subst
 
-            def __mro_entries__(self, bases):
+            def __mro_entries__(bases):
                 raise TypeError("Cannot subclass an instance of TypeVarTuple.")
             tvt.__mro_entries__ =  __mro_entries__
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2637,7 +2637,7 @@ elif hasattr(typing, "TypeVarTuple"):  # 3.11+
 
             def __mro_entries__(bases):
                 raise TypeError("Cannot subclass an instance of TypeVarTuple.")
-            tvt.__mro_entries__ =  __mro_entries__
+            tvt.__mro_entries__ = __mro_entries__
 
             return tvt
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -2634,12 +2634,18 @@ elif hasattr(typing, "TypeVarTuple"):  # 3.11+
                 )
 
             tvt.__typing_prepare_subst__ = _typevartuple_prepare_subst
+
+            def __mro_entries__(self, bases):
+                raise TypeError("Cannot subclass an instance of TypeVarTuple.")
+            tvt.__mro_entries__ =  __mro_entries__
+
             return tvt
 
         def __init_subclass__(self, *args, **kwds):
             raise TypeError(
                 f"type '{__name__}.TypeVarTuple' is not an acceptable base type"
             )
+
 
 else:  # <=3.10
     class TypeVarTuple(_DefaultMixin):
@@ -2717,7 +2723,12 @@ else:  # <=3.10
 
         def __init_subclass__(self, *args, **kwds):
             if '_root' not in kwds:
-                raise TypeError("Cannot subclass special typing classes")
+                raise TypeError(
+                    f"type '{__name__}.TypeVarTuple' is not an acceptable base type"
+                )
+
+        def __mro_entries__(self, bases):
+            raise TypeError("Cannot subclass an instance of TypeVarTuple.")
 
 
 if hasattr(typing, "reveal_type"):  # 3.11+


### PR DESCRIPTION
Issue discovered by running CPython 3.12 test_typing.py on typing_extensions: https://github.com/JanEricNitschke/typing_extensions/actions/runs/17692936537/job/50288896717#step:7:120

Test from here: https://github.com/python/cpython/blob/main/Lib/test/test_typing.py#L1526

Regex from here (adjusted to also handle typing_extensions): https://github.com/python/cpython/blob/main/Lib/test/test_typing.py#L61