### PR TITLE
Bump version to 4.16.0rc2.dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit_core.buildapi"
 # Project metadata
 [project]
 name = "typing_extensions"
-version = "4.16.0rc2"
+version = "4.16.0rc2.dev"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
rc2 is out; this is the final step in the [release process](https://github.com/python/typing_extensions/blob/main/CONTRIBUTING.md#workflow-for-pypi-releases)