### PR TITLE
Post-release followups for 4.16.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fix setting of `__required_keys__` and `__optional_keys__` when inheriting
   keys with the same name.
 - Add support for `AsyncIterator`, `io.Reader`, `io.Writer` and `os.PathLike` protocols
-  as bases for other protocls.
+  as bases for other protocols.
 - Fix incorrect behaviour on Python 3.9 and Python 3.10 that meant that
   calling `isinstance` with `typing_extensions.Concatenate[...]` or
   `typing_extensions.Unpack[...]` as the first argument could have a different
@@ -20,7 +20,22 @@
   Python 3.9. The `typing` implementation has always raised an error, and the
   `typing_extensions` implementation has raised an error on Python 3.10+ since
   `typing_extensions` v4.6.0. Patch by Brian Schubert.
-- Add `bound` and variance parameters to `TypeVarTuple`.
+- Add the `bound`, `covariant`, `contravariant`, and `infer_variance` parameters
+  to `TypeVarTuple`.
+- Officially support the `bound`, `covariant`, `contravariant` and `infer_variance`
+  parameters to `ParamSpec`. Improve the validation of these parameters at runtime.
+- Rename `typing_extensions.Sentinel` to `typing_extensions.sentinel`, following the
+  name that has been adopted for `builtins.sentinel` on Python 3.15.
+  `typing_extensions.Sentinel` is retained as a soft-deprecated alias for backwards
+  compatibility.
+- Add support for pickling sentinels.
+- Sentinels now preserve their identity when copied or deep-copied.
+- Deprecate passing `name` as a keyword argument or `repr` as a positional argument
+  to the `sentinel` constructor.
+- The default repr of a sentinel `X = sentinel("X")` is now `X` rather than `<X>`.
+- Deprecate arbitrary attribute assignments to sentinels.
+- Deprecate subclassing sentinels.
+- Add support for Python 3.15.
 
 # Release 4.15.0 (August 25, 2025)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,8 @@ pipx run pre-commit run -a
 
 - Ensure that GitHub Actions reports no errors.
 
+- Check that `CHANGELOG.md` accurately reflects all important changes committed to `main` since the previous release.
+
 - Update the version number in `typing_extensions/pyproject.toml` and in
   `typing_extensions/CHANGELOG.md`.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1301,7 +1301,7 @@ Sentinel objects
         than `<X>`.
       - Passing `repr` as a positional argument to the constructor is deprecated.
       - Passing `name` as a keyword argument to the constructor is deprecated.
-      - Subclassing a sentinel is deprecated.
+      - Subclassing `sentinel` is deprecated.
       - Assigning arbitrary attributes to a sentinel is deprecated.
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -267,9 +267,9 @@ Python version in which each feature was added to :py:mod:`typing` and the
      - 3.11
      - 4.0.0
      - :pep:`673`
-   * - :class:`Sentinel`
-     - 3.14
-     - 4.14.0
+   * - :class:`sentinel`
+     - 3.15
+     - 4.14.0 (originally under the name `Sentinel`)
      - :pep:`661`
    * - :class:`TypeAliasType`
      - 3.12
@@ -453,13 +453,13 @@ Special typing primitives
 
    .. versionadded:: 4.0.0
 
-.. class:: ParamSpec(name, *, default=NoDefault)
+.. class:: ParamSpec(name, *, bound=None, covariant=False,
+                     contravariant=False, infer_variance=False, default=NoDefault)
 
    See :py:class:`typing.ParamSpec` and :pep:`612`. In ``typing`` since 3.10.
 
    The ``typing_extensions`` version adds support for the
-   ``default=`` argument from :pep:`696`, and for the ``infer_variance=``,
-   ``covariant=`` and ``contravariant=`` arguments that were added in Python 3.15.
+   ``default=`` argument from :pep:`696`.
 
    On older Python versions, ``typing_extensions.ParamSpec`` may not work
    correctly with introspection tools like :func:`get_args` and
