### PR TITLE
Failing pre-commit: Remove *removed* ruff rule UP038

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ ignore = [
     "UP014",
     "UP019",
     "UP035",
-    "UP038",
     "UP045",  # X | None instead of Optional[X]
     # Not relevant here
     "RUF012",  # Use ClassVar for mutables


### PR DESCRIPTION
With [Ruff 0.13.0 ](https://github.com/astral-sh/ruff/releases/tag/0.13.0) rule UP038 was removed.

I could recreate the current pre-commit errors from #690.

Still had to do a `pre-commit clean` first. Removing the old rule fixes the error from `validate-pyproject`.