### PR TITLE
Drop typed-argument-parser 3.9 tests, add 3.14

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -381,6 +381,7 @@ jobs:
       - mypy
       - cattrs
       - sqlalchemy
+      - litestar
 
     if: >-
         ${{


### PR DESCRIPTION
Fixes #689.

3.9 is about to lose support and typed-argument-parser evidently already dropped support.

I took the opportunity to add 3.14 to all the third-party tests now that 3.14.0 is out, but had to disable a few that don't pass yet. I also added a missing line of code for litestar.