### PR TITLE
Update codecov action to 7.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           python -c 'import typing_extensions; import test.__main__' test_typing -v
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
+        uses: codecov/codecov-action@v7.0.0
         if: >-
           github.repository == 'python/typing_extensions'
           && (github.event_name == 'push' || github.event_name == 'pull_request')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           python -c 'import typing_extensions; import test.__main__' test_typing -v
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         if: >-
           github.repository == 'python/typing_extensions'
           && (github.event_name == 'push' || github.event_name == 'pull_request')


### PR DESCRIPTION
This should fix CI. The tag is immutable, so should be fine to use: https://github.com/codecov/codecov-action/releases/tag/v7.0.0