### PR TITLE
docs: add security implications of annotations

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -815,6 +815,11 @@ Functions
    *format* specifies the format of the annotation and is a member of
    the :class:`Format` enum, defaulting to :attr:`Format.VALUE`.
 
+   .. caution::
+
+      This function may execute arbitrary code contained in annotations.
+      See :ref:`annotations-security` for more information.
+
    .. versionadded:: 4.13.0
 
 .. function:: get_annotations(obj, *, globals=None, locals=None, eval_str=False, format=Format.VALUE)
@@ -833,6 +838,11 @@ Functions
    want to support earlier Python versions, to simply write::
 
       typing_extensions.get_annotations(obj, format=Format.FORWARDREF)
+
+   .. caution::
+
+      This function may execute arbitrary code contained in annotations.
+      See :ref:`annotations-security` for more information.
 
    .. versionadded:: 4.13.0
 
@@ -900,6 +910,11 @@ Functions
    In Python 3.11, this function was changed to support the new
    :py:data:`typing.Required` and :py:data:`typing.NotRequired`.
    ``typing_extensions`` backports these fixes.
+
+   .. caution::
+
+      This function may execute arbitrary code contained in annotations.
+      See :ref:`annotations-security` for more information.
 
    .. versionchanged:: 4.1.0
 
@@ -1415,3 +1430,25 @@ If you have any feedback on our security process, please `open an issue
 <https://github.com/python/typing_extensions/issues/new>`__. To report
 an issue privately, use `GitHub's private reporting feature
 <https://github.com/python/typing_extensions/security>`__.
+
+.. _annotations-security:
+
+Introspection of annotations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some functions in this module are designed to introspect annotations at
+runtime. These functions may therefore execute code contained in annotations,
+which can then perform arbitrary operations. For example,
+:func:`get_annotations` may call an arbitrary :term:`annotate function`, and
+:meth:`evaluate_forward_ref` may call :func:`eval` on an arbitrary string. Code contained
+in an annotation might make arbitrary system calls, enter an infinite loop, or perform any
+other operation. This is also true for any access of the :attr:`~object.__annotations__` attribute
+(as of Python 3.14),
+and for various functions in the :mod:`typing` module that work with annotations, such as
+:func:`typing.get_type_hints`.
+
+Any security issue arising from this also applies immediately after importing
+code that may contain untrusted annotations: importing code can always cause arbitrary operations
+to be performed. However, it is unsafe to accept strings or other input from an untrusted source and
+pass them to any of the APIs for introspecting annotations, for example by editing an
+``__annotations__`` dictionary or directly creating a :class:`ForwardRef` object.


### PR DESCRIPTION
I received a report alleging that the use of `eval()` here is a security vulnerability. There is a caution about this already in the stdlib at https://docs.python.org/3.14/library/annotationlib.html#security-implications-of-introspecting-annotations but I suppose we should put it in the typing-extensions docs too.