@@ -495,7 +495,8 @@ Special typing primitives
 
    .. versionchanged:: 4.16.0
 
-      The ``infer_variance``, ``covariant``, and ``contravariant`` arguments are now supported.
+      The ``infer_variance``, ``covariant``, and ``contravariant`` arguments are now
+      officially supported and their validation is improved.
 
 .. class:: ParamSpecArgs
            ParamSpecKwargs
@@ -719,13 +720,14 @@ Special typing primitives
       TypeVars now have a ``has_default()`` method, for compatibility
       with :py:class:`typing.TypeVar` on Python 3.13+.
 
-.. class:: TypeVarTuple(name, *, default=NoDefault)
+.. class:: TypeVarTuple(name, *, bound=None, covariant=False,
+                        contravariant=False, infer_variance=False, default=NoDefault)
 
    See :py:class:`typing.TypeVarTuple` and :pep:`646`. In ``typing`` since 3.11.
 
-   The ``typing_extensions`` version adds support for the
-   ``default=`` argument from :pep:`696`, and for the ``infer_variance=``,
-   ``covariant=`` and ``contravariant=`` arguments that were added in Python 3.15.
+   The ``typing_extensions`` version adds support for the ``default=`` argument
+   from :pep:`696`, and for the ``bound=``, ``infer_variance=``, ``covariant=``
+   and ``contravariant=`` arguments that were added in Python 3.15.
 
    .. versionadded:: 4.1.0
 
@@ -759,7 +761,8 @@ Special typing primitives
 
    .. versionchanged:: 4.16.0
 
-      The ``infer_variance``, ``covariant``, and ``contravariant`` arguments are now supported.
+      The ``bound``, ``infer_variance``, ``covariant``, and ``contravariant``
+      arguments are now supported.
 
 .. data:: Unpack
 
@@ -1288,14 +1291,18 @@ Sentinel objects
    .. versionchanged:: 4.16.0
 
       The implementation of this class has been updated to conform to
-      the accepted version of :pep:`661`.
+      the accepted version of :pep:`661`:
 
-      Now supports pickle and will be reduced as a singleton.
-      Renamed from `Sentinel` to `sentinel`, `Sentinel` is deprecated.
-      Automatic `repr` string no longer has angle brackets.
-      `repr` as a positional argument is deprecated.
-      `name` as a keyword is deprecated.
-      Subclassing and attribute assignment are deprecated.
+      - Sentinels can now be pickled. They are reduced as singletons, which
+        means that they also preserve their identity when copied or deep-copied.
+      - `Sentinel` has been renamed to `sentinel`. `Sentinel` is retained as a
+        soft-deprecated alias, for backwards compatibility.
+      - The default repr of a sentinel `X = sentinel("X")` is now `X`, rather
+        than `<X>`.
+      - Passing `repr` as a positional argument to the constructor is deprecated.
+      - Passing `name` as a keyword argument to the constructor is deprecated.
+      - Subclassing a sentinel is deprecated.
+      - Assigning arbitrary attributes to a sentinel is deprecated.
 
 
 Pure aliases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit_core.buildapi"
 # Project metadata
 [project]
 name = "typing_extensions"
-version = "4.16.0rc1"
+version = "4.16.0rc1.dev"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -40,6 +40,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: Software Development",
 ]
 


### PR DESCRIPTION
- Add some missing things from the changelog w.r.t. things we changed between 4.15 and 4.16.0rc1
- Spruce up a few details in the docs regarding things we changed between 4.15 and 4.16.0rc1
- Officially declare support for Python 3.15 in `pyproject.toml`
- Add a note to `CONTRIBUTING.md` reminding future maintainers to check the CHANGELOG before releasing things
- Bump the version in pyproject.toml to 4.16.0rc1.dev, per the CONTRIBUTING guidelines here: https://github.com/python/typing_extensions/blob/main/CONTRIBUTING.md#workflow-for-pypi-releases

I'll edit the changelog updates here into the GitHub release after this PR lands.