### PR TITLE
Drop 3.9 third-party tests

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -46,7 +46,8 @@ jobs:
         # PyPy is deliberately omitted here,
         # since pydantic's tests intermittently segfault on PyPy,
         # and it's nothing to do with typing_extensions
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # Tests on 3.14 don't pass as of 2 November 2025
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -186,7 +187,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # 3.9 is no longer supported. 3.14 fails some tests as of 2 November 2025
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -228,7 +230,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # 3.14 fails a test as of 2 November 2025
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -335,7 +338,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        # As of 2 November 2025 a dependency is missing 3.14 wheels
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
     steps:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41  # v7.1.2


### PR DESCRIPTION
Also try to see if any of the previously failing 3.14 tests started working.

Fixes #693.
