### PR TITLE
Remove use of `asyncio.coroutines.iscoroutinefunction()`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           cd src
           python --version  # just to make sure we're running the right one
           # Run tests under coverage
-          python -m coverage run -m unittest test_typing_extensions.py
+          python -We -m coverage run -m unittest test_typing_extensions.py
           # Create xml file for Codecov
           coverage xml --rcfile=../pyproject.toml --fail-under=0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Avoid a `DeprecationWarning` when applying `deprecated` to a coroutine function on
+  Python 3.14.0.
+
 # Release 4.16.0rc1 (June 24, 2026)
 
 - Make `typing_extensions.TypeAliasType`'s `__module__` attribute writable.

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -3130,7 +3130,6 @@ else:
                 __init_subclass__.__deprecated__ = msg
                 return arg
             elif callable(arg):
-                import asyncio.coroutines
                 import functools
                 import inspect
 
@@ -3139,11 +3138,13 @@ else:
                     warnings.warn(msg, category=category, stacklevel=stacklevel + 1)
                     return arg(*args, **kwargs)
 
-                if asyncio.coroutines.iscoroutinefunction(arg):
+                if inspect.iscoroutinefunction(arg):
                     # Breakpoint: https://github.com/python/cpython/pull/99247
                     if sys.version_info >= (3, 12):
                         wrapper = inspect.markcoroutinefunction(wrapper)
                     else:
+                        import asyncio.coroutines
+
                         wrapper._is_coroutine = asyncio.coroutines._is_coroutine
 
                 arg.__deprecated__ = wrapper.__deprecated__ = msg


### PR DESCRIPTION
Fixes https://github.com/python/typing_extensions/issues/747.

If we land this, I'll cut a new rc release, out of an abundance of caution