### PR TITLE
Pin SQLAlchemy third-party tests to pytest==9.0.3

### DIFF
--- a/.github/workflows/third_party.yml
+++ b/.github/workflows/third_party.yml
@@ -324,10 +324,10 @@ jobs:
         working-directory: sqlalchemy
         run: |
           set -x
-
+          # TODO: Remove pytest==9.0.3 pin. SQLAlchemy tests fail when using pytest 9.1.0. See #764.
           uvx \
             --with=setuptools \
-            tox -e github-nocext --force-dep="typing-extensions @ file://$(pwd)/../typing-extensions-latest" -- -q --nomemory --notimingintensive
+            tox -e github-nocext --override "testenv:github-nocext.deps+=pytest==9.0.3" --force-dep="typing-extensions @ file://$(pwd)/../typing-extensions-latest" -- -q --nomemory --notimingintensive
 
 
   litestar:


### PR DESCRIPTION
Fixes #764

For whatever reason, the SQLAlchemy tests fail when using the newly released pytest [v9.1.0](https://github.com/pytest-dev/pytest/releases/tag/9.1.0). Pinning pytest to v9.0.3 seems to fix things.

It looks like SQLAlchemy's CI is still using v9.0.3 ([example from recent run](https://github.com/sqlalchemy/sqlalchemy/actions/runs/27436600104/job/81100027407#step:5:39)), so this hasn't affected them yet. I'm guessing they'll start seeing the same failures when their CI updates to v9.1.0.