### PR TITLE
Fix Pydantic third-party test

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -65,9 +65,8 @@ jobs:
       - name: Run tests with typing_extensions main branch
         working-directory: pydantic
         run: |
-          uv sync --all-packages --group dev
-          uv pip uninstall typing-extensions
-          uv pip install --editable ../typing-extensions-latest
+          uv add --editable ../typing-extensions-latest
+          uv sync --all-packages --group testing-extra --all-extras
 
           printf "\n\nINSTALLED DEPENDENCIES ARE:\n\n"
           uv pip list


### PR DESCRIPTION
Part of https://github.com/python/typing_extensions/issues/696. We recently merged `pydantic-core` inside the pydantic repo, and it is now a workspace member.