### PR TITLE
link to failing run directly from the issue when the daily test fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,5 +130,5 @@ jobs:
               owner: "python",
               repo: "typing_extensions",
               title: `Daily tests failed on ${new Date().toDateString()}`,
-              body: "Runs listed here: https://github.com/python/typing_extensions/actions/workflows/ci.yml",
+              body: "Run listed here: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
             })


### PR DESCRIPTION
We already do this for the third-party workflow but forgot to apply the same change to this workflow. X-ref https://github.com/python/typing_extensions/issues/751, where the bot unhelpfully just pasted a link to all runs of that workflow rather than specifically the run that caused the failure