### PR TITLE
Use an argument list in test_typing_extensions_compiles_with_opt

### DIFF
--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -7221,9 +7221,8 @@ class AllTests(BaseTestCase):
     def test_typing_extensions_compiles_with_opt(self):
         file_path = typing_extensions.__file__
         try:
-            subprocess.check_output(f'{sys.executable} -OO {file_path}',
-                                    stderr=subprocess.STDOUT,
-                                    shell=True)
+            subprocess.check_output([sys.executable, '-OO', file_path],
+                                    stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError:  # pragma: no cover
             self.fail('Module does not compile with optimize=2 (-OO flag).')
 


### PR DESCRIPTION
`test_typing_extensions_compiles_with_opt` builds a shell command string from
`sys.executable` and `typing_extensions.__file__` without quoting either:

```python
subprocess.check_output(f'{sys.executable} -OO {file_path}',
                        stderr=subprocess.STDOUT,
                        shell=True)
```

When the checkout (or the interpreter) is under a path containing a space, the shell
splits the path and the subprocess fails for that reason alone. Because the `except`
clause maps *any* `CalledProcessError` to `'Module does not compile with optimize=2
(-OO flag).'`, the failure is indistinguishable from a real `-OO` compilation error —
which is the part that cost me some time before I looked at the command being run.

Replacing the string with an argument list needs no quoting and no shell.

### Reproducing

On any checkout whose path contains a space (mine is on Windows, but the same applies
to `/home/user/my projects/...`):

```
$ cd src/
$ python -m unittest test_typing_extensions.AllTests.test_typing_extensions_compiles_with_opt
AssertionError: Module does not compile with optimize=2 (-OO flag).
```

`typing_extensions` compiles fine under `-OO`; only the test is broken.

With this change, from the same directory:

```
$ python -m unittest test_typing_extensions.AllTests.test_typing_extensions_compiles_with_opt
Ran 1 test in 0.265s
OK
```

Full suite on the same checkout: `Ran 576 tests ... OK (skipped=24)`.

### Notes

- Test-only change; no behavior change in `typing_extensions` itself, so I have not
  added a CHANGELOG entry — happy to add one if you would prefer.
- Disclosure: this was found and prepared with AI assistance (Claude), which is why the
  commit carries a `Co-Authored-By` trailer. The reproduction, the fix and the test runs
  above are real and were executed on my machine; I am happy to adjust or drop the
  trailer if it conflicts with your policy.
