### PR TITLE
Implement sentinels as types, support isinstance and match statments

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1056,10 +1056,13 @@ Capsule objects
 Sentinel objects
 ~~~~~~~~~~~~~~~~
 
-.. class:: Sentinel(name, repr=None)
+.. class:: Sentinel(name, module_name=None, *, repr=None)
 
    A type used to define sentinel values. The *name* argument should be the
    name of the variable to which the return value shall be assigned.
+
+   *module_name* is the module where the sentinel is defined.
+   Defaults to the current modules ``__name__``.
 
    If *repr* is provided, it will be used for the :meth:`~object.__repr__`
    of the sentinel object. If not provided, ``"<name>"`` will be used.
@@ -1075,6 +1078,13 @@ Sentinel objects
       ...         assert_type(arg, int)
       ...
       >>> func(MISSING)
+
+   Sentinels defined inside a class scope should use a :term:`qualified name`.
+
+   Example::
+
+      >>> class MyClass:
+      ...     MISSING = Sentinel('MyClass.MISSING')
 
    .. versionadded:: 4.14.0
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1067,17 +1067,28 @@ Sentinel objects
    If *repr* is provided, it will be used for the :meth:`~object.__repr__`
    of the sentinel object. If not provided, ``"<name>"`` will be used.
 
+   Sentinels can be tested using :ref:`is`, :func:`isinstance`,
+   or :ref:`match`.
+
    Example::
 
       >>> from typing_extensions import Sentinel, assert_type
       >>> MISSING = Sentinel('MISSING')
-      >>> def func(arg: int | MISSING = MISSING) -> None:
+      >>> def check_identity(arg: int | MISSING = MISSING) -> None:
       ...     if arg is MISSING:
       ...         assert_type(arg, MISSING)
       ...     else:
       ...         assert_type(arg, int)
       ...
-      >>> func(MISSING)
+      >>> check_identity(MISSING)
+      >>> def check_match(arg: int | MISSING = MISSING) -> None:
+      ...     match arg:
+      ...         case MISSING():
+      ...             assert_type(arg, MISSING)
+      ...         case int()
+      ...             assert_type(arg, int)
+      ...
+      >>> check_match(MISSING)
 
    Sentinels defined inside a class scope should use a :term:`qualified name`.
 

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -9546,8 +9546,10 @@ class TestSentinels(BaseTestCase):
     def test_sentinel_no_repr(self):
         sentinel_no_repr = Sentinel('sentinel_no_repr')
 
-        self.assertEqual(sentinel_no_repr._name, 'sentinel_no_repr')
+        self.assertEqual(sentinel_no_repr.__name__, 'sentinel_no_repr')
         self.assertEqual(repr(sentinel_no_repr), '<sentinel_no_repr>')
+
+        self.assertEqual(repr(Sentinel), "<class 'typing_extensions.Sentinel'>")
 
     def test_sentinel_explicit_repr(self):
         sentinel_explicit_repr = Sentinel('sentinel_explicit_repr', repr='explicit_repr')
@@ -9568,7 +9570,7 @@ class TestSentinels(BaseTestCase):
         sentinel = Sentinel('sentinel')
         with self.assertRaisesRegex(
             TypeError,
-            "'Sentinel' object is not callable"
+            f"Sentinel object {re.escape(repr(sentinel))} is not callable"
         ):
             sentinel()
 
@@ -9592,6 +9594,21 @@ class TestSentinels(BaseTestCase):
                 r"attribute lookup anonymous_sentinel on \w+ failed|not found as \w+.anonymous_sentinel"
             ):
                 self.assertIs(anonymous_sentinel, pickle.loads(pickle.dumps(anonymous_sentinel, protocol=proto)))
+
+    def test_sentinel_isinstance(self):
+        anonymous_sentinel = Sentinel("anonymous_sentinel")
+        self.assertIsInstance(self.SENTINEL, self.SENTINEL)
+        self.assertIsInstance(anonymous_sentinel, anonymous_sentinel)
+        self.assertNotIsInstance(self.SENTINEL, anonymous_sentinel)
+
+        self.assertIsInstance(self.SENTINEL, object)
+        self.assertIsInstance(self.SENTINEL, type)
+        self.assertNotIsInstance(self.SENTINEL, Sentinel)
+
+        self.assertIsSubclass(self.SENTINEL, object)
+        self.assertIsSubclass(self.SENTINEL, Sentinel)
+        self.assertIsSubclass(self.SENTINEL, self.SENTINEL)
+        self.assertNotIsSubclass(self.SENTINEL, anonymous_sentinel)
 
 def load_tests(loader, tests, pattern):
     import doctest


### PR DESCRIPTION
Two main things here:
- The Sentinel class now uses the builtin `type` function to dynamically generate new sentinel types.
- The new meta class `_SentinelMeta` is setup so that sentinels can be used with themselves in `isinstance` checks.

This new type logic ended up being simpler than the workarounds required to make sentinels pretend they are types so I ended up removing those workarounds. I'm not fully experienced with their usage but they were covered by tests.

This PR is based on #617 so `repr` being made a keyword parameter is included. With sentinels being types now it's more important to get `__module__` correct anyways. Pickle is supported and tested.

`self.__name__` takes the place of `self._name` now that sentinels are types.

Updated documentation for sentinels, in addition to #617 it now explains `isinstance` and `match` statements.

Improved the error message for calling a sentinel to include the name of the sentinel.

`isinstance(MySentinel, typing_extensions.Sentinel)` currently returns `False`, but that can be changed in `__instancecheck__` if necessary.

Relevant documentation:
- [metaclasses](https://docs.python.org/3/reference/datamodel.html#metaclasses)
- [`__instancecheck__`](https://docs.python.org/3/reference/datamodel.html#type.__instancecheck__)
- [`type` function](https://docs.python.org/3/library/functions.html#type)

Closes #720