### PR TITLE
Fix tests on PyPy3.11+

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7443,7 +7443,7 @@ class NamedTupleTests(BaseTestCase):
 
     def test_same_as_typing_NamedTuple(self):
         self.assertEqual(
-            set(dir(NamedTuple)) - {"__text_signature__"},
+            set(dir(NamedTuple)),
             set(dir(typing.NamedTuple))
         )
         self.assertIs(type(NamedTuple), type(typing.NamedTuple))


### PR DESCRIPTION
PyPy made a recent change that exposes a `__text_signature__` attribute on all functions: https://github.com/pypy/pypy/commit/d3fba0e2e881731b900056cb224a1239a8ba14c3. That broke this test, which assumed that `typing_extensions.NamedTuple` would define `__text_signature__` but `typing.NamedTuple` would not. But `typing_extensions.NamedTuple` itself hasn't defined `__text_signature__` for a while, so the special-casing of `__text_signature__` here is outdated. We can fix the PyPy failure by just simplifying the test and getting rid of the special casing.

Fixes https://github.com/python/typing_extensions/issues/751