### PR TITLE
Clarify version policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,11 @@ Starting with version 4.0.0, `typing_extensions` uses
 for more detail.
 
 ## Development version
-After a release the version is increased once in [pyproject.toml](/pyproject.toml) and
-appended with a `.dev` suffix, e.g. `4.0.1.dev`.
-Further subsequent updates are not planned between releases.
+
+After a release the patch version is increased in [pyproject.toml](/pyproject.toml) and
+appended with a `.dev0` suffix, e.g. `4.0.1.dev0`.
+
+When a new feature is added we will increase the minor version once between releases. For example, from 4.0.1.dev0 to 4.1.0.dev0.
 
 # Type stubs
 
@@ -111,4 +113,4 @@ pipx run pre-commit run -a
 - Release automation will finish the release. You'll have to manually
   approve the last step before upload.
 
-- After the release has been published on PyPI upgrade the version in number in [pyproject.toml](/pyproject.toml) to a `dev` version of the next planned release. For example, change 4.1.1 to 4.X.X.dev, see also [Development versions](#development-version). # TODO decide on major vs. minor increase.
+- After the release has been published on PyPI upgrade the version in number in [pyproject.toml](/pyproject.toml) to a `dev` version of the next planned release. For example, change 4.1.1 to 4.1.2.dev0, see also [Development versions](#development-version).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,15 +88,18 @@ pipx run pre-commit run -a
 
 # Workflow for PyPI releases
 
-- Make sure you follow the versioning policy in the documentation
-  (e.g., release candidates before any feature release, do not release development versions)
+- Make sure to release at least one release candidate (starting with `rc1`) before making a full release. E.g. release `4.2.0rc1` before releasing `4.2.0`.
+  When an urgent hotfix is necessary (and you bump only the patch version), you can skip the release candidates.
 
 - Ensure that GitHub Actions reports no errors.
 
 - Check that `CHANGELOG.md` accurately reflects all important changes committed to `main` since the previous release.
 
 - Update the version number in `typing_extensions/pyproject.toml` and in
-  `typing_extensions/CHANGELOG.md`.
+  `typing_extensions/CHANGELOG.md` by removing `.dev0` and potentially adding the `rcX` suffix:
+  - `4.1.0.dev0` → `4.1.0rc1`
+  - `4.1.0rc2.dev0` → `4.1.0rc2` or `4.1.0` when making a full release
+  - `4.1.1.dev0` → `4.1.1rc1` or `4.1.1` when making an urgent hotfix
 
 - Create a new GitHub release at https://github.com/python/typing_extensions/releases/new.
   Details:
@@ -106,4 +109,6 @@ pipx run pre-commit run -a
 - Release automation will finish the release. You'll have to manually
   approve the last step before upload.
 
-- After the release has been published on PyPI upgrade the version in number in [pyproject.toml](/pyproject.toml) to a `dev` version of the next planned release. For example, change 4.1.1 to 4.1.2.dev0.
+- After the release has been published on PyPI upgrade the patch or rc version number in [pyproject.toml](/pyproject.toml) and append `.dev0`. For example:
+    - 4.1.1 → 4.1.2.dev0
+    - 4.1.1rc1 → 4.1.1rc2.dev0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ pipx run pre-commit run -a
 - Update the version number in `typing_extensions/pyproject.toml` and in
   `typing_extensions/CHANGELOG.md` by removing `.dev0` and potentially adding the `rcX` suffix:
   - `4.1.0.dev0` → `4.1.0rc1` for the initial release candidate
-  - `4.1.0rc2.dev0` → `4.1.0rc2` or `4.1.0` when making a full release
+  - `4.1.0rc2.dev0` → `4.1.0rc2` or `4.1.0`, depending on whether the release is a second release candidate or a full release
   - `4.1.1.dev0` → `4.1.1` when making a hotfix release
 
 - Create a new GitHub release at https://github.com/python/typing_extensions/releases/new.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,13 +24,6 @@ Starting with version 4.0.0, `typing_extensions` uses
 [Semantic Versioning](https://semver.org/). See the documentation
 for more detail.
 
-## Development version
-
-After a release the patch version is increased in [pyproject.toml](/pyproject.toml) and
-appended with a `.dev0` suffix, e.g. `4.0.1.dev0`.
-
-When a new feature is added we will increase the minor version once between releases. For example, from 4.0.1.dev0 to 4.1.0.dev0.
-
 # Type stubs
 
 A stub file for `typing_extensions` is maintained
@@ -113,4 +106,4 @@ pipx run pre-commit run -a
 - Release automation will finish the release. You'll have to manually
   approve the last step before upload.
 
-- After the release has been published on PyPI upgrade the version in number in [pyproject.toml](/pyproject.toml) to a `dev` version of the next planned release. For example, change 4.1.1 to 4.1.2.dev0, see also [Development versions](#development-version).
+- After the release has been published on PyPI upgrade the version in number in [pyproject.toml](/pyproject.toml) to a `dev` version of the next planned release. For example, change 4.1.1 to 4.1.2.dev0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,5 +110,5 @@ pipx run pre-commit run -a
   approve the last step before upload.
 
 - After the release has been published on PyPI upgrade the patch or rc version number in [pyproject.toml](/pyproject.toml) and append `.dev0`. For example:
-    - 4.1.1 → 4.1.2.dev0
-    - 4.1.1rc1 → 4.1.1rc2.dev0
+    - `4.1.1` → `4.1.2.dev0`
+    - `4.1.1rc1` → `4.1.1rc2.dev0`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,8 +88,8 @@ pipx run pre-commit run -a
 
 # Workflow for PyPI releases
 
-- Make sure to release at least one release candidate (starting with `rc1`) before making a full release. E.g. release `4.2.0rc1` before releasing `4.2.0`.
-  When an urgent hotfix is necessary (and you bump only the patch version), you can skip the release candidates.
+- Make sure that the version in `pyproject.toml` and `CHANGELOG.md` follows the versioning policy outlined in
+  [the documentation](https://typing-extensions.readthedocs.io/en/latest/#versioning-and-backwards-compatibility).
 
 - Ensure that GitHub Actions reports no errors.
 
@@ -97,9 +97,9 @@ pipx run pre-commit run -a
 
 - Update the version number in `typing_extensions/pyproject.toml` and in
   `typing_extensions/CHANGELOG.md` by removing `.dev0` and potentially adding the `rcX` suffix:
-  - `4.1.0.dev0` → `4.1.0rc1`
+  - `4.1.0.dev0` → `4.1.0rc1` for the initial release candidate
   - `4.1.0rc2.dev0` → `4.1.0rc2` or `4.1.0` when making a full release
-  - `4.1.1.dev0` → `4.1.1rc1` or `4.1.1` when making an urgent hotfix
+  - `4.1.1.dev0` → `4.1.1` when making a hotfix release
 
 - Create a new GitHub release at https://github.com/python/typing_extensions/releases/new.
   Details:
@@ -111,4 +111,4 @@ pipx run pre-commit run -a
 
 - After the release has been published on PyPI upgrade the patch or rc version number in [pyproject.toml](/pyproject.toml) and append `.dev0`. For example:
     - `4.1.1` → `4.1.2.dev0`
-    - `4.1.1rc1` → `4.1.1rc2.dev0`
+    - `4.1.0rc1` → `4.1.0rc2.dev0`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ CPython's `main` branch.
 # Versioning scheme
 
 Starting with version 4.0.0, `typing_extensions` uses
-[Semantic Versioning](https://semver.org/). See the documentation
+[Semantic Versioning](https://semver.org/). [See the documentation](https://typing-extensions.readthedocs.io/en/latest/#versioning-and-backwards-compatibility)
 for more detail.
 
 # Type stubs


### PR DESCRIPTION
We will increase the patch version after a release. The minor version is increased when features are added.

Also, use `dev0` instead of `dev`, since the former is the normalized version of the latter.