### PR TITLE
Improve Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,34 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["schedule:monthly", "helpers:pinGitHubActionDigestsToSemver"],
+  "extends": [
+    "config:recommended",
+    "schedule:monthly",
+    "helpers:pinGitHubActionDigestsToSemver",
+    "replacements:all",
+    "abandonments:recommended"
+  ],
+  "configMigration": true,
   "dependencyDashboard": true,
+  "separateMajorMinor": false,
+
+  // By default, Renovate will only create 2 PRs in any single hourly interval.
+  // But we only allow Renovate to create PRs between midnight and 4am on the first
+  // day of each month, so this is not sufficient in general. Per the docs,
+  // 0 means "no limit": <https://docs.renovatebot.com/configuration-options/#prhourlylimit>
+  "prHourlyLimit": 0,
+
+  // Similarly, by default, Renovate will not create any new PRs if it already has 10 open
+  // on this repo, but that isn't generally what we want: we generally want dependency update PRs
+  // for all available dependencies. Per the docs, 0 means "no limit":
+  // <https://docs.renovatebot.com/configuration-options/#prconcurrentlimit>
+  "prConcurrentLimit": 0,
+
+  // Conventions: we generally don't use semantic commits.
+  "semanticCommits": "disabled",
+
+  // These notifications are very noisy.
+  "suppressNotifications": ["prEditedNotification"],
+
   "enabledManagers": ["github-actions", "custom.regex", "pre-commit", "pep621"],
   "pre-commit": {
     "enabled": true
@@ -27,8 +54,16 @@
       "enabled": false
     },
     {
-      "matchManagers": ["github-actions", "custom.regex", "pre-commit", "pep621"],
-      "groupName": "CI dependencies"
+      "matchFileNames": [".pre-commit-config.yaml"],
+      "groupName": "pre-commit dependencies"
+    },
+    {
+      "matchFileNames": [".github/workflows/**"],
+      "groupName": "GitHub Actions dependencies"
+    },
+    {
+      "matchManagers": ["pep621"],
+      "groupName": "Build dependencies"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Followup to https://github.com/python/typing_extensions/pull/792.

- Replace the single `CI dependencies` [group](https://docs.renovatebot.com/configuration-options/#groupname) with:
  - `pre-commit dependencies` for `.pre-commit-config.yaml`, including hook revisions and additional dependencies.
  - `GitHub Actions dependencies` for `.github/workflows/**`, including action references and the custom uv/Codecov tool pins.
  - `Build dependencies` for the managed PEP 621 build requirements.
- Add [`config:recommended`](https://docs.renovatebot.com/presets-config/#configrecommended), [`replacements:all`](https://docs.renovatebot.com/presets-replacements/#replacementsall), and [`abandonments:recommended`](https://docs.renovatebot.com/presets-abandonments/#abandonmentsrecommended) to the presets we extend.
- Extend [`abandonments:recommended`](https://docs.renovatebot.com/presets-abandonments/#abandonmentsrecommended) to report packages with no release for a year, subject to Renovate's curated package-specific exceptions.
- Enable [`configMigration`](https://docs.renovatebot.com/configuration-options/#configmigration) so Renovate can propose configuration migrations when its configuration format changes.
- Set [`separateMajorMinor: false`](https://docs.renovatebot.com/configuration-options/#separatemajorminor) so major and non-major updates can share the same dependency group.
- Set [`prHourlyLimit`](https://docs.renovatebot.com/configuration-options/#prhourlylimit) and [`prConcurrentLimit`](https://docs.renovatebot.com/configuration-options/#prconcurrentlimit) to `0`, removing the default limits of two new PRs per hour and ten open PRs so they do not constrain the monthly update window.
- Set [`semanticCommits: "disabled"`](https://docs.renovatebot.com/configuration-options/#semanticcommits). We don't use semantic commit titles in this repo.
- Suppress [`prEditedNotification`](https://docs.renovatebot.com/configuration-options/#suppressnotifications), the comment explaining that Renovate has stopped automatically rebasing a manually edited branch. These notifications are noisy and annoying.

Many/most of these config options are ones we've been using in Astral repos for a while, and they've served us well over there. I validated the changes using `npx --yes --package renovate@43.280.2 -- renovate-config-validator --strict --no-global .github/renovate.json5`.