### PR TITLE
Remove obsolete Literal deduplication assertion

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -1337,8 +1337,6 @@ class LiteralTests(BaseTestCase):
         self.assertEqual(Literal[1, 2, 3].__args__, (1, 2, 3))
         self.assertEqual(Literal[1, 2, 3, 3].__args__, (1, 2, 3))
         self.assertEqual(Literal[1, Literal[2], Literal[3, 4]].__args__, (1, 2, 3, 4))
-        # Mutable arguments will not be deduplicated
-        self.assertEqual(Literal[[], []].__args__, ([], []))
 
     def test_union_of_literals(self):
         self.assertEqual(Union[Literal[1], Literal[2]].__args__,


### PR DESCRIPTION
Fixes #784.

## Summary

Remove the assertion that `Literal[[], []].__args__` is `([], [])`. python/cpython#153914 deliberately changed `typing.Literal` to deduplicate unhashable arguments, so Python 3.14.7 now returns `([],)` instead. On supported Python versions where `typing_extensions.Literal` aliases `typing.Literal`, the old assertion therefore contradicts the standard library behavior.

This PR just deletes the assertion entirely: the behaviour here is now version-dependent, and the assertion was always testing an implementation detail that wasn't really that important.

## Historical context

- The assertion entered `typing_extensions` in #145. That PR addressed #113 and backported python/cpython#23294 and python/cpython#23383. The assertion was copied verbatim with the rest of CPython's `LiteralTests.test_args` in [the first commit of that PR](https://github.com/python/typing_extensions/commit/ba96d1bb2a2f42afa964784f49d6c5e1f86495e6). There was no discussion about this particular assertion on #145.
- The original CPython behavior was intentional. In [the original review discussion](https://github.com/python/cpython/pull/23294#discussion_r524317072), a reviewer proposed deduplicating unhashable arguments as well. [The PR author noted](https://github.com/python/cpython/pull/23294#discussion_r524353335) that changing the shared deduplication helper would slow down `Union`, and Guido asked whether mutable `Literal` arguments were actually valid.
- [PEP 586](https://peps.python.org/pep-0586/#illegal-parameters-for-literal-at-type-check-time) rejects mutable `Literal` arguments at type-checking time but intentionally does not validate them at runtime. The CPython reviewers therefore [agreed not to deduplicate mutable arguments](https://github.com/python/cpython/pull/23294#discussion_r524384460). Guido subsequently [requested explicit `__args__` coverage](https://github.com/python/cpython/pull/23294#discussion_r524752782), and [commit f653d680](https://github.com/python/cpython/commit/f653d680e2fbf94e254f32a8a7e24cb0f95369a9) introduced the exact assertion that #145 later copied.
- python/cpython#153914 revisited that historical decision and now deduplicates unhashable arguments too; the change was backported to Python 3.13, 3.14, and 3.15. The old assertion is consequently obsolete and does not represent a `typing_extensions` implementation bug.
